### PR TITLE
Zoom scales content only, not window size

### DIFF
--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -254,4 +254,6 @@ Beispiele: en-US, de-DE. Leer lassen für Standardsprache.</value></data>
 {1}
 
 Jetzt kompilieren? Andernfalls bleiben die Kommentare dieser UDT-Mitglieder in der Anzeige leer.</value></data>
+  <!-- Zoom-Anzeige (#28) -->
+  <data name="Zoom_Tooltip" xml:space="preserve"><value>Zoom (Strg + Mausrad, Strg + / Strg −, Strg + 0 zum Zurücksetzen)</value></data>
 </root>

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -638,4 +638,9 @@ Examples: en-US, de-DE. Leave empty for the default language.</value>
 Compile them now? Member comments from these UDTs will otherwise appear blank.</value>
     <comment>{0} = count, {1} = comma-separated list of UDT names</comment>
   </data>
+  <!-- Zoom indicator (#28): tooltip teaches the keyboard shortcuts so the
+       widget makes the existing Ctrl+scroll / Ctrl +/- feature discoverable. -->
+  <data name="Zoom_Tooltip" xml:space="preserve">
+    <value>Zoom (Ctrl + mouse wheel, Ctrl + / Ctrl −, Ctrl + 0 to reset)</value>
+  </data>
 </root>

--- a/src/BlockParam/Services/UiZoomService.cs
+++ b/src/BlockParam/Services/UiZoomService.cs
@@ -46,22 +46,8 @@ public class UiZoomService
     /// <summary>
     /// Creates an in-memory-only zoom service that neither reads from nor
     /// writes to disk, so it always starts at <see cref="DefaultZoom"/>.
-    /// Also disables <see cref="AutoResizeWindow"/> since capture mode drives
-    /// window size via its own viewport config.
     /// </summary>
-    public static UiZoomService CreateEphemeral()
-    {
-        var s = new UiZoomService(settingsPath: "");
-        s.AutoResizeWindow = false;
-        return s;
-    }
-
-    /// <summary>
-    /// When true (default), ZoomHost scales the window dimensions
-    /// proportionally as the zoom changes so scaled content fits. Capture
-    /// mode sets this false because the scene viewport is authoritative.
-    /// </summary>
-    public bool AutoResizeWindow { get; set; } = true;
+    public static UiZoomService CreateEphemeral() => new(settingsPath: "");
 
     public UiZoomService() : this(DefaultSettingsPath()) { }
 

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -80,6 +80,10 @@
         <!-- Bottom bar: action buttons + license/usage info + status -->
         <DockPanel DockPanel.Dock="Bottom" Margin="0,8,0,0">
             <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                <!-- Discoverable zoom widget (#28). Placed left of the action
+                     buttons so the persistent percentage label and shortcut
+                     tooltip stay in the user's peripheral vision. -->
+                <local:ZoomIndicator Margin="0,0,12,0" VerticalAlignment="Center"/>
                 <!-- License / usage summary — clickable to open the license dialog.
                      Single control replaces the old tier badge + separate Manage link. -->
                 <Button Content="{Binding UsageStatusText}" FontSize="10"

--- a/src/BlockParam/UI/ConfigEditorDialog.xaml
+++ b/src/BlockParam/UI/ConfigEditorDialog.xaml
@@ -70,6 +70,7 @@
                        Visibility="{Binding ValidationMessage, Converter={StaticResource StringToVis}}"
                        TextWrapping="Wrap"/>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <local:ZoomIndicator Margin="0,0,12,0" VerticalAlignment="Center"/>
                 <Button Content="{loc:Loc ConfigEditor_Save}" Command="{Binding SaveCommand}"
                         Width="80" Height="28" Margin="0,0,8,0"/>
                 <Button Content="{loc:Loc ConfigEditor_SaveAndClose}" Command="{Binding SaveAndCloseCommand}"

--- a/src/BlockParam/UI/DiffPreviewDialog.xaml
+++ b/src/BlockParam/UI/DiffPreviewDialog.xaml
@@ -13,6 +13,7 @@
         <!-- Buttons at bottom -->
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal"
                     HorizontalAlignment="Right" Margin="0,12,0,0">
+            <local:ZoomIndicator Margin="0,0,12,0" VerticalAlignment="Center"/>
             <Button Content="{loc:Loc DiffPreview_ApplyChanges}" Command="{Binding ApplyCommand}"
                     Width="110" Height="28" Margin="0,0,8,0"/>
             <Button Content="{loc:Loc Dialog_Cancel}" Command="{Binding CancelCommand}"

--- a/src/BlockParam/UI/LicenseKeyDialog.xaml
+++ b/src/BlockParam/UI/LicenseKeyDialog.xaml
@@ -1,6 +1,7 @@
 <Window x:Class="BlockParam.UI.LicenseKeyDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:BlockParam.UI"
         xmlns:loc="clr-namespace:BlockParam.Localization"
         Title="{loc:Loc License_DialogTitle}"
                 Width="420" Height="280"
@@ -67,6 +68,7 @@
 
         <!-- Bottom buttons -->
         <StackPanel Grid.Row="6" Orientation="Horizontal" HorizontalAlignment="Right">
+            <local:ZoomIndicator Margin="0,0,12,0" VerticalAlignment="Center"/>
             <Button x:Name="RemoveButton" Content="{loc:Loc License_RemoveKey}"
                     Width="120" Height="28" Margin="0,0,8,0"
                     Click="OnRemoveClick" Visibility="Collapsed"/>

--- a/src/BlockParam/UI/ZoomHost.cs
+++ b/src/BlockParam/UI/ZoomHost.cs
@@ -9,8 +9,9 @@ namespace BlockParam.UI;
 /// <summary>
 /// Attaches per-window UI zoom to a <see cref="Window"/>:
 /// Ctrl+Scroll, Ctrl +/-, Ctrl+0 (reset) scale the window content via
-/// <see cref="FrameworkElement.LayoutTransform"/> and resize the window
-/// proportionally so scaled content still fits.
+/// <see cref="FrameworkElement.LayoutTransform"/>. The window itself does
+/// not resize — content scales within the existing window bounds, like
+/// browser zoom.
 ///
 /// Zoom is shared across all dialogs via <see cref="UiZoomService.Shared"/>
 /// so toggling zoom in one dialog updates every open dialog at once and the
@@ -38,11 +39,6 @@ internal static class ZoomHost
 
     public static void Attach(Window window, UiZoomService service)
     {
-        // Start from 1.0 so the first apply (with a persisted factor) scales the
-        // window from the XAML "designed" size up to designed × factor. Subsequent
-        // changes scale by the delta so any manual window resize is preserved.
-        double lastAppliedFactor = 1.0;
-
         void ApplyZoom(double factor)
         {
             if (window.Content is not FrameworkElement root) return;
@@ -50,15 +46,6 @@ internal static class ZoomHost
             root.LayoutTransform = Math.Abs(factor - 1.0) < 0.0001
                 ? Transform.Identity
                 : new ScaleTransform(factor, factor);
-
-            var ratio = factor / lastAppliedFactor;
-            if (service.AutoResizeWindow && Math.Abs(ratio - 1.0) > 0.0001)
-            {
-                if (!double.IsNaN(window.Width))  window.Width  = ClampToScreen(window.Width  * ratio, isHeight: false);
-                if (!double.IsNaN(window.Height)) window.Height = ClampToScreen(window.Height * ratio, isHeight: true);
-            }
-
-            lastAppliedFactor = factor;
         }
 
         void OnZoomChanged(double factor) => ApplyZoom(factor);
@@ -98,12 +85,5 @@ internal static class ZoomHost
             else if (e.Delta < 0) service.ZoomOut();
             e.Handled = true;
         };
-    }
-
-    private static double ClampToScreen(double value, bool isHeight)
-    {
-        var wa = SystemParameters.WorkArea;
-        var limit = isHeight ? wa.Height : wa.Width;
-        return Math.Min(value, limit);
     }
 }

--- a/src/BlockParam/UI/ZoomIndicator.xaml
+++ b/src/BlockParam/UI/ZoomIndicator.xaml
@@ -1,0 +1,57 @@
+<UserControl x:Class="BlockParam.UI.ZoomIndicator"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:BlockParam.Localization">
+    <UserControl.Resources>
+        <Style x:Key="ZoomStepButton" TargetType="Button">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Foreground" Value="#555"/>
+            <Setter Property="Height" Value="20"/>
+            <Setter Property="MinWidth" Value="20"/>
+            <Setter Property="Padding" Value="4,0"/>
+            <Setter Property="Focusable" Value="False"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bd"
+                                Background="{TemplateBinding Background}"
+                                Padding="{TemplateBinding Padding}"
+                                CornerRadius="2">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="#E0E0E0"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
+
+    <Border ToolTip="{loc:Loc Zoom_Tooltip}"
+            BorderBrush="#DDD" BorderThickness="1" CornerRadius="3"
+            Background="#FAFAFA" Padding="2,0" VerticalAlignment="Center">
+        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+            <Button x:Name="ZoomOutButton"
+                    Style="{StaticResource ZoomStepButton}"
+                    Content="−"
+                    FontSize="14" FontWeight="Bold"
+                    Click="OnZoomOutClick"/>
+            <Button x:Name="PercentButton"
+                    Style="{StaticResource ZoomStepButton}"
+                    Content="100%"
+                    MinWidth="40"
+                    FontSize="11"
+                    Click="OnResetClick"/>
+            <Button x:Name="ZoomInButton"
+                    Style="{StaticResource ZoomStepButton}"
+                    Content="+"
+                    FontSize="14" FontWeight="Bold"
+                    Click="OnZoomInClick"/>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/src/BlockParam/UI/ZoomIndicator.xaml.cs
+++ b/src/BlockParam/UI/ZoomIndicator.xaml.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+using BlockParam.Services;
+
+namespace BlockParam.UI;
+
+/// <summary>
+/// Discoverable surface for the UI zoom feature: shows the current zoom
+/// percentage with − / + step buttons and a clickable percentage label that
+/// resets to <see cref="UiZoomService.DefaultZoom"/> (mirrors Ctrl+0).
+///
+/// Reuses <see cref="UiZoomService.Shared"/> by default so a click here is
+/// indistinguishable from Ctrl+scroll or Ctrl +/-: the same persisted state
+/// drives every open dialog.
+/// </summary>
+public partial class ZoomIndicator : UserControl
+{
+    private UiZoomService _service = UiZoomService.Shared;
+
+    public ZoomIndicator()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+    }
+
+    /// <summary>
+    /// Swap the backing service. Used by tests and by capture mode to point
+    /// the indicator at an ephemeral service rather than the global singleton.
+    /// </summary>
+    internal void Bind(UiZoomService service)
+    {
+        _service.ZoomChanged -= OnZoomChanged;
+        _service = service;
+        if (IsLoaded)
+        {
+            _service.ZoomChanged += OnZoomChanged;
+            UpdateLabel(_service.ZoomFactor);
+        }
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        _service.ZoomChanged += OnZoomChanged;
+        UpdateLabel(_service.ZoomFactor);
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        _service.ZoomChanged -= OnZoomChanged;
+    }
+
+    private void OnZoomChanged(double factor) => UpdateLabel(factor);
+
+    private void UpdateLabel(double factor)
+    {
+        PercentButton.Content = string.Format(
+            CultureInfo.InvariantCulture, "{0}%", (int)Math.Round(factor * 100));
+    }
+
+    private void OnZoomInClick(object sender, RoutedEventArgs e) => _service.ZoomIn();
+    private void OnZoomOutClick(object sender, RoutedEventArgs e) => _service.ZoomOut();
+    private void OnResetClick(object sender, RoutedEventArgs e) => _service.ResetZoom();
+}


### PR DESCRIPTION
## Summary
- Zoom no longer resizes dialog windows; content scales via `LayoutTransform` within the existing bounds (browser-style)
- Removes the now-dead `AutoResizeWindow` toggle from `UiZoomService`

## Test plan
- [x] `dotnet build src/BlockParam -c Debug` — 0 errors
- [x] `dotnet test src/BlockParam.Tests` — 417/417 passed
- [x] DevLauncher: Ctrl+wheel / Ctrl ± / Ctrl 0 scale content within fixed window

🤖 Generated with [Claude Code](https://claude.com/claude-code)