### PR TITLE
Validate existing start values on dialog load

### DIFF
--- a/src/BlockParam.Tests/BulkChangeViewModelTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelTests.cs
@@ -9,8 +9,18 @@ using Xunit;
 
 namespace BlockParam.Tests;
 
-public class BulkChangeViewModelTests
+public class BulkChangeViewModelTests : IDisposable
 {
+    private readonly List<string> _tempDirs = new();
+
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirs)
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
     private static BulkChangeViewModel CreateViewModel()
     {
         var xml = TestFixtures.LoadXml("flat-db.xml");
@@ -22,6 +32,39 @@ public class BulkChangeViewModelTests
         var usageTracker = Substitute.For<IUsageTracker>();
         usageTracker.GetStatus().Returns(new UsageStatus(0, 3));
         usageTracker.GetInlineStatus().Returns(new UsageStatus(0, 10));
+
+        return new BulkChangeViewModel(db, xml, analyzer, bulkService, usageTracker, configLoader);
+    }
+
+    private ConfigLoader CreateConfigLoaderWithRule(string ruleJson)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"test_vm_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        _tempDirs.Add(tempDir);
+
+        var configPath = Path.Combine(tempDir, "config.json");
+        File.WriteAllText(configPath, @"{ ""version"": ""1.0"" }");
+
+        var rulesDir = Path.Combine(tempDir, "rules");
+        Directory.CreateDirectory(rulesDir);
+        File.WriteAllText(Path.Combine(rulesDir, "test-rules.json"), ruleJson);
+
+        return new ConfigLoader(configPath);
+    }
+
+    private BulkChangeViewModel CreateViewModelWithRule(string fixtureName, string ruleJson)
+    {
+        var xml = TestFixtures.LoadXml(fixtureName);
+        var parser = new SimaticMLParser();
+        var db = parser.Parse(xml);
+        var analyzer = new HierarchyAnalyzer();
+        var configLoader = CreateConfigLoaderWithRule(ruleJson);
+        var bulkService = new BulkChangeService(new ChangeLogger(), configLoader);
+        var usageTracker = Substitute.For<IUsageTracker>();
+        usageTracker.GetStatus().Returns(new UsageStatus(0, 3));
+        usageTracker.GetInlineStatus().Returns(new UsageStatus(0, 10));
+        usageTracker.RecordInlineEdit().Returns(true);
+        usageTracker.RecordUsage().Returns(true);
 
         return new BulkChangeViewModel(db, xml, analyzer, bulkService, usageTracker, configLoader);
     }
@@ -47,5 +90,62 @@ public class BulkChangeViewModelTests
 
         vm.HasPendingValueDebounce.Should().BeFalse(
             "AcceptSuggestion must cancel the trailing timer so it can't re-populate FilteredSuggestions");
+    }
+
+    /// <summary>
+    /// #26: Pre-existing values that violate a configured rule should be surfaced
+    /// in <see cref="BulkChangeViewModel.ExistingIssues"/> on dialog load —
+    /// without the user needing to edit them first.
+    /// </summary>
+    [Fact]
+    public void ExistingIssues_PopulatedOnLoad_ForOutOfRangeValues()
+    {
+        // flat-db.xml has Speed=1500 — fail a rule that caps Speed at 1000.
+        var rule = @"{ ""rules"": [{ ""pathPattern"": ""Speed"", ""datatype"": ""Int"",
+            ""constraints"": { ""min"": 0, ""max"": 1000 } }] }";
+        var vm = CreateViewModelWithRule("flat-db.xml", rule);
+
+        vm.HasExistingIssues.Should().BeTrue("Speed=1500 violates max=1000");
+        vm.ExistingIssuesCount.Should().Be(1);
+        vm.ExistingIssues.Single().Node.Name.Should().Be("Speed");
+        vm.ExistingIssues.Single().CurrentValue.Should().Be("1500");
+        vm.ExistingIssues.Single().Node.HasExistingViolation.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// #26: When no rules apply (or no values violate them), <see cref="BulkChangeViewModel.ExistingIssues"/>
+    /// must stay empty. Otherwise the inspector would surface noise.
+    /// </summary>
+    [Fact]
+    public void ExistingIssues_Empty_WhenNoRules()
+    {
+        var vm = CreateViewModel(); // no rules configured
+        vm.HasExistingIssues.Should().BeFalse();
+        vm.ExistingIssuesCount.Should().Be(0);
+    }
+
+    /// <summary>
+    /// #26: Pre-existing rule violations are findings, not blockers — they must
+    /// NOT prevent Apply. Only invalid PENDING edits (HasInlineError) block Apply.
+    /// </summary>
+    [Fact]
+    public void ExistingIssues_DoNotBlockApply()
+    {
+        var rule = @"{ ""rules"": [{ ""pathPattern"": ""Speed"", ""datatype"": ""Int"",
+            ""constraints"": { ""min"": 0, ""max"": 1000 } }] }";
+        var vm = CreateViewModelWithRule("flat-db.xml", rule);
+
+        // Pre-existing violation present
+        vm.HasExistingIssues.Should().BeTrue();
+        // No pending edits, no inline errors
+        vm.HasInlineErrors.Should().BeFalse(
+            "existing violations must not flip HasInlineError — that's the Apply blocker");
+
+        // Stage a valid pending edit on a *different* member so Apply has work
+        var enable = vm.RootMembers.Single(m => m.Name == "Enable");
+        enable.EditableStartValue = "false";
+
+        vm.ApplyCommand.CanExecute(null).Should().BeTrue(
+            "a pre-existing violation on Speed must not block applying a valid pending edit on Enable");
     }
 }

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -247,6 +247,10 @@ Beispiele: en-US, de-DE. Leer lassen für Standardsprache.</value></data>
   <!-- Seitenleiste „Ausstehende Änderungen“ (#11) -->
   <data name="Pending_InvalidBadge" xml:space="preserve"><value>{0} von {1} ungültig</value></data>
   <data name="Pending_InvalidBadgeTooltip" xml:space="preserve"><value>Ungültige Einträge korrigieren oder verwerfen, bevor übernommen wird.</value></data>
+  <!-- Vorhandene Wert-Findings (#26) -->
+  <data name="Issues_Header" xml:space="preserve"><value>FINDINGS</value></data>
+  <data name="Issues_Empty" xml:space="preserve"><value>Keine Regelverletzungen in den aktuellen Werten gefunden.</value></data>
+  <data name="Issues_Tooltip" xml:space="preserve"><value>Vorhandene Werte, die bereits gegen eine konfigurierte Regel verstoßen. Schreibgeschützt — manuell beheben falls nötig; das Übernehmen wird nicht blockiert.</value></data>
   <!-- Inkonsistente UDT Kompilier-Abfrage (#27) -->
   <data name="Udt_InconsistentPromptTitle" xml:space="preserve"><value>BlockParam — Kompilierung erforderlich</value></data>
   <data name="Udt_InconsistentPrompt" xml:space="preserve"><value>{0} UDT(s) können nicht exportiert werden, da sie inkonsistent sind:

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -626,6 +626,16 @@ Examples: en-US, de-DE. Leave empty for the default language.</value>
   <data name="Pending_InvalidBadgeTooltip" xml:space="preserve">
     <value>Fix or undo invalid entries before applying.</value>
   </data>
+  <!-- Existing-value validator findings (#26) -->
+  <data name="Issues_Header" xml:space="preserve">
+    <value>ISSUES</value>
+  </data>
+  <data name="Issues_Empty" xml:space="preserve">
+    <value>No rule violations found in current values.</value>
+  </data>
+  <data name="Issues_Tooltip" xml:space="preserve">
+    <value>Existing values that already violate a configured rule. Read-only — fix manually if needed; Apply is not blocked.</value>
+  </data>
   <!-- Inconsistent UDT compile prompt (#27) -->
   <data name="Udt_InconsistentPromptTitle" xml:space="preserve">
     <value>BlockParam — Compilation Required</value>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -231,6 +231,14 @@
                                 <Setter Property="Background" Value="#FAFAFA"/>
                             </Trigger>
                             <!-- Status is shown as a 3px colored left edge (plus a pale fill in the Value column) -->
+                            <!-- Pre-existing rule violation (purple, non-blocking — #26).
+                                 Lower priority than every interactive state: rows the user
+                                 is actively editing or affecting take the regular colors;
+                                 the purple edge only stays visible when nothing else applies. -->
+                            <DataTrigger Binding="{Binding HasExistingViolation}" Value="True">
+                                <Setter Property="BorderBrush" Value="#9C27B0"/>
+                                <Setter Property="ToolTip" Value="{Binding ExistingViolationMessage}"/>
+                            </DataTrigger>
                             <!-- Pending inline edit (orange) -->
                             <DataTrigger Binding="{Binding IsPendingInlineEdit}" Value="True">
                                 <Setter Property="BorderBrush" Value="#F39C12"/>
@@ -243,7 +251,7 @@
                             <DataTrigger Binding="{Binding IsAffected}" Value="True">
                                 <Setter Property="BorderBrush" Value="#2196F3"/>
                             </DataTrigger>
-                            <!-- Invalid inline edit (red, highest priority) -->
+                            <!-- Invalid inline edit (red, highest priority — blocks Apply) -->
                             <DataTrigger Binding="{Binding HasInlineError}" Value="True">
                                 <Setter Property="BorderBrush" Value="#D32F2F"/>
                                 <Setter Property="ToolTip" Value="{Binding InlineErrorMessage}"/>
@@ -348,6 +356,10 @@
                                             <Style TargetType="Border">
                                                 <Setter Property="Background" Value="Transparent"/>
                                                 <Style.Triggers>
+                                                    <!-- Pre-existing rule violation (light purple, #26). -->
+                                                    <DataTrigger Binding="{Binding HasExistingViolation}" Value="True">
+                                                        <Setter Property="Background" Value="#F3E5F5"/>
+                                                    </DataTrigger>
                                                     <DataTrigger Binding="{Binding IsPendingInlineEdit}" Value="True">
                                                         <Setter Property="Background" Value="#FFE0B2"/>
                                                     </DataTrigger>
@@ -503,7 +515,7 @@
                             </Border>
                         </Grid>
                         <!-- Pending edits + count badge -->
-                        <Grid Width="26" Height="26" Margin="0,2,0,6">
+                        <Grid Width="26" Height="26" Margin="0,2">
                             <Button Command="{Binding ToggleInspectorCommand}"
                                     Background="Transparent" BorderThickness="0" Cursor="Hand"
                                     ToolTip="Pending edits">
@@ -517,6 +529,26 @@
                                     IsHitTestVisible="False"
                                     Visibility="{Binding HasPendingEdits, Converter={StaticResource BoolToVis}}">
                                 <TextBlock Text="{Binding PendingInlineEditCount}" FontSize="8"
+                                           FontWeight="Bold" Foreground="White"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                        </Grid>
+                        <!-- Issues + count badge (#26) -->
+                        <Grid Width="26" Height="26" Margin="0,2,0,6">
+                            <Button Command="{Binding ToggleInspectorCommand}"
+                                    Background="Transparent" BorderThickness="0" Cursor="Hand"
+                                    ToolTip="{loc:Loc Issues_Tooltip}">
+                                <Viewbox Width="16" Height="16">
+                                    <Path Data="M 8,1 L 15,14 L 1,14 Z M 8,5 L 8,10 M 8,11.5 L 8,12.5"
+                                          Stroke="#9C27B0" StrokeThickness="1.5" Fill="#F3E5F5"/>
+                                </Viewbox>
+                            </Button>
+                            <Border Background="#9C27B0" CornerRadius="7" MinWidth="14" Height="12"
+                                    HorizontalAlignment="Right" VerticalAlignment="Top"
+                                    Padding="3,0" Margin="0,-2,-2,0"
+                                    IsHitTestVisible="False"
+                                    Visibility="{Binding HasExistingIssues, Converter={StaticResource BoolToVis}}">
+                                <TextBlock Text="{Binding ExistingIssuesCount}" FontSize="8"
                                            FontWeight="Bold" Foreground="White"
                                            HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Border>
@@ -1071,6 +1103,133 @@
                                                            FontSize="10" Foreground="#B71C1C"
                                                            TextWrapping="Wrap" Margin="0,2,0,0"
                                                            Visibility="{Binding Node.HasInlineError, Converter={StaticResource BoolToVis}}"/>
+                                            </StackPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+
+                            <!-- =========================================================
+                                 Section 4 — ISSUES (#26)
+                                 Read-only findings: existing StartValues that already violate
+                                 a configured rule. Click a row to jump to the member in the
+                                 tree. Does NOT block Apply.
+                                 ========================================================= -->
+                            <Border Background="#EEF0F3" BorderBrush="#B9BEC6"
+                                    BorderThickness="0,1,0,1">
+                                <DockPanel ToolTip="{loc:Loc Issues_Tooltip}">
+                                    <Button DockPanel.Dock="Left"
+                                            Command="{Binding ToggleIssuesCommand}"
+                                            Background="Transparent" BorderThickness="0"
+                                            Width="18" Height="24" Cursor="Hand" Focusable="False">
+                                        <Grid Width="10" Height="10">
+                                            <TextBlock Text="&#x25BC;" FontSize="9" Foreground="#5b6471"
+                                                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                       Visibility="{Binding IsIssuesExpanded, Converter={StaticResource BoolToVis}}"/>
+                                            <TextBlock Text="&#x25B6;" FontSize="9" Foreground="#5b6471"
+                                                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                       Visibility="{Binding IsIssuesExpanded, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"/>
+                                        </Grid>
+                                    </Button>
+                                    <!-- Section icon: triangle/exclamation = warning finding -->
+                                    <Viewbox DockPanel.Dock="Left" Width="13" Height="13"
+                                             Margin="0,0,6,0" VerticalAlignment="Center">
+                                        <Path Data="M 8,1 L 15,14 L 1,14 Z M 8,5 L 8,10 M 8,11.5 L 8,12.5"
+                                              Stroke="#9C27B0" StrokeThickness="1.5" Fill="#F3E5F5"/>
+                                    </Viewbox>
+                                    <TextBlock DockPanel.Dock="Left" Text="{loc:Loc Issues_Header}"
+                                               Margin="0,6,0,6"
+                                               FontSize="10.5" FontWeight="Bold" Foreground="#1e2227"
+                                               VerticalAlignment="Center"/>
+                                    <Border DockPanel.Dock="Left" Margin="6,0,0,0" Padding="5,0"
+                                            Background="#9C27B0" CornerRadius="8"
+                                            VerticalAlignment="Center"
+                                            Visibility="{Binding HasExistingIssues, Converter={StaticResource BoolToVis}}">
+                                        <TextBlock Text="{Binding ExistingIssuesCount}"
+                                                   FontSize="10" FontWeight="Bold" Foreground="White"/>
+                                    </Border>
+                                    <!-- Filler to consume remaining space (avoids the icon's tooltip
+                                         being the only hover target on a wide section header). -->
+                                    <Border/>
+                                </DockPanel>
+                            </Border>
+                            <!-- Empty state -->
+                            <Border Background="White" Padding="12,10" MinHeight="52">
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                        <Style.Triggers>
+                                            <MultiDataTrigger>
+                                                <MultiDataTrigger.Conditions>
+                                                    <Condition Binding="{Binding IsIssuesExpanded}" Value="True"/>
+                                                    <Condition Binding="{Binding HasExistingIssues}" Value="False"/>
+                                                </MultiDataTrigger.Conditions>
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </MultiDataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+                                <TextBlock Text="{loc:Loc Issues_Empty}"
+                                           FontSize="10.5" Foreground="#8a929d" FontStyle="Italic"
+                                           TextWrapping="Wrap"/>
+                            </Border>
+                            <!-- List -->
+                            <ItemsControl x:Name="ExistingIssuesList"
+                                          ItemsSource="{Binding ExistingIssues}"
+                                          Background="White">
+                                <ItemsControl.Style>
+                                    <Style TargetType="ItemsControl">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                        <Style.Triggers>
+                                            <MultiDataTrigger>
+                                                <MultiDataTrigger.Conditions>
+                                                    <Condition Binding="{Binding IsIssuesExpanded}" Value="True"/>
+                                                    <Condition Binding="{Binding HasExistingIssues}" Value="True"/>
+                                                </MultiDataTrigger.Conditions>
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </MultiDataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </ItemsControl.Style>
+                                <ItemsControl.Template>
+                                    <ControlTemplate TargetType="ItemsControl">
+                                        <Border Background="White">
+                                            <ItemsPresenter/>
+                                        </Border>
+                                    </ControlTemplate>
+                                </ItemsControl.Template>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border BorderBrush="#9C27B0" BorderThickness="3,0,0,1"
+                                                Background="#FBF4FC"
+                                                Padding="10,4,10,4"
+                                                ToolTip="{Binding Message}"
+                                                MouseLeftButtonUp="OnIssueRowClick"
+                                                Cursor="Hand">
+                                            <StackPanel>
+                                                <DockPanel LastChildFill="True">
+                                                    <TextBlock Text="{Binding ShortPath}"
+                                                               FontFamily="Consolas,Courier New" FontSize="10"
+                                                               Foreground="#5b6471"
+                                                               TextTrimming="CharacterEllipsis"
+                                                               VerticalAlignment="Center"/>
+                                                </DockPanel>
+                                                <StackPanel Orientation="Horizontal" Margin="0,1,0,0">
+                                                    <Border Background="#F3E5F5" Padding="3,0">
+                                                        <TextBlock Text="{Binding CurrentValue}"
+                                                                   FontFamily="Consolas,Courier New" FontSize="10"
+                                                                   FontWeight="SemiBold"
+                                                                   Foreground="#4A148C"/>
+                                                    </Border>
+                                                </StackPanel>
+                                                <TextBlock Text="{Binding Message}"
+                                                           FontSize="10" Foreground="#4A148C"
+                                                           TextWrapping="Wrap" Margin="0,2,0,0"/>
+                                                <TextBlock Text="{Binding Hint}"
+                                                           FontSize="9.5" Foreground="#8a929d"
+                                                           FontStyle="Italic"
+                                                           TextWrapping="Wrap" Margin="0,1,0,0"
+                                                           Visibility="{Binding Hint, Converter={StaticResource NullToVis}}"/>
                                             </StackPanel>
                                         </Border>
                                     </DataTemplate>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml.cs
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml.cs
@@ -84,6 +84,18 @@ public partial class BulkChangeDialog : Window
         JumpToMember(entry.Node);
     }
 
+    /// <summary>
+    /// Click on an Issues-list row → jump to that member in the tree (#26).
+    /// Issues are read-only findings; the row has no buttons of its own,
+    /// so any click anywhere on the row should jump.
+    /// </summary>
+    private void OnIssueRowClick(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is not FrameworkElement fe) return;
+        if (fe.DataContext is not ExistingIssueEntry entry) return;
+        JumpToMember(entry.Node);
+    }
+
     /// <summary>Per-row ↶ button in the Pending-edits list.</summary>
     private void OnUndoPendingClick(object sender, RoutedEventArgs e)
     {

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -75,6 +75,7 @@ public class BulkChangeViewModel : ViewModelBase
     private bool _isBulkEditExpanded = true;
     private bool _isBulkPreviewExpanded = true;
     private bool _isPendingExpanded = true;
+    private bool _isIssuesExpanded = true;
     private string _currentXml;
     private readonly IReadOnlyList<string> _projectLanguages;
     private readonly CommentLanguagePolicy _commentLanguagePolicy;
@@ -147,6 +148,7 @@ public class BulkChangeViewModel : ViewModelBase
 
         BulkPreview = new ObservableCollection<BulkPreviewEntry>();
         PendingEdits = new ObservableCollection<PendingEditEntry>();
+        ExistingIssues = new ObservableCollection<ExistingIssueEntry>();
 
         // Build tree view models
         RootMembers = new ObservableCollection<MemberNodeViewModel>();
@@ -176,6 +178,7 @@ public class BulkChangeViewModel : ViewModelBase
         ToggleBulkEditCommand = new RelayCommand(() => IsBulkEditExpanded = !IsBulkEditExpanded);
         ToggleBulkPreviewCommand = new RelayCommand(() => IsBulkPreviewExpanded = !IsBulkPreviewExpanded);
         TogglePendingCommand = new RelayCommand(() => IsPendingExpanded = !IsPendingExpanded);
+        ToggleIssuesCommand = new RelayCommand(() => IsIssuesExpanded = !IsIssuesExpanded);
         ClearManualSelectionCommand = new RelayCommand(ExecuteClearManualSelection,
             () => _manualSelectedPaths.Count > 0);
 
@@ -189,6 +192,10 @@ public class BulkChangeViewModel : ViewModelBase
         ApplyAllFilters();
         RefreshFlatList();
         UpdateUsageStatus();
+
+        // #26: Surface pre-existing rule violations on dialog load. Runs after
+        // RefreshRuleHints so RuleHint is available for the issue tooltip.
+        RebuildExistingIssues();
     }
 
     // --- Properties ---
@@ -211,9 +218,19 @@ public class BulkChangeViewModel : ViewModelBase
     /// </summary>
     public ObservableCollection<PendingEditEntry> PendingEdits { get; }
 
+    /// <summary>
+    /// Findings produced by running the validator over the *existing* StartValues
+    /// when the dialog opens (and after every tree refresh / inline edit). Read-only —
+    /// these are pre-existing rule violations the user can fix manually, not pending
+    /// edits. They never block Apply (#26).
+    /// </summary>
+    public ObservableCollection<ExistingIssueEntry> ExistingIssues { get; }
+
     public bool HasBulkPreview => BulkPreview.Count > 0;
     public int BulkPreviewCount => BulkPreview.Count;
     public bool HasPendingEdits => PendingEdits.Count > 0;
+    public bool HasExistingIssues => ExistingIssues.Count > 0;
+    public int ExistingIssuesCount => ExistingIssues.Count;
 
     /// <summary>Preview rows whose node already has a pending edit — they'd overwrite it on Set.</summary>
     public int BulkPreviewConflictCount => BulkPreview.Count(e => e.HasPendingConflict);
@@ -595,9 +612,16 @@ public class BulkChangeViewModel : ViewModelBase
         set { if (_isPendingExpanded != value) { _isPendingExpanded = value; OnPropertyChanged(nameof(IsPendingExpanded)); } }
     }
 
+    public bool IsIssuesExpanded
+    {
+        get => _isIssuesExpanded;
+        set { if (_isIssuesExpanded != value) { _isIssuesExpanded = value; OnPropertyChanged(nameof(IsIssuesExpanded)); } }
+    }
+
     public ICommand ToggleBulkEditCommand { get; }
     public ICommand ToggleBulkPreviewCommand { get; }
     public ICommand TogglePendingCommand { get; }
+    public ICommand ToggleIssuesCommand { get; }
 
     /// <summary>
     /// Raised after the flat list has been refreshed so the view can rehydrate
@@ -1459,6 +1483,52 @@ public class BulkChangeViewModel : ViewModelBase
             ApplyRuleHint(child, config);
     }
 
+    /// <summary>
+    /// Runs the shared <see cref="MemberValidator"/> over every leaf member's
+    /// *current* StartValue (independent of any pending edit) and rebuilds
+    /// <see cref="ExistingIssues"/> with one entry per violation. Surfaces
+    /// rule drift and edits made directly in TIA without forcing the user to
+    /// touch the value first (#26).
+    /// </summary>
+    /// <remarks>
+    /// Intentionally does not depend on tag tables having been exported — the
+    /// validator already short-circuits cleanly when the cache is missing
+    /// (no false positives for tag-table rules with no cache yet).
+    /// </remarks>
+    private void RebuildExistingIssues()
+    {
+        ExistingIssues.Clear();
+        var validator = BuildValidator();
+
+        foreach (var root in RootMembers)
+            ScanExistingViolations(root, validator);
+
+        OnPropertyChanged(nameof(HasExistingIssues));
+        OnPropertyChanged(nameof(ExistingIssuesCount));
+    }
+
+    private void ScanExistingViolations(MemberNodeViewModel node, MemberValidator validator)
+    {
+        if (node.IsLeaf && !string.IsNullOrEmpty(node.StartValue))
+        {
+            var error = validator.Validate(node.Model, node.StartValue);
+            if (error != null)
+            {
+                node.HasExistingViolation = true;
+                node.ExistingViolationMessage = error;
+                ExistingIssues.Add(new ExistingIssueEntry(
+                    node, node.StartValue ?? "", error, node.RuleHint));
+            }
+            else if (node.HasExistingViolation)
+            {
+                node.HasExistingViolation = false;
+                node.ExistingViolationMessage = null;
+            }
+        }
+        foreach (var child in node.Children)
+            ScanExistingViolations(child, validator);
+    }
+
     private void UpdateFilteredSuggestions()
     {
         if (_suggestions.Count == 0 || _suppressSuggestions)
@@ -1599,6 +1669,9 @@ public class BulkChangeViewModel : ViewModelBase
 
         UpdateTagTableAge();
         ReloadSuggestions();
+        // Tag-table rules may have flipped from "no cache → no validation" to
+        // "cache loaded → validates" — rerun the existing-value scan (#26).
+        RebuildExistingIssues();
     }
 
     private void UpdateTagTableAge()
@@ -2015,6 +2088,10 @@ public class BulkChangeViewModel : ViewModelBase
         // Reload config after editor closes (may have been saved)
         _configLoader.Invalidate();
         OnPropertyChanged(nameof(HasCommentConfig));
+        // Re-evaluate rule hints + existing-value findings against the
+        // (possibly updated) ruleset (#26).
+        RefreshRuleHints();
+        RebuildExistingIssues();
         StatusText = Res.Get("Status_Ready");
     }
 
@@ -2247,6 +2324,7 @@ public class BulkChangeViewModel : ViewModelBase
             RootMembers.Add(vm);
         }
         RefreshRuleHints();
+        RebuildExistingIssues();
 
         // Restore expand states on ALL new nodes before building flat list
         foreach (var root in RootMembers)

--- a/src/BlockParam/UI/ExistingIssueEntry.cs
+++ b/src/BlockParam/UI/ExistingIssueEntry.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+
+namespace BlockParam.UI;
+
+/// <summary>
+/// One row in the right inspector's "Issues" section (#26).
+/// Mirrors a member whose *current* StartValue (already in the DB before the
+/// user opened the dialog) violates a configured rule. Read-only — these are
+/// findings, not edits, and they do NOT block Apply.
+/// </summary>
+public class ExistingIssueEntry
+{
+    public ExistingIssueEntry(MemberNodeViewModel node, string currentValue,
+        string message, string? hint)
+    {
+        Node = node;
+        CurrentValue = currentValue;
+        Message = message;
+        Hint = hint;
+    }
+
+    public MemberNodeViewModel Node { get; }
+    public string CurrentValue { get; }
+    public string Message { get; }
+    public string? Hint { get; }
+
+    public string Path => Node.Path;
+
+    /// <summary>Last up-to-three path segments joined with " › " (matches PendingEditEntry).</summary>
+    public string ShortPath
+    {
+        get
+        {
+            var segments = Node.Path.Split('.');
+            return string.Join(" › ", segments.Skip(System.Math.Max(0, segments.Length - 3)));
+        }
+    }
+}

--- a/src/BlockParam/UI/MemberNodeViewModel.cs
+++ b/src/BlockParam/UI/MemberNodeViewModel.cs
@@ -19,6 +19,8 @@ public class MemberNodeViewModel : ViewModelBase
     private bool _isSearchMatch;
     private bool _hasInlineError;
     private string? _inlineErrorMessage;
+    private bool _hasExistingViolation;
+    private string? _existingViolationMessage;
     private string? _editableStartValue;
     private string? _ruleHint;
 
@@ -177,6 +179,29 @@ public class MemberNodeViewModel : ViewModelBase
     {
         get => _inlineErrorMessage;
         set => SetProperty(ref _inlineErrorMessage, value);
+    }
+
+    /// <summary>
+    /// True when this member's *current* StartValue (as it sits in the DB,
+    /// independent of any pending edit) violates a configured rule. Surfaced
+    /// in the inspector "Issues" section as a read-only finding (#26).
+    /// Distinct from <see cref="HasInlineError"/>: pre-existing violations
+    /// must NOT block Apply — Apply only cares about pending edits.
+    /// </summary>
+    public bool HasExistingViolation
+    {
+        get => _hasExistingViolation;
+        set => SetProperty(ref _hasExistingViolation, value);
+    }
+
+    /// <summary>
+    /// Human-readable description of why this member's existing value fails its
+    /// rule (e.g. "Range: 0 – 100"). Null when <see cref="HasExistingViolation"/> is false.
+    /// </summary>
+    public string? ExistingViolationMessage
+    {
+        get => _existingViolationMessage;
+        set => SetProperty(ref _existingViolationMessage, value);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Surface pre-existing rule violations in a new read-only "Issues" section of the inspector, populated on dialog load and after every config / tag-table / tree refresh.
- Findings are non-blocking — `HasInlineError` (pending edits) remains the only Apply blocker.
- Click an issue row to jump to the member in the tree; rows get a purple left edge / pale fill via existing trigger ordering.

## Test plan
- [x] `ExistingIssues_PopulatedOnLoad_ForOutOfRangeValues` — Speed=1500 vs max=1000 surfaces.
- [x] `ExistingIssues_Empty_WhenNoRules` — no rules → no noise.
- [x] `ExistingIssues_DoNotBlockApply` — pre-existing violation + valid pending edit → Apply enabled.
- [ ] Manual: open a DB with a known-bad value in TIA, confirm the purple badge + section row.

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)