### PR TITLE
Make Start Value cell read-only on non-leaf members

### DIFF
--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -366,13 +366,29 @@
                                     <Grid>
                                         <TextBox x:Name="InlineStartValue"
                                                  Text="{Binding EditableStartValue, UpdateSourceTrigger=PropertyChanged}"
+                                                 IsReadOnly="{Binding IsLeaf, Converter={StaticResource InvertBool}}"
                                                  BorderThickness="0" Background="Transparent"
                                                  FontFamily="Consolas,Courier New"
                                                  Padding="0,0,14,0" Margin="0"
                                                  GotFocus="OnStartValueGotFocus"
                                                  LostFocus="OnStartValueLostFocus"
                                                  TextChanged="OnInlineTextChanged"
-                                                 Tag="{Binding}"/>
+                                                 Tag="{Binding}">
+                                            <TextBox.Style>
+                                                <Style TargetType="TextBox">
+                                                    <Style.Triggers>
+                                                        <!-- Non-leaves (struct/UDT/array/DB root) carry no
+                                                             start value in TIA — make the cell visibly
+                                                             non-editable: muted text, no caret, not focusable. -->
+                                                        <DataTrigger Binding="{Binding IsLeaf}" Value="False">
+                                                            <Setter Property="Focusable" Value="False"/>
+                                                            <Setter Property="Cursor" Value="Arrow"/>
+                                                            <Setter Property="Foreground" Value="#999"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBox.Style>
+                                        </TextBox>
                                         <Button HorizontalAlignment="Right" VerticalAlignment="Stretch"
                                                 Width="14" Background="Transparent" BorderThickness="0"
                                                 Click="OnInlineDropdownClick" Cursor="Hand"


### PR DESCRIPTION
## Summary
- Only leaf primitives carry start values in TIA, so typing into a struct/UDT/array/DB-root row was silently no-op and confusing.
- Bound the inline `TextBox.IsReadOnly` to `!IsLeaf`. On non-leaves the cell is now also non-`Focusable`, uses an arrow cursor, and has a muted foreground (`#999`) so it reads as inert.

## Test plan
- [x] `dotnet build` clean (0 errors)
- [x] `dotnet test` — all 417 unit tests pass
- [ ] Manual: in DevLauncher, click into a struct/UDT row's Start Value cell — should not enter edit mode, no caret
- [ ] Manual: leaf rows (Bool/Int/Real) still editable as before

Closes #15