### PR TITLE
Shared validator + hint service, draggable inline hint overlay

### DIFF
--- a/.claude/skills/recreate-workflow-video/SKILL.md
+++ b/.claude/skills/recreate-workflow-video/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: recreate-workflow-video
+description: Rebuilds the narrated workflow MP4 (assets/screenshots/workflow/workflow_inline.mp4) from the BlockParam DevLauncher capture script. Use when the user asks to "recreate the workflow video", "rebuild the workflow GIF/MP4", or after any UI change under src/BlockParam/ whose visuals should be reflected in the marketing video.
+---
+
+# Recreate workflow video
+
+Rebuilds `assets/screenshots/workflow/workflow_inline.mp4` end-to-end: rebuild DevLauncher → capture frames → stitch MP4.
+
+## Run from the repo root
+
+```bash
+dotnet build src/BlockParam.DevLauncher -c Debug
+
+src/BlockParam.DevLauncher/bin/Debug/net48/BlockParam.DevLauncher.exe \
+    --capture-script assets/screenshots/scripts/workflow_inline.json
+
+bash assets/screenshots/scripts/build_workflow_video.sh
+```
+
+Output: `assets/screenshots/workflow/workflow_inline.mp4`. The stitch script auto-opens it in the default player.
+
+## Why the build step is not optional
+
+`--capture-script` renders from the dialog assembly **embedded in the DevLauncher EXE**, not from the current sources. A stale binary silently captures the old UI — the fix or feature you just made will be missing from the video with no error.
+
+`dotnet build` is incremental: on a clean tree it returns in a few seconds without recompiling, so running it unconditionally is cheaper than reasoning about whether it is needed.
+
+## Scene / pacing changes
+
+- Add / remove / reorder scenes: edit `assets/screenshots/scripts/workflow_inline.json`.
+- Timing is driven by each scene's `beat` field. If you introduce a new beat name, add it to the `BEATS` map in `assets/screenshots/scripts/build_workflow_video.sh` — otherwise the stitch fails with `Unknown beat`.
+
+## Troubleshooting
+
+- **Capture fails with `IOException` on `devlauncher.log`.** Another DevLauncher instance on the same user account is holding the log file (`%TEMP%\BlockParam\devlauncher.log` is user-wide, not per-worktree — any parallel session in the main repo or another worktree collides). **Ask the user before killing it** — the other instance may be their active testing session. If they approve: `powershell -c "Stop-Process -Name BlockParam.DevLauncher -Force"`, then retry step 2.
+
+## Do not
+
+- Launch the DevLauncher via `cmd /c start` or `start` — WPF silently fails to show. Run the EXE path directly from bash (the `--capture-script` mode exits on its own, so it does not block the terminal).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,10 @@ src/BlockParam.DevLauncher/bin/Debug/net48/BlockParam.DevLauncher.exe \
 
 Canonical outputs live in `assets/screenshots/`. To add a new shot, pick a preset DB (export one into `%TEMP%\BlockParam\` from TIA if missing) and add a capture line. For richer states (expanded tree, member selected, dialog open), extend `Program.cs` with a small script hook — do not try to drive the running UI from outside.
 
+### Workflow video
+
+For rebuilding the narrated workflow MP4 (`assets/screenshots/workflow/workflow_inline.mp4`), use the `recreate-workflow-video` skill — it bundles the rebuild-then-capture-then-stitch steps and the rationale for each.
+
 ## Development Guidelines
 
 - Read only the research file relevant to the current task (token efficiency)

--- a/src/BlockParam.Tests/MemberValidatorTests.cs
+++ b/src/BlockParam.Tests/MemberValidatorTests.cs
@@ -1,0 +1,129 @@
+using FluentAssertions;
+using NSubstitute;
+using BlockParam.Config;
+using BlockParam.Models;
+using BlockParam.Services;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+public class MemberValidatorTests
+{
+    private static MemberNode IntMember(string path = "db.moduleId") =>
+        new("moduleId", "Int", "0", path, null, Array.Empty<MemberNode>());
+
+    private static TagTableCache CacheWithMod()
+    {
+        var reader = Substitute.For<ITagTableReader>();
+        reader.GetTagTableNames().Returns(new[] { "MOD_Halle1" });
+        reader.ReadTagTable("MOD_Halle1").Returns(new[]
+        {
+            new TagTableEntry("MOD_TP310", "42", "Int", ""),
+            new TagTableEntry("MOD_TP311", "43", "Int", ""),
+        });
+        return new TagTableCache(reader);
+    }
+
+    private static BulkChangeConfig ConfigWithModRule() => new()
+    {
+        Rules = new List<MemberRule>
+        {
+            new()
+            {
+                PathPattern = @".*\.moduleId$",
+                TagTableReference = new TagTableReference { TableName = "MOD_*" },
+                Constraints = new ValueConstraint { RequireTagTableValue = true },
+            },
+        },
+    };
+
+    [Fact]
+    public void EmptyValue_ReturnsNull()
+    {
+        var v = new MemberValidator(null, null);
+        v.Validate(IntMember(), null).Should().BeNull();
+        v.Validate(IntMember(), "").Should().BeNull();
+    }
+
+    [Fact]
+    public void NoRule_InRangeInt_ReturnsNull()
+    {
+        var v = new MemberValidator(null, null);
+        v.Validate(IntMember(), "42").Should().BeNull();
+    }
+
+    [Fact]
+    public void NoRule_OutOfRangeInt_ReturnsTypeError()
+    {
+        var v = new MemberValidator(null, null);
+        v.Validate(IntMember(), "99999").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void TagTableRequired_ValidConstantName_ReturnsNull()
+    {
+        var v = new MemberValidator(ConfigWithModRule(), CacheWithMod());
+        v.Validate(IntMember(), "MOD_TP310").Should().BeNull();
+    }
+
+    [Fact]
+    public void TagTableRequired_ConstantValue_ReturnsNull()
+    {
+        // The validator also accepts the tag's value literal (not just the name).
+        var v = new MemberValidator(ConfigWithModRule(), CacheWithMod());
+        v.Validate(IntMember(), "42").Should().BeNull();
+    }
+
+    [Fact]
+    public void TagTableRequired_UnknownSymbolicName_ReturnsTagTableError()
+    {
+        // Regression guard: typing a name-like value that isn't in the table
+        // must report the tag-table error, not the datatype format error. If
+        // the validator ordering regresses, this flips to "Invalid Int value".
+        var v = new MemberValidator(ConfigWithModRule(), CacheWithMod());
+        var error = v.Validate(IntMember(), "MOD_TP999");
+        error.Should().NotBeNull();
+        error.Should().Contain("MOD_*");
+    }
+
+    [Fact]
+    public void TagTableRequired_NumericNotInTable_ReturnsTagTableError()
+    {
+        var v = new MemberValidator(ConfigWithModRule(), CacheWithMod());
+        var error = v.Validate(IntMember(), "9999");
+        error.Should().NotBeNull();
+        error.Should().Contain("MOD_*");
+    }
+
+    [Fact]
+    public void GetHint_Int_NoRule_ReturnsDatatypeFallback()
+    {
+        var v = new MemberValidator(null, null);
+        var hint = v.GetHint(IntMember());
+        hint.Should().NotBeNull();
+        hint.Should().Contain("Int");
+        hint.Should().Contain("-32768");
+        hint.Should().Contain("32767");
+    }
+
+    [Fact]
+    public void GetHint_UsesRuleConstraintOverDatatype()
+    {
+        var config = new BulkChangeConfig
+        {
+            Rules = new List<MemberRule>
+            {
+                new()
+                {
+                    PathPattern = @".*\.moduleId$",
+                    Constraints = new ValueConstraint { Min = 0, Max = 100 },
+                },
+            },
+        };
+        var v = new MemberValidator(config, null);
+        var hint = v.GetHint(IntMember());
+        hint.Should().NotBeNull();
+        hint.Should().Contain("0");
+        hint.Should().Contain("100");
+    }
+}

--- a/src/BlockParam.Tests/RuleHintFormatterTests.cs
+++ b/src/BlockParam.Tests/RuleHintFormatterTests.cs
@@ -1,0 +1,136 @@
+using FluentAssertions;
+using BlockParam.Config;
+using BlockParam.Services;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+public class RuleHintFormatterTests
+{
+    [Fact]
+    public void NullRule_NoDatatype_ReturnsNull()
+    {
+        RuleHintFormatter.Format(null, null).Should().BeNull();
+    }
+
+    [Fact]
+    public void NullRule_WithIntDatatype_ReturnsDatatypeFallback()
+    {
+        var hint = RuleHintFormatter.Format(null, "Int");
+        hint.Should().NotBeNull();
+        hint.Should().Contain("Int");
+        hint.Should().Contain("-32768");
+        hint.Should().Contain("32767");
+    }
+
+    [Fact]
+    public void NullRule_WithUnknownDatatype_ReturnsNull()
+    {
+        RuleHintFormatter.Format(null, "SomeUdt").Should().BeNull();
+    }
+
+    [Fact]
+    public void RuleRange_OverridesDatatypeFallback()
+    {
+        var rule = new MemberRule
+        {
+            PathPattern = ".*",
+            Constraints = new ValueConstraint { Min = 0L, Max = 100L },
+        };
+        var hint = RuleHintFormatter.Format(rule, "Int");
+        hint.Should().NotBeNull();
+        hint.Should().Contain("0");
+        hint.Should().Contain("100");
+        // Datatype fallback MUST NOT appear alongside an explicit rule range.
+        hint.Should().NotContain("32767");
+    }
+
+    [Fact]
+    public void AllowedValues_DoesNotAppendDatatypeFallback()
+    {
+        // Regression guard: a datatype fallback appended after "One of:" reads
+        // as "allowed values OR any Int", which contradicts the validator.
+        var rule = new MemberRule
+        {
+            PathPattern = ".*",
+            Constraints = new ValueConstraint
+            {
+                AllowedValues = new List<object> { "OPEN", "CLOSED" },
+            },
+        };
+        var hint = RuleHintFormatter.Format(rule, "Int");
+        hint.Should().NotBeNull();
+        hint.Should().Contain("OPEN");
+        hint.Should().Contain("CLOSED");
+        hint.Should().NotContain("32767");
+    }
+
+    [Fact]
+    public void RequireTagTable_DoesNotAppendDatatypeFallback()
+    {
+        var rule = new MemberRule
+        {
+            PathPattern = ".*",
+            TagTableReference = new TagTableReference { TableName = "MOD_*" },
+            Constraints = new ValueConstraint { RequireTagTableValue = true },
+        };
+        var hint = RuleHintFormatter.Format(rule, "Int");
+        hint.Should().NotBeNull();
+        hint.Should().Contain("MOD_*");
+        hint.Should().NotContain("32767");
+    }
+
+    [Fact]
+    public void EmptyConstraints_ReturnsDatatypeFallback()
+    {
+        // Rule exists but has no user-visible constraint parts — the datatype
+        // fallback should still provide something useful.
+        var rule = new MemberRule
+        {
+            PathPattern = ".*",
+            Constraints = new ValueConstraint(),
+        };
+        var hint = RuleHintFormatter.Format(rule, "Int");
+        hint.Should().NotBeNull();
+        hint.Should().Contain("Int");
+    }
+
+    [Fact]
+    public void IntRangeHint_UsesInvariantCultureFormatting()
+    {
+        // TIA parser accepts InvariantCulture literals ("-32768"), not culture
+        // grouping ("-32.768"). The hint must match so users don't type invalid
+        // values by copying the hint verbatim.
+        var prev = System.Threading.Thread.CurrentThread.CurrentCulture;
+        System.Threading.Thread.CurrentThread.CurrentCulture =
+            new System.Globalization.CultureInfo("de-DE");
+        try
+        {
+            var hint = RuleHintFormatter.Format(null, "Int");
+            hint.Should().NotBeNull();
+            hint.Should().Contain("-32768");
+            hint.Should().Contain("32767");
+            hint.Should().NotContain("32.767");
+        }
+        finally
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = prev;
+        }
+    }
+
+    [Fact]
+    public void BoolDatatype_ReturnsBoolHint()
+    {
+        var hint = RuleHintFormatter.Format(null, "Bool");
+        hint.Should().NotBeNull();
+        hint.Should().Contain("Bool");
+    }
+
+    [Fact]
+    public void RealDatatype_ReturnsFloatHint()
+    {
+        var hint = RuleHintFormatter.Format(null, "Real");
+        hint.Should().NotBeNull();
+        hint.Should().Contain("Real");
+    }
+}

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -232,6 +232,18 @@ Beispiele: en-US, de-DE. Leer lassen für Standardsprache.</value></data>
   <data name="Dialog_CollapseAll" xml:space="preserve"><value>Alle zuklappen</value></data>
   <data name="Context_ExpandAllChildren" xml:space="preserve"><value>Alle Unterelemente aufklappen</value></data>
   <data name="Context_CollapseAllChildren" xml:space="preserve"><value>Alle Unterelemente zuklappen</value></data>
+  <!-- Regel-Hinweise (#7) — proaktiv im Inspector und Inline-Tooltip angezeigt. -->
+  <data name="Hint_Range" xml:space="preserve"><value>Bereich: {0} – {1}</value></data>
+  <data name="Hint_Min" xml:space="preserve"><value>Min: {0}</value></data>
+  <data name="Hint_Max" xml:space="preserve"><value>Max: {0}</value></data>
+  <data name="Hint_AllowedOf" xml:space="preserve"><value>Erlaubt: {0}</value></data>
+  <data name="Hint_TagTable" xml:space="preserve"><value>Aus Tag-Tabelle „{0}“</value></data>
+  <data name="Hint_Separator" xml:space="preserve"><value> · </value></data>
+  <!-- Validierungs-Meldung für shared MemberValidator -->
+  <data name="Validation_RequireTagTable" xml:space="preserve"><value>Wert muss eine Konstante aus der Tag-Tabelle „{0}“ sein.</value></data>
+  <!-- Seitenleiste „Ausstehende Änderungen“ (#11) -->
+  <data name="Pending_InvalidBadge" xml:space="preserve"><value>{0} von {1} ungültig</value></data>
+  <data name="Pending_InvalidBadgeTooltip" xml:space="preserve"><value>Ungültige Einträge korrigieren oder verwerfen, bevor übernommen wird.</value></data>
   <!-- Inkonsistente UDT Kompilier-Abfrage (#27) -->
   <data name="Udt_InconsistentPromptTitle" xml:space="preserve"><value>BlockParam — Kompilierung erforderlich</value></data>
   <data name="Udt_InconsistentPrompt" xml:space="preserve"><value>{0} UDT(s) können nicht exportiert werden, da sie inkonsistent sind:

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -239,6 +239,9 @@ Beispiele: en-US, de-DE. Leer lassen für Standardsprache.</value></data>
   <data name="Hint_AllowedOf" xml:space="preserve"><value>Erlaubt: {0}</value></data>
   <data name="Hint_TagTable" xml:space="preserve"><value>Aus Tag-Tabelle „{0}“</value></data>
   <data name="Hint_Separator" xml:space="preserve"><value> · </value></data>
+  <data name="Hint_Datatype_IntRange" xml:space="preserve"><value>{0}: {1} – {2}</value></data>
+  <data name="Hint_Datatype_Float" xml:space="preserve"><value>{0}: Dezimalzahl (z. B. 3,14)</value></data>
+  <data name="Hint_Datatype_Bool" xml:space="preserve"><value>Bool: true / false / 0 / 1</value></data>
   <!-- Validierungs-Meldung für shared MemberValidator -->
   <data name="Validation_RequireTagTable" xml:space="preserve"><value>Wert muss eine Konstante aus der Tag-Tabelle „{0}“ sein.</value></data>
   <!-- Seitenleiste „Ausstehende Änderungen“ (#11) -->

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -240,7 +240,7 @@ Beispiele: en-US, de-DE. Leer lassen für Standardsprache.</value></data>
   <data name="Hint_TagTable" xml:space="preserve"><value>Aus Tag-Tabelle „{0}“</value></data>
   <data name="Hint_Separator" xml:space="preserve"><value> · </value></data>
   <data name="Hint_Datatype_IntRange" xml:space="preserve"><value>{0}: {1} – {2}</value></data>
-  <data name="Hint_Datatype_Float" xml:space="preserve"><value>{0}: Dezimalzahl (z. B. 3,14)</value></data>
+  <data name="Hint_Datatype_Float" xml:space="preserve"><value>{0}: Dezimalzahl (z. B. 3.14)</value></data>
   <data name="Hint_Datatype_Bool" xml:space="preserve"><value>Bool: true / false / 0 / 1</value></data>
   <!-- Validierungs-Meldung für shared MemberValidator -->
   <data name="Validation_RequireTagTable" xml:space="preserve"><value>Wert muss eine Konstante aus der Tag-Tabelle „{0}“ sein.</value></data>

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -580,6 +580,41 @@ Examples: en-US, de-DE. Leave empty for the default language.</value>
   <data name="Context_CollapseAllChildren" xml:space="preserve">
     <value>Collapse All Children</value>
   </data>
+  <!-- Rule hints (#7) — shown proactively in the inspector and inline tooltips. -->
+  <data name="Hint_Range" xml:space="preserve">
+    <value>Range: {0} – {1}</value>
+    <comment>{0} = min, {1} = max</comment>
+  </data>
+  <data name="Hint_Min" xml:space="preserve">
+    <value>Min: {0}</value>
+  </data>
+  <data name="Hint_Max" xml:space="preserve">
+    <value>Max: {0}</value>
+  </data>
+  <data name="Hint_AllowedOf" xml:space="preserve">
+    <value>One of: {0}</value>
+    <comment>{0} = comma-separated allowed values</comment>
+  </data>
+  <data name="Hint_TagTable" xml:space="preserve">
+    <value>From tag table '{0}'</value>
+    <comment>{0} = tag table name</comment>
+  </data>
+  <data name="Hint_Separator" xml:space="preserve">
+    <value> · </value>
+  </data>
+  <!-- Validation messages used by the shared MemberValidator. -->
+  <data name="Validation_RequireTagTable" xml:space="preserve">
+    <value>Value must be a constant from the '{0}' tag table.</value>
+    <comment>{0} = tag table name</comment>
+  </data>
+  <!-- Pending-edits sidebar (#11) -->
+  <data name="Pending_InvalidBadge" xml:space="preserve">
+    <value>{0} of {1} invalid</value>
+    <comment>{0} = invalid count, {1} = total pending count</comment>
+  </data>
+  <data name="Pending_InvalidBadgeTooltip" xml:space="preserve">
+    <value>Fix or undo invalid entries before applying.</value>
+  </data>
   <!-- Inconsistent UDT compile prompt (#27) -->
   <data name="Udt_InconsistentPromptTitle" xml:space="preserve">
     <value>BlockParam — Compilation Required</value>

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -602,6 +602,17 @@ Examples: en-US, de-DE. Leave empty for the default language.</value>
   <data name="Hint_Separator" xml:space="preserve">
     <value> · </value>
   </data>
+  <data name="Hint_Datatype_IntRange" xml:space="preserve">
+    <value>{0}: {1} – {2}</value>
+    <comment>{0} = datatype name, {1} = min, {2} = max — shown as implicit range when no rule override</comment>
+  </data>
+  <data name="Hint_Datatype_Float" xml:space="preserve">
+    <value>{0}: decimal (e.g. 3.14)</value>
+    <comment>{0} = datatype name</comment>
+  </data>
+  <data name="Hint_Datatype_Bool" xml:space="preserve">
+    <value>Bool: true / false / 0 / 1</value>
+  </data>
   <!-- Validation messages used by the shared MemberValidator. -->
   <data name="Validation_RequireTagTable" xml:space="preserve">
     <value>Value must be a constant from the '{0}' tag table.</value>

--- a/src/BlockParam/Services/MemberValidator.cs
+++ b/src/BlockParam/Services/MemberValidator.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Linq;
+using BlockParam.Config;
+using BlockParam.Localization;
+using BlockParam.Models;
+
+namespace BlockParam.Services;
+
+/// <summary>
+/// Shared validator for a single member value. Consolidates the pipeline
+/// (datatype format → rule constraints → tag-table membership) so the bulk
+/// dialog, inline editor and pending-changes list all agree on what "valid"
+/// means — and the hint we surface proactively matches the error we'd emit.
+/// </summary>
+public class MemberValidator
+{
+    private readonly BulkChangeConfig? _config;
+    private readonly TagTableCache? _tagTableCache;
+
+    public MemberValidator(BulkChangeConfig? config, TagTableCache? tagTableCache)
+    {
+        _config = config;
+        _tagTableCache = tagTableCache;
+    }
+
+    /// <summary>
+    /// Validates <paramref name="value"/> against <paramref name="member"/>'s
+    /// datatype and any matching rule. Returns null when valid or the input
+    /// is empty; otherwise a human-readable error message.
+    /// </summary>
+    public string? Validate(MemberNode member, string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return null;
+
+        var datatype = member.Datatype;
+        var constants = _tagTableCache?.GetAllConstantNames();
+
+        var typeError = TiaDataTypeValidator.Validate(value!, datatype, constants);
+        if (typeError != null) return typeError;
+
+        var rule = _config?.GetRule(member);
+        var ruleError = rule?.Constraints?.Validate(value!, datatype, constants);
+        if (ruleError != null) return ruleError;
+
+        if (rule?.Constraints?.RequireTagTableValue == true
+            && rule.TagTableReference != null
+            && _tagTableCache != null)
+        {
+            var entries = _tagTableCache.GetEntriesByPattern(rule.TagTableReference.TableName);
+            var matches = entries.Any(e =>
+                string.Equals(e.Name, value, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(e.Value, value, StringComparison.OrdinalIgnoreCase));
+            if (!matches)
+                return Res.Format("Validation_RequireTagTable", rule.TagTableReference.TableName);
+        }
+
+        return null;
+    }
+
+    /// <summary>Returns the formatted hint for <paramref name="member"/> or null.</summary>
+    public string? GetHint(MemberNode member) =>
+        RuleHintFormatter.Format(_config?.GetRule(member));
+}

--- a/src/BlockParam/Services/MemberValidator.cs
+++ b/src/BlockParam/Services/MemberValidator.cs
@@ -34,14 +34,13 @@ public class MemberValidator
 
         var datatype = member.Datatype;
         var constants = _tagTableCache?.GetAllConstantNames();
-
-        var typeError = TiaDataTypeValidator.Validate(value!, datatype, constants);
-        if (typeError != null) return typeError;
-
         var rule = _config?.GetRule(member);
-        var ruleError = rule?.Constraints?.Validate(value!, datatype, constants);
-        if (ruleError != null) return ruleError;
 
+        // Tag-table requirement wins over datatype format: when the rule demands
+        // a constant from a specific table, surfacing "Value must be from MOD_*"
+        // is more helpful than "Invalid Int value" for the typical user mistake
+        // (typing a name that isn't in the table). Values that *are* in the
+        // table fall through so later checks can still catch rule violations.
         if (rule?.Constraints?.RequireTagTableValue == true
             && rule.TagTableReference != null
             && _tagTableCache != null)
@@ -54,10 +53,16 @@ public class MemberValidator
                 return Res.Format("Validation_RequireTagTable", rule.TagTableReference.TableName);
         }
 
+        var typeError = TiaDataTypeValidator.Validate(value!, datatype, constants);
+        if (typeError != null) return typeError;
+
+        var ruleError = rule?.Constraints?.Validate(value!, datatype, constants);
+        if (ruleError != null) return ruleError;
+
         return null;
     }
 
     /// <summary>Returns the formatted hint for <paramref name="member"/> or null.</summary>
     public string? GetHint(MemberNode member) =>
-        RuleHintFormatter.Format(_config?.GetRule(member));
+        RuleHintFormatter.Format(_config?.GetRule(member), member.Datatype);
 }

--- a/src/BlockParam/Services/RuleHintFormatter.cs
+++ b/src/BlockParam/Services/RuleHintFormatter.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using BlockParam.Config;
 using BlockParam.Localization;
@@ -14,21 +15,19 @@ public static class RuleHintFormatter
 {
     /// <summary>
     /// Returns a single-line hint like "Range: 0 – 100 · One of: OPEN, CLOSED"
-    /// or null when the rule has no user-visible constraint. Includes datatype
-    /// limits (e.g. "Int: -32768 – 32767") as a fallback so typed fields still
-    /// get a useful hint when no rule override is defined.
+    /// or null when the rule has no user-visible constraint. When no rule
+    /// constraint applies at all, falls back to the datatype's implicit range
+    /// (e.g. "Int: -32768 – 32767") so typed fields still get useful guidance.
     /// </summary>
     public static string? Format(MemberRule? rule, string? datatype = null)
     {
         var parts = new List<string>();
 
         var c = rule?.Constraints;
-        bool hasRuleRange = false;
         if (c != null)
         {
             bool hasMin = !IsEmpty(c.Min);
             bool hasMax = !IsEmpty(c.Max);
-            hasRuleRange = hasMin || hasMax;
             if (hasMin && hasMax)
                 parts.Add(Res.Format("Hint_Range", Display(c.Min!), Display(c.Max!)));
             else if (hasMin)
@@ -42,13 +41,14 @@ public static class RuleHintFormatter
                 parts.Add(Res.Format("Hint_AllowedOf", values));
             }
 
-            if (c.RequireTagTableValue && rule?.TagTableReference != null)
+            if (c.RequireTagTableValue && rule!.TagTableReference != null)
                 parts.Add(Res.Format("Hint_TagTable", rule.TagTableReference.TableName));
         }
 
-        // Fallback: when the rule leaves the range unconstrained, show the
-        // implicit datatype range so the user still sees "what's allowed here".
-        if (!hasRuleRange)
+        // Fallback only when no rule-visible constraint was added — a datatype
+        // range appended next to "One of: OPEN, CLOSED" or a tag-table hint
+        // would misleadingly suggest numeric literals are also accepted.
+        if (parts.Count == 0)
         {
             var typeHint = FormatDatatypeHint(datatype);
             if (typeHint != null) parts.Add(typeHint);
@@ -66,26 +66,40 @@ public static class RuleHintFormatter
     {
         if (string.IsNullOrEmpty(datatype)) return null;
         var key = datatype!.Trim('"');
+        // Min/Max rendered with InvariantCulture so the hint matches what the
+        // TIA parser actually accepts — showing "32.767" to a de-DE user would
+        // otherwise read as a valid Int literal (it isn't; TIA uses '.'-less
+        // grouping or none at all, with the decimal dot reserved for Real).
         return key switch
         {
-            "SInt"  => Res.Format("Hint_Datatype_IntRange", key, sbyte.MinValue, sbyte.MaxValue),
-            "Int"   => Res.Format("Hint_Datatype_IntRange", key, short.MinValue, short.MaxValue),
-            "DInt"  => Res.Format("Hint_Datatype_IntRange", key, int.MinValue, int.MaxValue),
-            "LInt"  => Res.Format("Hint_Datatype_IntRange", key, long.MinValue, long.MaxValue),
-            "USInt" => Res.Format("Hint_Datatype_IntRange", key, byte.MinValue, byte.MaxValue),
-            "UInt"  => Res.Format("Hint_Datatype_IntRange", key, ushort.MinValue, ushort.MaxValue),
-            "UDInt" => Res.Format("Hint_Datatype_IntRange", key, uint.MinValue, uint.MaxValue),
-            "ULInt" => Res.Format("Hint_Datatype_IntRange", key, ulong.MinValue, ulong.MaxValue),
-            "Byte"  => Res.Format("Hint_Datatype_IntRange", key, byte.MinValue, byte.MaxValue),
-            "Word"  => Res.Format("Hint_Datatype_IntRange", key, ushort.MinValue, ushort.MaxValue),
-            "DWord" => Res.Format("Hint_Datatype_IntRange", key, uint.MinValue, uint.MaxValue),
-            "LWord" => Res.Format("Hint_Datatype_IntRange", key, ulong.MinValue, ulong.MaxValue),
+            "SInt"  => IntRange(key, sbyte.MinValue, sbyte.MaxValue),
+            "Int"   => IntRange(key, short.MinValue, short.MaxValue),
+            "DInt"  => IntRange(key, int.MinValue, int.MaxValue),
+            "LInt"  => IntRange(key, long.MinValue, long.MaxValue),
+            "USInt" => IntRange(key, byte.MinValue, byte.MaxValue),
+            "UInt"  => IntRange(key, ushort.MinValue, ushort.MaxValue),
+            "UDInt" => IntRange(key, uint.MinValue, uint.MaxValue),
+            "ULInt" => IntRange(key, ulong.MinValue, ulong.MaxValue),
+            "Byte"  => IntRange(key, byte.MinValue, byte.MaxValue),
+            "Word"  => IntRange(key, ushort.MinValue, ushort.MaxValue),
+            "DWord" => IntRange(key, uint.MinValue, uint.MaxValue),
+            "LWord" => IntRange(key, ulong.MinValue, ulong.MaxValue),
             "Real"  => Res.Format("Hint_Datatype_Float", key),
             "LReal" => Res.Format("Hint_Datatype_Float", key),
             "Bool"  => Res.Get("Hint_Datatype_Bool"),
             _       => null,
         };
     }
+
+    private static string IntRange(string type, long min, long max) =>
+        Res.Format("Hint_Datatype_IntRange", type,
+            min.ToString(CultureInfo.InvariantCulture),
+            max.ToString(CultureInfo.InvariantCulture));
+
+    private static string IntRange(string type, ulong min, ulong max) =>
+        Res.Format("Hint_Datatype_IntRange", type,
+            min.ToString(CultureInfo.InvariantCulture),
+            max.ToString(CultureInfo.InvariantCulture));
 
     private static bool IsEmpty(object? value) =>
         value == null || (value is string s && string.IsNullOrEmpty(s));

--- a/src/BlockParam/Services/RuleHintFormatter.cs
+++ b/src/BlockParam/Services/RuleHintFormatter.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Linq;
+using BlockParam.Config;
+using BlockParam.Localization;
+
+namespace BlockParam.Services;
+
+/// <summary>
+/// Produces human-readable, localized hint strings describing the constraints
+/// attached to a <see cref="MemberRule"/>. Shared by the bulk-change inspector
+/// and inline-edit cells so both paths surface the same rule language.
+/// </summary>
+public static class RuleHintFormatter
+{
+    /// <summary>
+    /// Returns a single-line hint like "Range: 0 – 100 · One of: OPEN, CLOSED"
+    /// or null when the rule has no user-visible constraint.
+    /// </summary>
+    public static string? Format(MemberRule? rule)
+    {
+        if (rule == null) return null;
+
+        var parts = new List<string>();
+
+        var c = rule.Constraints;
+        if (c != null)
+        {
+            bool hasMin = !IsEmpty(c.Min);
+            bool hasMax = !IsEmpty(c.Max);
+            if (hasMin && hasMax)
+                parts.Add(Res.Format("Hint_Range", Display(c.Min!), Display(c.Max!)));
+            else if (hasMin)
+                parts.Add(Res.Format("Hint_Min", Display(c.Min!)));
+            else if (hasMax)
+                parts.Add(Res.Format("Hint_Max", Display(c.Max!)));
+
+            if (c.AllowedValues is { Count: > 0 })
+            {
+                var values = string.Join(", ", c.AllowedValues.Select(v => v?.ToString() ?? ""));
+                parts.Add(Res.Format("Hint_AllowedOf", values));
+            }
+
+            if (c.RequireTagTableValue && rule.TagTableReference != null)
+                parts.Add(Res.Format("Hint_TagTable", rule.TagTableReference.TableName));
+        }
+
+        return parts.Count == 0 ? null : string.Join(Res.Get("Hint_Separator"), parts);
+    }
+
+    private static bool IsEmpty(object? value) =>
+        value == null || (value is string s && string.IsNullOrEmpty(s));
+
+    private static string Display(object value) =>
+        value is string s ? s : System.Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture) ?? "";
+}

--- a/src/BlockParam/Services/RuleHintFormatter.cs
+++ b/src/BlockParam/Services/RuleHintFormatter.cs
@@ -14,19 +14,21 @@ public static class RuleHintFormatter
 {
     /// <summary>
     /// Returns a single-line hint like "Range: 0 – 100 · One of: OPEN, CLOSED"
-    /// or null when the rule has no user-visible constraint.
+    /// or null when the rule has no user-visible constraint. Includes datatype
+    /// limits (e.g. "Int: -32768 – 32767") as a fallback so typed fields still
+    /// get a useful hint when no rule override is defined.
     /// </summary>
-    public static string? Format(MemberRule? rule)
+    public static string? Format(MemberRule? rule, string? datatype = null)
     {
-        if (rule == null) return null;
-
         var parts = new List<string>();
 
-        var c = rule.Constraints;
+        var c = rule?.Constraints;
+        bool hasRuleRange = false;
         if (c != null)
         {
             bool hasMin = !IsEmpty(c.Min);
             bool hasMax = !IsEmpty(c.Max);
+            hasRuleRange = hasMin || hasMax;
             if (hasMin && hasMax)
                 parts.Add(Res.Format("Hint_Range", Display(c.Min!), Display(c.Max!)));
             else if (hasMin)
@@ -40,11 +42,49 @@ public static class RuleHintFormatter
                 parts.Add(Res.Format("Hint_AllowedOf", values));
             }
 
-            if (c.RequireTagTableValue && rule.TagTableReference != null)
+            if (c.RequireTagTableValue && rule?.TagTableReference != null)
                 parts.Add(Res.Format("Hint_TagTable", rule.TagTableReference.TableName));
         }
 
+        // Fallback: when the rule leaves the range unconstrained, show the
+        // implicit datatype range so the user still sees "what's allowed here".
+        if (!hasRuleRange)
+        {
+            var typeHint = FormatDatatypeHint(datatype);
+            if (typeHint != null) parts.Add(typeHint);
+        }
+
         return parts.Count == 0 ? null : string.Join(Res.Get("Hint_Separator"), parts);
+    }
+
+    /// <summary>
+    /// Back-compat overload matching the pre-datatype signature.
+    /// </summary>
+    public static string? Format(MemberRule? rule) => Format(rule, null);
+
+    private static string? FormatDatatypeHint(string? datatype)
+    {
+        if (string.IsNullOrEmpty(datatype)) return null;
+        var key = datatype!.Trim('"');
+        return key switch
+        {
+            "SInt"  => Res.Format("Hint_Datatype_IntRange", key, sbyte.MinValue, sbyte.MaxValue),
+            "Int"   => Res.Format("Hint_Datatype_IntRange", key, short.MinValue, short.MaxValue),
+            "DInt"  => Res.Format("Hint_Datatype_IntRange", key, int.MinValue, int.MaxValue),
+            "LInt"  => Res.Format("Hint_Datatype_IntRange", key, long.MinValue, long.MaxValue),
+            "USInt" => Res.Format("Hint_Datatype_IntRange", key, byte.MinValue, byte.MaxValue),
+            "UInt"  => Res.Format("Hint_Datatype_IntRange", key, ushort.MinValue, ushort.MaxValue),
+            "UDInt" => Res.Format("Hint_Datatype_IntRange", key, uint.MinValue, uint.MaxValue),
+            "ULInt" => Res.Format("Hint_Datatype_IntRange", key, ulong.MinValue, ulong.MaxValue),
+            "Byte"  => Res.Format("Hint_Datatype_IntRange", key, byte.MinValue, byte.MaxValue),
+            "Word"  => Res.Format("Hint_Datatype_IntRange", key, ushort.MinValue, ushort.MaxValue),
+            "DWord" => Res.Format("Hint_Datatype_IntRange", key, uint.MinValue, uint.MaxValue),
+            "LWord" => Res.Format("Hint_Datatype_IntRange", key, ulong.MinValue, ulong.MaxValue),
+            "Real"  => Res.Format("Hint_Datatype_Float", key),
+            "LReal" => Res.Format("Hint_Datatype_Float", key),
+            "Bool"  => Res.Get("Hint_Datatype_Bool"),
+            _       => null,
+        };
     }
 
     private static bool IsEmpty(object? value) =>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -209,7 +209,9 @@
                       GridViewColumnHeader.Click="OnColumnHeaderClick"
                       MouseDoubleClick="OnListViewDoubleClick"
                       ContextMenuOpening="OnListViewContextMenuOpening"
-                      SelectionChanged="OnListViewSelectionChanged">
+                      SelectionChanged="OnListViewSelectionChanged"
+                      SizeChanged="OnMemberListSizeChanged"
+                      ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                 <ListView.ContextMenu>
                     <ContextMenu/>
                 </ListView.ContextMenu>
@@ -259,7 +261,7 @@
                         <!-- Name column with tree guide lines, indentation, and expand toggle.
                              Indentation is applied ONLY in this column so the other columns
                              stay flush regardless of depth (#45). -->
-                        <GridViewColumn Header="{loc:Loc Column_Name}" Width="280">
+                        <GridViewColumn x:Name="NameColumn" Header="{loc:Loc Column_Name}" Width="280">
                             <GridViewColumn.CellTemplate>
                                 <DataTemplate>
                                     <StackPanel Orientation="Horizontal">
@@ -308,7 +310,7 @@
                         </GridViewColumn>
 
                         <!-- Data type column -->
-                        <GridViewColumn Header="{loc:Loc Column_DataType}" Width="140">
+                        <GridViewColumn x:Name="DataTypeColumn" Header="{loc:Loc Column_DataType}" Width="140">
                             <GridViewColumn.CellTemplate>
                                 <DataTemplate>
                                     <TextBlock Text="{Binding Datatype}">
@@ -338,7 +340,7 @@
                         </GridViewColumn>
 
                         <!-- Start value column (editable with inline autocomplete) -->
-                        <GridViewColumn Header="{loc:Loc Column_StartValue}" Width="120">
+                        <GridViewColumn x:Name="StartValueColumn" Header="{loc:Loc Column_StartValue}" Width="120">
                             <GridViewColumn.CellTemplate>
                                 <DataTemplate>
                                     <Border Margin="-6,-1,-6,-1">
@@ -370,7 +372,26 @@
                                                  GotFocus="OnStartValueGotFocus"
                                                  LostFocus="OnStartValueLostFocus"
                                                  TextChanged="OnInlineTextChanged"
-                                                 Tag="{Binding}"/>
+                                                 Tag="{Binding}"
+                                                 ToolTipService.ShowOnDisabled="True">
+                                            <TextBox.Style>
+                                                <Style TargetType="TextBox">
+                                                    <Style.Triggers>
+                                                        <!-- Error tooltip takes priority over hint (#7/#11) -->
+                                                        <DataTrigger Binding="{Binding HasInlineError}" Value="True">
+                                                            <Setter Property="ToolTip" Value="{Binding InlineErrorMessage}"/>
+                                                        </DataTrigger>
+                                                        <MultiDataTrigger>
+                                                            <MultiDataTrigger.Conditions>
+                                                                <Condition Binding="{Binding HasInlineError}" Value="False"/>
+                                                                <Condition Binding="{Binding HasRuleHint}" Value="True"/>
+                                                            </MultiDataTrigger.Conditions>
+                                                            <Setter Property="ToolTip" Value="{Binding RuleHint}"/>
+                                                        </MultiDataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBox.Style>
+                                        </TextBox>
                                         <Button HorizontalAlignment="Right" VerticalAlignment="Stretch"
                                                 Width="14" Background="Transparent" BorderThickness="0"
                                                 Click="OnInlineDropdownClick" Cursor="Hand"
@@ -383,8 +404,9 @@
                             </GridViewColumn.CellTemplate>
                         </GridViewColumn>
 
-                        <!-- Comment column with color coding and tooltip -->
-                        <GridViewColumn Header="{loc:Loc Column_Comment}" Width="250">
+                        <!-- Comment column — resized dynamically (#9) so it fills
+                             the remaining horizontal space in the grid. -->
+                        <GridViewColumn x:Name="CommentColumn" Header="{loc:Loc Column_Comment}" Width="250">
                             <GridViewColumn.CellTemplate>
                                 <DataTemplate>
                                     <TextBlock Text="{Binding DisplayComment}"
@@ -651,8 +673,29 @@
                                                     </ListBox.ItemTemplate>
                                                 </ListBox>
                                             </Border>
+                                            <!-- Proactive rule hint (#7): shown before any validation error,
+                                                 hidden while an error is active so users see the diagnostic. -->
+                                            <TextBlock Text="{Binding ConstraintInfo}" Foreground="#5b6471"
+                                                       FontSize="10" Margin="0,2,0,0"
+                                                       TextWrapping="Wrap">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                        <Style.Triggers>
+                                                            <MultiDataTrigger>
+                                                                <MultiDataTrigger.Conditions>
+                                                                    <Condition Binding="{Binding ConstraintInfo, Converter={StaticResource StringToVis}}" Value="Visible"/>
+                                                                    <Condition Binding="{Binding HasValidationError}" Value="False"/>
+                                                                </MultiDataTrigger.Conditions>
+                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                            </MultiDataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
                                             <TextBlock Text="{Binding ValidationError}" Foreground="Red"
                                                        FontSize="10" Margin="0,2,0,0"
+                                                       TextWrapping="Wrap"
                                                        Visibility="{Binding ValidationError, Converter={StaticResource StringToVis}}"/>
                                         </StackPanel>
 
@@ -873,6 +916,15 @@
                                         <TextBlock Text="{Binding PendingInlineEditCount}"
                                                    FontSize="10" FontWeight="Bold" Foreground="White"/>
                                     </Border>
+                                    <!-- Invalid-count badge (#11): appears when any pending entry fails validation. -->
+                                    <Border DockPanel.Dock="Left" Margin="6,0,0,0" Padding="5,0"
+                                            Background="#D32F2F" CornerRadius="8"
+                                            VerticalAlignment="Center"
+                                            ToolTip="{loc:Loc Pending_InvalidBadgeTooltip}"
+                                            Visibility="{Binding HasInvalidPending, Converter={StaticResource BoolToVis}}">
+                                        <TextBlock Text="{Binding InvalidPendingBadge}"
+                                                   FontSize="10" FontWeight="Bold" Foreground="White"/>
+                                    </Border>
                                     <Button DockPanel.Dock="Right" HorizontalAlignment="Right"
                                             Content="Undo all"
                                             Command="{Binding DiscardPendingCommand}"
@@ -932,9 +984,24 @@
                                 </ItemsControl.Template>
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
+                                        <!-- Invalid pending entries (#11): red left edge + pale fill +
+                                             tooltip with the validation message. Valid entries stay white. -->
                                         <Border BorderBrush="#E6E8EC" BorderThickness="0,0,0,1"
-                                                Padding="10,4,10,4" Background="White"
+                                                Padding="10,4,10,4"
                                                 MouseLeftButtonUp="OnPendingRowClick">
+                                            <Border.Style>
+                                                <Style TargetType="Border">
+                                                    <Setter Property="Background" Value="White"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding Node.HasInlineError}" Value="True">
+                                                            <Setter Property="Background" Value="#FFF4F4"/>
+                                                            <Setter Property="BorderBrush" Value="#D32F2F"/>
+                                                            <Setter Property="BorderThickness" Value="3,0,0,1"/>
+                                                            <Setter Property="ToolTip" Value="{Binding Node.InlineErrorMessage}"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Border.Style>
                                             <StackPanel>
                                                 <DockPanel LastChildFill="True">
                                                     <Button DockPanel.Dock="Right"
@@ -944,6 +1011,16 @@
                                                             FontSize="12" Foreground="#5b6471"
                                                             Cursor="Hand" Padding="4,0"
                                                             ToolTip="Undo this pending edit"/>
+                                                    <!-- Invalid marker (#11). -->
+                                                    <Border DockPanel.Dock="Right" Margin="6,0,0,0"
+                                                            Background="#D32F2F" BorderBrush="#D32F2F" BorderThickness="1"
+                                                            Padding="3,0" CornerRadius="2"
+                                                            VerticalAlignment="Center"
+                                                            ToolTip="{Binding Node.InlineErrorMessage}"
+                                                            Visibility="{Binding Node.HasInlineError, Converter={StaticResource BoolToVis}}">
+                                                        <TextBlock Text="!" FontSize="10" FontWeight="Bold"
+                                                                   Foreground="White"/>
+                                                    </Border>
                                                     <Border DockPanel.Dock="Right" Margin="6,0,0,0"
                                                             Background="#e3edfc" BorderBrush="#1f6feb" BorderThickness="1"
                                                             Padding="3,0" CornerRadius="2"
@@ -965,13 +1042,38 @@
                                                                Foreground="#8a929d"
                                                                TextDecorations="Strikethrough"/>
                                                     <TextBlock Text=" &#x2192; " FontSize="10" Foreground="#e0a93a"/>
-                                                    <Border Background="#fde7a8" Padding="3,0">
+                                                    <Border Padding="3,0">
+                                                        <Border.Style>
+                                                            <Style TargetType="Border">
+                                                                <Setter Property="Background" Value="#fde7a8"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding Node.HasInlineError}" Value="True">
+                                                                        <Setter Property="Background" Value="#FFCDD2"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </Border.Style>
                                                         <TextBlock Text="{Binding PendingValue}"
                                                                    FontFamily="Consolas,Courier New" FontSize="10"
-                                                                   FontWeight="SemiBold"
-                                                                   Foreground="#6b4a0a"/>
+                                                                   FontWeight="SemiBold">
+                                                            <TextBlock.Style>
+                                                                <Style TargetType="TextBlock">
+                                                                    <Setter Property="Foreground" Value="#6b4a0a"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding Node.HasInlineError}" Value="True">
+                                                                            <Setter Property="Foreground" Value="#B71C1C"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </TextBlock.Style>
+                                                        </TextBlock>
                                                     </Border>
                                                 </StackPanel>
+                                                <!-- Inline validation message (#11) — surfaces why the entry is invalid. -->
+                                                <TextBlock Text="{Binding Node.InlineErrorMessage}"
+                                                           FontSize="10" Foreground="#B71C1C"
+                                                           TextWrapping="Wrap" Margin="0,2,0,0"
+                                                           Visibility="{Binding Node.HasInlineError, Converter={StaticResource BoolToVis}}"/>
                                             </StackPanel>
                                         </Border>
                                     </DataTemplate>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -372,26 +372,7 @@
                                                  GotFocus="OnStartValueGotFocus"
                                                  LostFocus="OnStartValueLostFocus"
                                                  TextChanged="OnInlineTextChanged"
-                                                 Tag="{Binding}"
-                                                 ToolTipService.ShowOnDisabled="True">
-                                            <TextBox.Style>
-                                                <Style TargetType="TextBox">
-                                                    <Style.Triggers>
-                                                        <!-- Error tooltip takes priority over hint (#7/#11) -->
-                                                        <DataTrigger Binding="{Binding HasInlineError}" Value="True">
-                                                            <Setter Property="ToolTip" Value="{Binding InlineErrorMessage}"/>
-                                                        </DataTrigger>
-                                                        <MultiDataTrigger>
-                                                            <MultiDataTrigger.Conditions>
-                                                                <Condition Binding="{Binding HasInlineError}" Value="False"/>
-                                                                <Condition Binding="{Binding HasRuleHint}" Value="True"/>
-                                                            </MultiDataTrigger.Conditions>
-                                                            <Setter Property="ToolTip" Value="{Binding RuleHint}"/>
-                                                        </MultiDataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </TextBox.Style>
-                                        </TextBox>
+                                                 Tag="{Binding}"/>
                                         <Button HorizontalAlignment="Right" VerticalAlignment="Stretch"
                                                 Width="14" Background="Transparent" BorderThickness="0"
                                                 Click="OnInlineDropdownClick" Cursor="Hand"
@@ -1125,6 +1106,47 @@
             </Path.Effect>
         </Path>
     </Canvas>
+
+    <!-- Dialog-root inline hint/error overlay (#7/#11). Positioned imperatively
+         next to the focused inline cell so the user sees the rule constraint
+         and any validation error without hover delay. Lives in the visual tree
+         (not a WPF Popup) so it follows the window when the user drags or
+         resizes the dialog. Content binds to a MemberNodeViewModel DataContext. -->
+    <Border x:Name="InlineHintOverlay" Panel.ZIndex="1001"
+            HorizontalAlignment="Left" VerticalAlignment="Top"
+            Visibility="Collapsed"
+            BorderThickness="1" Padding="6,3" MaxWidth="320"
+            Cursor="SizeAll"
+            PreviewMouseLeftButtonDown="OnInlineHintMouseDown"
+            PreviewMouseMove="OnInlineHintMouseMove"
+            PreviewMouseLeftButtonUp="OnInlineHintMouseUp">
+        <Border.Style>
+            <Style TargetType="Border">
+                <Setter Property="Background" Value="#FFFDF5"/>
+                <Setter Property="BorderBrush" Value="#E0C97F"/>
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding HasInlineError}" Value="True">
+                        <Setter Property="Background" Value="#FFF4F4"/>
+                        <Setter Property="BorderBrush" Value="#D32F2F"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+        </Border.Style>
+        <TextBlock FontSize="11" TextWrapping="Wrap">
+            <TextBlock.Style>
+                <Style TargetType="TextBlock">
+                    <Setter Property="Text" Value="{Binding RuleHint}"/>
+                    <Setter Property="Foreground" Value="#5b6471"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding HasInlineError}" Value="True">
+                            <Setter Property="Text" Value="{Binding InlineErrorMessage}"/>
+                            <Setter Property="Foreground" Value="#B71C1C"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBlock.Style>
+        </TextBlock>
+    </Border>
 
     <!-- Dialog-root inline-autocomplete overlay. Positioned imperatively
          by BulkChangeDialog code-behind whenever an inline cell enters

--- a/src/BlockParam/UI/BulkChangeDialog.xaml.cs
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml.cs
@@ -323,6 +323,11 @@ public partial class BulkChangeDialog : Window
         {
             var suggestions = vm.GetSuggestionsForMember(memberVm, tb.Text);
             ShowInlineOverlay(tb, memberVm, suggestions);
+            // HasInlineError can flip on each keystroke — keep the hint overlay
+            // in sync so a cell that starts valid but becomes invalid (or vice
+            // versa) surfaces the right feedback without needing a refocus.
+            UpdateInlineHintVisibility(memberVm);
+            PositionInlineHintOverlay(tb);
         }
     }
 
@@ -717,6 +722,7 @@ public partial class BulkChangeDialog : Window
                 && DataContext is BulkChangeViewModel vm)
             {
                 vm.SelectedFlatMember = memberVm;
+                ShowInlineHintOverlay(tb, memberVm);
             }
         }
     }
@@ -734,7 +740,94 @@ public partial class BulkChangeDialog : Window
             // handler hide the overlay itself.
             if (!InlineOverlay.IsKeyboardFocusWithin && !InlineOverlay.IsMouseOver)
                 HideInlineOverlay();
+            // Same pattern for the hint overlay: if the user is interacting
+            // with it (clicking to drag), the TextBox losing focus must not
+            // snatch it away mid-gesture.
+            if (!InlineHintOverlay.IsMouseOver && !_draggingHint)
+                HideInlineHintOverlay();
         }
+    }
+
+    /// <summary>
+    /// Positions the dialog-root <c>InlineHintOverlay</c> to the right of the
+    /// given TextBox so the rule hint / validation error stays visible while
+    /// the cell is focused. Hidden when the member has neither a hint nor an
+    /// error — an empty popup would just be visual noise.
+    /// </summary>
+    private void ShowInlineHintOverlay(TextBox tb, MemberNodeViewModel memberVm)
+    {
+        _inlineHintAnchor = tb;
+        InlineHintOverlay.DataContext = memberVm;
+        UpdateInlineHintVisibility(memberVm);
+        // Focus can fire before the selected row has had its final layout pass
+        // (e.g. when clicking an unrealized virtualized row), so a direct
+        // TranslatePoint would land on stale coords. Defer until WPF finishes
+        // laying out — Render priority runs after Arrange.
+        Dispatcher.BeginInvoke(new Action(() => PositionInlineHintOverlay(tb)),
+            System.Windows.Threading.DispatcherPriority.Render);
+    }
+
+    private void UpdateInlineHintVisibility(MemberNodeViewModel memberVm)
+    {
+        bool hasContent = memberVm.HasInlineError || memberVm.HasRuleHint;
+        InlineHintOverlay.Visibility = hasContent ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private void PositionInlineHintOverlay(TextBox tb)
+    {
+        if (InlineHintOverlay.Visibility != Visibility.Visible) return;
+        if (!tb.IsDescendantOf(this)) return;
+        // Right of the TextBox so the autocomplete overlay below the cell stays clear.
+        var topRight = tb.TranslatePoint(new System.Windows.Point(tb.ActualWidth, 0), this);
+        InlineHintOverlay.Margin = new Thickness(topRight.X + 8, topRight.Y, 0, 0);
+    }
+
+    private void HideInlineHintOverlay()
+    {
+        InlineHintOverlay.Visibility = Visibility.Collapsed;
+        InlineHintOverlay.DataContext = null;
+        _inlineHintAnchor = null;
+    }
+
+    private TextBox? _inlineHintAnchor;
+
+    private bool _draggingHint;
+    private System.Windows.Point _hintDragStart;
+    private System.Windows.Point _hintDragOrigin;
+
+    /// <summary>
+    /// Starts a drag-to-reposition gesture on the hint overlay. The user can
+    /// pull it out of the way when it covers content they want to see. The
+    /// next focus change re-anchors it next to the newly focused cell, so
+    /// the moved position is intentionally session-scoped.
+    /// </summary>
+    private void OnInlineHintMouseDown(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is not FrameworkElement fe) return;
+        _hintDragStart = e.GetPosition(this);
+        _hintDragOrigin = new System.Windows.Point(
+            InlineHintOverlay.Margin.Left, InlineHintOverlay.Margin.Top);
+        _draggingHint = true;
+        fe.CaptureMouse();
+        e.Handled = true;
+    }
+
+    private void OnInlineHintMouseMove(object sender, MouseEventArgs e)
+    {
+        if (!_draggingHint) return;
+        var pos = e.GetPosition(this);
+        InlineHintOverlay.Margin = new Thickness(
+            _hintDragOrigin.X + (pos.X - _hintDragStart.X),
+            _hintDragOrigin.Y + (pos.Y - _hintDragStart.Y),
+            0, 0);
+    }
+
+    private void OnInlineHintMouseUp(object sender, MouseButtonEventArgs e)
+    {
+        if (!_draggingHint) return;
+        _draggingHint = false;
+        if (sender is FrameworkElement fe) fe.ReleaseMouseCapture();
+        e.Handled = true;
     }
 
     private void OnListViewContextMenuOpening(object sender, ContextMenuEventArgs e)

--- a/src/BlockParam/UI/BulkChangeDialog.xaml.cs
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml.cs
@@ -326,8 +326,9 @@ public partial class BulkChangeDialog : Window
             // HasInlineError can flip on each keystroke — keep the hint overlay
             // in sync so a cell that starts valid but becomes invalid (or vice
             // versa) surfaces the right feedback without needing a refocus.
+            // Do NOT reposition here: if the user dragged the overlay out of
+            // the way, re-anchoring on every keystroke would snap it back.
             UpdateInlineHintVisibility(memberVm);
-            PositionInlineHintOverlay(tb);
         }
     }
 
@@ -776,7 +777,13 @@ public partial class BulkChangeDialog : Window
     private void PositionInlineHintOverlay(TextBox tb)
     {
         if (InlineHintOverlay.Visibility != Visibility.Visible) return;
-        if (!tb.IsDescendantOf(this)) return;
+        if (!tb.IsDescendantOf(this))
+        {
+            // Anchor was virtualized / detached while the overlay was open —
+            // drop references rather than computing coords against a ghost.
+            _inlineHintAnchor = null;
+            return;
+        }
         // Right of the TextBox so the autocomplete overlay below the cell stays clear.
         var topRight = tb.TranslatePoint(new System.Windows.Point(tb.ActualWidth, 0), this);
         InlineHintOverlay.Margin = new Thickness(topRight.X + 8, topRight.Y, 0, 0);
@@ -787,6 +794,12 @@ public partial class BulkChangeDialog : Window
         InlineHintOverlay.Visibility = Visibility.Collapsed;
         InlineHintOverlay.DataContext = null;
         _inlineHintAnchor = null;
+        // Cancel any in-flight drag whose mouse-up we'd otherwise miss.
+        if (_draggingHint)
+        {
+            _draggingHint = false;
+            InlineHintOverlay.ReleaseMouseCapture();
+        }
     }
 
     private TextBox? _inlineHintAnchor;

--- a/src/BlockParam/UI/BulkChangeDialog.xaml.cs
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml.cs
@@ -220,6 +220,29 @@ public partial class BulkChangeDialog : Window
         }
     }
 
+    /// <summary>
+    /// #9: GridView columns have no native star sizing, so we compute it here.
+    /// Fixed columns keep their widths; the Comment column soaks up whatever
+    /// space is left so long comments stop truncating when the dialog is wide.
+    /// </summary>
+    private void OnMemberListSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        if (CommentColumn == null || NameColumn == null
+            || DataTypeColumn == null || StartValueColumn == null) return;
+
+        // Chrome + vertical scrollbar + row padding. Slightly conservative so
+        // we never force a horizontal scrollbar when space is tight.
+        const double Chrome = 32;
+        var available = MemberListView.ActualWidth
+                        - NameColumn.Width
+                        - DataTypeColumn.Width
+                        - StartValueColumn.Width
+                        - Chrome;
+
+        const double MinCommentWidth = 160;
+        CommentColumn.Width = System.Math.Max(MinCommentWidth, available);
+    }
+
     private void OnListViewDoubleClick(object sender, MouseButtonEventArgs e)
     {
         if (MemberListView.SelectedItem is MemberNodeViewModel memberVm && !memberVm.IsLeaf)

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -165,6 +165,7 @@ public class BulkChangeViewModel : ViewModelBase
             SubscribeStartValueEdited(vm);
             RootMembers.Add(vm);
         }
+        RefreshRuleHints();
 
         AvailableScopes = new ObservableCollection<ScopeLevel>();
 
@@ -965,17 +966,8 @@ public class BulkChangeViewModel : ViewModelBase
         if (AvailableScopes.Count > 0)
             SelectedScope = AvailableScopes[0];
 
-        var config = _configLoader.GetConfig();
-        var constraint = config?.GetRule(memberVm.Model)?.Constraints;
-        if (constraint != null)
-        {
-            var parts = new List<string>();
-            if (constraint.HasMinMax)
-                parts.Add($"Range: {constraint.Min ?? "..."} — {constraint.Max ?? "..."}");
-            if (constraint.AllowedValues is { Count: > 0 })
-                parts.Add($"Allowed: {string.Join(", ", constraint.AllowedValues)}");
-            ConstraintInfo = string.Join(" | ", parts);
-        }
+        // Proactive hint (#7) — single source of truth with the inline-edit tooltip.
+        ConstraintInfo = memberVm.RuleHint ?? "";
 
         StatusText = "";
 
@@ -1127,6 +1119,18 @@ public class BulkChangeViewModel : ViewModelBase
             : null;
         CollectPendingEntries(RootMembers, bulkPaths);
         OnPropertyChanged(nameof(HasPendingEdits));
+        RaiseInvalidPendingChanged();
+    }
+
+    /// <summary>
+    /// Nudges bindings attached to <see cref="InvalidPendingCount"/> and friends.
+    /// Call after any mutation that could flip a pending entry's error state.
+    /// </summary>
+    private void RaiseInvalidPendingChanged()
+    {
+        OnPropertyChanged(nameof(InvalidPendingCount));
+        OnPropertyChanged(nameof(HasInvalidPending));
+        OnPropertyChanged(nameof(InvalidPendingBadge));
     }
 
     private void CollectPendingEntries(IEnumerable<MemberNodeViewModel> nodes,
@@ -1315,9 +1319,8 @@ public class BulkChangeViewModel : ViewModelBase
                 SmartExpandSearchMatches(root, searchPaths);
         }
 
-        // Smart-expand parents of pending inline edits so they stay visible
-        foreach (var root in RootMembers)
-            SmartExpandPendingEdits(root);
+        // Pending inline edits no longer smart-expand (#10) — they're surfaced
+        // in the sidebar, so forcing the tree open was redundant and disruptive.
     }
 
     private void SmartExpandSearchMatches(MemberNodeViewModel node, HashSet<string> searchPaths)
@@ -1329,24 +1332,10 @@ public class BulkChangeViewModel : ViewModelBase
             SmartExpandSearchMatches(child, searchPaths);
     }
 
-    private void SmartExpandPendingEdits(MemberNodeViewModel node)
-    {
-        if (node.IsPendingInlineEdit || node.HasInlineError)
-        {
-            Log.Debug("SmartExpandPending: {Path} IsVisible={Vis} ParentExpanded={ParExp}",
-                node.Path, node.IsVisible, node.Parent?.IsExpanded);
-            node.EnsureVisible();
-            Log.Debug("SmartExpandPending: after EnsureVisible: IsVisible={Vis} ParentExpanded={ParExp}",
-                node.IsVisible, node.Parent?.IsExpanded);
-        }
-
-        foreach (var child in node.Children)
-            SmartExpandPendingEdits(child);
-    }
-
     /// <summary>
-    /// Re-expands search matches and pending edits.
-    /// Called after ClearAffected which collapses all smart-expanded nodes.
+    /// Re-expands search matches after <see cref="MemberNodeViewModel.ClearAffected"/>
+    /// collapsed smart-expanded nodes. Pending inline edits are intentionally not
+    /// re-expanded (#10) — they live in the sidebar.
     /// </summary>
     private void ReExpandNonAffected()
     {
@@ -1357,9 +1346,6 @@ public class BulkChangeViewModel : ViewModelBase
             foreach (var root in RootMembers)
                 SmartExpandSearchMatches(root, searchPaths);
         }
-
-        foreach (var root in RootMembers)
-            SmartExpandPendingEdits(root);
     }
 
     private void ValidateValue()
@@ -1443,38 +1429,40 @@ public class BulkChangeViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Runs the full validation pipeline for a single member: datatype format,
-    /// rule constraints (min/max, allowedValues), and requireTagTableValue.
-    /// Returns null on success, otherwise an error message.
+    /// Runs the full validation pipeline for a single member via the shared
+    /// <see cref="MemberValidator"/>. Returns null on success.
     /// </summary>
-    private string? ValidateValueForMember(MemberNodeViewModel memberVm, string value)
+    private string? ValidateValueForMember(MemberNodeViewModel memberVm, string value) =>
+        BuildValidator().Validate(memberVm.Model, value);
+
+    /// <summary>
+    /// Builds a validator pinned to the current config + tag-table cache. Fresh
+    /// on each call so rule/cache invalidation is picked up without bookkeeping.
+    /// </summary>
+    private MemberValidator BuildValidator()
     {
-        if (string.IsNullOrEmpty(value)) return null;
+        EnsureTagTableCache();
+        return new MemberValidator(_configLoader.GetConfig(), _tagTableCache);
+    }
 
+    /// <summary>
+    /// Refreshes <see cref="MemberNodeViewModel.RuleHint"/> on every node so
+    /// rule-constrained cells surface the hint proactively (tooltip + inspector).
+    /// Hints read only rule metadata — no tag-table export is forced here; that
+    /// stays lazy and runs on the validation path.
+    /// </summary>
+    private void RefreshRuleHints()
+    {
         var config = _configLoader.GetConfig();
-        var rule = config?.GetRule(memberVm.Model);
-        var datatype = memberVm.Model.Datatype;
-        var constants = _tagTableCache?.GetAllConstantNames();
+        foreach (var root in RootMembers)
+            ApplyRuleHint(root, config);
+    }
 
-        var typeError = TiaDataTypeValidator.Validate(value, datatype, constants);
-        if (typeError != null) return typeError;
-
-        var ruleError = rule?.Constraints?.Validate(value, datatype, constants);
-        if (ruleError != null) return ruleError;
-
-        if (rule?.Constraints?.RequireTagTableValue == true
-            && rule.TagTableReference != null
-            && _tagTableCache != null)
-        {
-            var entries = _tagTableCache.GetEntriesByPattern(rule.TagTableReference.TableName);
-            var isValid = entries.Any(e =>
-                string.Equals(e.Name, value, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(e.Value, value, StringComparison.OrdinalIgnoreCase));
-            if (!isValid)
-                return $"Value must be a constant from {rule.TagTableReference.TableName} tables.";
-        }
-
-        return null;
+    private static void ApplyRuleHint(MemberNodeViewModel node, BulkChangeConfig? config)
+    {
+        node.RuleHint = RuleHintFormatter.Format(config?.GetRule(node.Model));
+        foreach (var child in node.Children)
+            ApplyRuleHint(child, config);
     }
 
     private void UpdateFilteredSuggestions()
@@ -1859,6 +1847,25 @@ public class BulkChangeViewModel : ViewModelBase
     }
 
     /// <summary>
+    /// Count of pending entries whose staged value fails validation (#11).
+    /// Derived from the tree so it stays in sync with inline-edit validation.
+    /// </summary>
+    public int InvalidPendingCount => PendingEdits.Count(e => e.Node.HasInlineError);
+
+    public bool HasInvalidPending => InvalidPendingCount > 0;
+
+    /// <summary>"N of M invalid" summary shown on the sidebar header badge.</summary>
+    public string InvalidPendingBadge
+    {
+        get
+        {
+            var total = PendingEdits.Count;
+            var invalid = InvalidPendingCount;
+            return invalid == 0 ? "" : Res.Format("Pending_InvalidBadge", invalid, total);
+        }
+    }
+
+    /// <summary>
     /// Applies ALL pending changes (bulk-staged + inline edits) to XML.
     /// </summary>
     private void ExecuteApply()
@@ -2115,51 +2122,21 @@ public class BulkChangeViewModel : ViewModelBase
 
         Log.Information("Inline edit pending: {Path} → {Value}", memberVm.Path, newValue);
 
-        // Validate constraints for the edited member
-        string? error = null;
-        var datatype = memberVm.Model.Datatype;
-        var config = _configLoader.GetConfig();
-        var rule = config?.GetRule(memberVm.Model);
-        var constants = _tagTableCache?.GetAllConstantNames();
-
-        // Data type format validation (even without a rule)
-        error = TiaDataTypeValidator.Validate(newValue, datatype, constants);
-
-        // Rule-based constraint validation with datatype
-        if (error == null && rule?.Constraints != null)
-            error = rule.Constraints.Validate(newValue, datatype, constants);
-
-        // Validate requireTagTableValue: value must be a known constant name or value
-        if (error == null && rule?.Constraints?.RequireTagTableValue == true
-            && rule.TagTableReference != null)
-        {
-            EnsureTagTableCache();
-            if (_tagTableCache != null)
-            {
-                var entries = _tagTableCache.GetEntriesByPattern(rule.TagTableReference.TableName);
-                var isValid = entries.Any(e =>
-                    string.Equals(e.Name, newValue, StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(e.Value, newValue, StringComparison.OrdinalIgnoreCase));
-                if (!isValid)
-                    error = $"Value must be from tag table '{rule.TagTableReference.TableName}'";
-            }
-        }
+        // Shared validator → same rule language as the bulk inspector (#7).
+        var error = BuildValidator().Validate(memberVm.Model, newValue);
 
         memberVm.HasInlineError = error != null;
         memberVm.InlineErrorMessage = error;
         if (error != null)
             StatusText = $"{memberVm.Name}: {error}";
 
-        // Ensure pending edit is visible (expand parents if collapsed)
-        // Only refresh if node wasn't already in the flat list (avoids destroying open popups)
-        if (!memberVm.IsVisible || memberVm.Parent is { IsExpanded: false })
-        {
-            memberVm.EnsureVisible();
-            RefreshFlatList();
-        }
+        // Pending edits no longer smart-expand ancestors (#10): they surface in the
+        // sidebar, which is where the user looks for them. The tree's expansion
+        // state stays under the user's control.
 
         RefreshPendingAndPreview();
         OnPropertyChanged(nameof(HasInlineErrors));
+        RaiseInvalidPendingChanged();
     }
 
     /// <summary>
@@ -2258,8 +2235,12 @@ public class BulkChangeViewModel : ViewModelBase
         foreach (var root in RootMembers)
             CollectExpandStates(root, expandStates);
 
+        // Preserve selection + scope by stable identity (#8). Index-based lookup
+        // broke because OnMemberSelected adds scopes reversed while RefreshTree
+        // used plain order — indices didn't line up after Apply.
         var selectedPath = _selectedFlatMember?.Path;
-        var selectedScopeIndex = AvailableScopes.IndexOf(_selectedScope!);
+        var selectedScopeAncestorPath = _selectedScope?.AncestorPath;
+        var selectedScopeDepth = _selectedScope?.Depth;
 
         // Keep the most recent UDT resolvers so later RefreshTree calls (from Apply) don't drop them.
         if (udtResolver != null) _udtResolver = udtResolver;
@@ -2278,6 +2259,7 @@ public class BulkChangeViewModel : ViewModelBase
             SubscribeStartValueEdited(vm);
             RootMembers.Add(vm);
         }
+        RefreshRuleHints();
 
         // Restore expand states on ALL new nodes before building flat list
         foreach (var root in RootMembers)
@@ -2297,17 +2279,29 @@ public class BulkChangeViewModel : ViewModelBase
                 OnPropertyChanged(nameof(HasSelection));
                 OnPropertyChanged(nameof(SelectedMemberDisplay));
 
-                // Re-populate scopes for the restored selection
+                // Re-populate scopes for the restored selection using the same
+                // ordering as OnMemberSelected so index/position stay stable.
                 var result = _analyzer.Analyze(_dataBlockInfo, restored.Model);
                 AvailableScopes.Clear();
-                foreach (var scope in result.Scopes)
+                foreach (var scope in result.Scopes.Reverse())
                     AvailableScopes.Add(scope);
-                if (selectedScopeIndex >= 0 && selectedScopeIndex < AvailableScopes.Count)
-                    SelectedScope = AvailableScopes[selectedScopeIndex];
 
-                // Update start value display (suppress suggestion popup)
+                // #8: Match the previously selected scope by ancestor path, not
+                // by index. Keeps the dropdown sticky through Apply even when
+                // the scope count/order drifts.
+                var restoredScope = AvailableScopes.FirstOrDefault(s =>
+                    string.Equals(s.AncestorPath, selectedScopeAncestorPath, StringComparison.Ordinal)
+                    && s.Depth == selectedScopeDepth);
+                if (restoredScope != null)
+                    SelectedScope = restoredScope;
+
+                // Value is reset after Apply: the just-committed value would
+                // misrepresent the current state (#8). Clear touched so the
+                // next selection can prefill cleanly.
                 _suppressSuggestions = true;
-                NewValue = restored.StartValue ?? "";
+                _newValueTouched = false;
+                _newValue = "";
+                OnPropertyChanged(nameof(NewValue));
                 _suppressSuggestions = false;
             }
         }

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -1460,7 +1460,7 @@ public class BulkChangeViewModel : ViewModelBase
 
     private static void ApplyRuleHint(MemberNodeViewModel node, BulkChangeConfig? config)
     {
-        node.RuleHint = RuleHintFormatter.Format(config?.GetRule(node.Model));
+        node.RuleHint = RuleHintFormatter.Format(config?.GetRule(node.Model), node.Model.Datatype);
         foreach (var child in node.Children)
             ApplyRuleHint(child, config);
     }
@@ -2129,6 +2129,8 @@ public class BulkChangeViewModel : ViewModelBase
         memberVm.InlineErrorMessage = error;
         if (error != null)
             StatusText = $"{memberVm.Name}: {error}";
+        else if (StatusText.StartsWith(memberVm.Name + ":"))
+            StatusText = "";
 
         // Pending edits no longer smart-expand ancestors (#10): they surface in the
         // sidebar, which is where the user looks for them. The tree's expansion

--- a/src/BlockParam/UI/MemberNodeViewModel.cs
+++ b/src/BlockParam/UI/MemberNodeViewModel.cs
@@ -21,6 +21,7 @@ public class MemberNodeViewModel : ViewModelBase
     private bool _hasInlineError;
     private string? _inlineErrorMessage;
     private string? _editableStartValue;
+    private string? _ruleHint;
 
     public MemberNodeViewModel(
         MemberNode model,
@@ -178,6 +179,25 @@ public class MemberNodeViewModel : ViewModelBase
         get => _inlineErrorMessage;
         set => SetProperty(ref _inlineErrorMessage, value);
     }
+
+    /// <summary>
+    /// Human-readable description of the rule constraining this member
+    /// (e.g. "Range: 0 – 100"). Populated by the owning ViewModel at build
+    /// time from <see cref="Services.RuleHintFormatter"/>. Null when the
+    /// member has no rule or the rule exposes no constraints.
+    /// </summary>
+    public string? RuleHint
+    {
+        get => _ruleHint;
+        set
+        {
+            if (SetProperty(ref _ruleHint, value))
+                OnPropertyChanged(nameof(HasRuleHint));
+        }
+    }
+
+    /// <summary>True when <see cref="RuleHint"/> is non-empty.</summary>
+    public bool HasRuleHint => !string.IsNullOrEmpty(_ruleHint);
 
     /// <summary>Has a start value that can be bulk-edited.</summary>
     public bool HasStartValue => !string.IsNullOrEmpty(StartValue);
@@ -357,10 +377,11 @@ public class MemberNodeViewModel : ViewModelBase
     {
         IsAffected = false;
         IsAlreadyMatching = false;
-        if (IsSmartExpanded && !HasPendingDescendant())
+        if (IsSmartExpanded)
         {
             // Collapse nodes that were only auto-expanded by highlighting.
-            // Keep expanded if there are pending inline edits below.
+            // Pending inline edits no longer force expansion (#10) — they are
+            // surfaced in the sidebar, so the tree's shape stays user-driven.
             IsExpanded = false;
             IsSmartExpanded = false;
         }


### PR DESCRIPTION
## Summary
- Extract `MemberValidator` and `RuleHintFormatter` as the single source of truth for inline-edit + bulk-inspector validation, so error messages and proactive hints stay in lockstep.
- Replace the per-cell hover tooltip with a dialog-level draggable `Border` overlay that opens on focus, follows the window when dragged, and surfaces either the validation error or a rule-aware hint (with datatype fallback for typed fields that have no rule).
- Reorder validator so `RequireTagTableValue` is checked before the TIA datatype format — values that look like symbolic names (e.g. `MOD_TP1234`) now report "must be from MOD_* table" instead of the misleading "Invalid Int value". This error now also reaches the Pending Edits sidebar.
- Sidebar UX cleanup: scope survives Apply via `AncestorPath + Depth` identity (#8), Comment column gets flex sizing (#9), pending edits no longer smart-expand ancestors (#10), invalid pending count badge (#11), `recreate-workflow-video` skill for rebuilding the marketing MP4.

## Review fixes folded in
Agent review flagged and this branch addresses:
- Datatype fallback gated on `parts.Count == 0` so it no longer appears alongside `AllowedValues` / `RequireTagTableValue` (would misleadingly suggest numeric literals are accepted).
- Int min/max rendered with `InvariantCulture` so the hint matches what the parser accepts (de-DE users saw `32.768` which is not a valid Int literal).
- German `Real` example uses `3.14` to match the parser.
- Drag-reposition of the hint overlay is preserved while typing (no re-anchoring on keystroke).
- Drag state / mouse capture cleaned up when the overlay hides or its anchor is virtualized.
- Added `MemberValidatorTests` + `RuleHintFormatterTests` covering the regression-prone spots (tag-table ordering, fallback gating, InvariantCulture formatting).

Test suite: 385 → 404 passing.

## Test plan
- [ ] Inline-edit a rule-constrained cell (e.g. `moduleId` with `MOD_*` tag table): typing a name not in the table shows "Value must be a constant from the 'MOD_*' tag table" in the draggable hint overlay and in the Pending Edits sidebar.
- [ ] Inline-edit an Int cell without a rule: hint shows `Int: -32768 – 32767`.
- [ ] Drag the hint overlay to a different spot, keep typing — the overlay stays where the user put it until focus moves to another cell.
- [ ] Drag the dialog window around — the hint overlay follows the window (the old `Popup` did not).
- [ ] Type an invalid value, then pick a valid one from the autocomplete dropdown — the status bar no longer shows the stale error.
- [ ] Sidebar scope ComboBox stays on the user's selection across Apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)