### PR TITLE
Dispose VM debounce timers + comment cleanup pass

### DIFF
--- a/src/BlockParam/AddIn/BulkChangeContextMenu.cs
+++ b/src/BlockParam/AddIn/BulkChangeContextMenu.cs
@@ -81,7 +81,7 @@ public class BulkChangeContextMenu : ContextMenuAddIn
         {
             // Mutable: ImportBlock disposes the old DataBlock instance; we must refresh
             // this reference after every import so subsequent Apply clicks don't hit a
-            // disposed GlobalDB (#19).
+            // disposed GlobalDB.
             var selection = provider.GetSelection<DataBlock>().FirstOrDefault();
             if (selection == null) return;
 
@@ -152,7 +152,6 @@ public class BulkChangeContextMenu : ContextMenuAddIn
             var configPath = FindConfigFile();
             var configLoader = new ConfigLoader(configPath);
 
-            // Auto-detect TIA project path and language settings (project already resolved above for scope)
             IReadOnlyList<string> projectLanguages = Array.Empty<string>();
             string? editingLanguage = null;
             string? referenceLanguage = null;

--- a/src/BlockParam/Config/ValueConstraint.cs
+++ b/src/BlockParam/Config/ValueConstraint.cs
@@ -32,14 +32,12 @@ public class ValueConstraint
     /// </summary>
     public string? Validate(string value, string? datatype = null, ISet<string>? knownConstants = null)
     {
-        // 1. Data type format validation (if datatype provided)
         if (datatype != null)
         {
             var typeError = TiaDataTypeValidator.Validate(value, datatype, knownConstants);
             if (typeError != null) return typeError;
         }
 
-        // 2. Check Min/Max range
         if (HasMinMax)
         {
             // Known constants skip Min/Max — they resolve at TIA runtime
@@ -73,7 +71,6 @@ public class ValueConstraint
             }
         }
 
-        // 3. Check allowed values list
         if (AllowedValues is { Count: > 0 })
         {
             var stringValues = AllowedValues.Select(v => v.ToString()).ToList();

--- a/src/BlockParam/Licensing/LocalUsageTracker.cs
+++ b/src/BlockParam/Licensing/LocalUsageTracker.cs
@@ -103,7 +103,6 @@ public class LocalUsageTracker : IUsageTracker
         var json = JsonConvert.SerializeObject(data);
         var bytes = Obfuscation.Obfuscate(json);
 
-        // Use a temporary file + rename for atomicity
         var tempPath = _storagePath + ".tmp";
         File.WriteAllBytes(tempPath, bytes);
         if (File.Exists(_storagePath))

--- a/src/BlockParam/Licensing/ShopUrls.cs
+++ b/src/BlockParam/Licensing/ShopUrls.cs
@@ -2,14 +2,10 @@ namespace BlockParam.Licensing;
 
 /// <summary>
 /// Central configuration for all shop and licensing URLs.
-/// Replace placeholder URLs with real LemonSqueezy URLs before launch.
 /// </summary>
 public static class ShopUrls
 {
-    /// <summary>
-    /// LemonSqueezy checkout URL for purchasing a Pro license.
-    /// TODO: Replace with actual LemonSqueezy checkout link after product creation.
-    /// </summary>
+    /// <summary>LemonSqueezy checkout URL for purchasing a Pro license.</summary>
     public const string CheckoutUrl = "https://blockparam.lemonsqueezy.com/buy";
 
     /// <summary>

--- a/src/BlockParam/SimaticML/SimaticMLParser.cs
+++ b/src/BlockParam/SimaticML/SimaticMLParser.cs
@@ -128,15 +128,7 @@ public class SimaticMLParser
         return new DataBlockInfo(name, number, memoryLayout, blockType, members, unresolved.ToArray());
     }
 
-    /// <summary>
-    /// Walks <c>&lt;Member&gt;</c> children and builds a MemberNode tree.
-    /// <paramref name="indexStack"/> accumulates array indices from all enclosing
-    /// array expansions so primitive leaves inside array context can read
-    /// their StartValue from <c>&lt;Subelement Path="i,j,..."&gt;</c>.
-    /// <paramref name="enclosingUdt"/> and <paramref name="pathWithinUdt"/>
-    /// propagate the current UDT context so members without a SetPoint
-    /// attribute can be resolved via <see cref="UdtSetPointResolver"/>.
-    /// </summary>
+    /// <summary>Walks <c>&lt;Member&gt;</c> children and builds a MemberNode tree.</summary>
     private IReadOnlyList<MemberNode> ParseMembers(
         XElement parent,
         XNamespace ns,

--- a/src/BlockParam/UI/BulkChangeDialog.xaml.cs
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml.cs
@@ -30,6 +30,7 @@ public partial class BulkChangeDialog : Window
         viewModel.RequestClose += () => Close();
         viewModel.FlatListRefreshed += RehydrateManualSelection;
         viewModel.PropertyChanged += OnViewModelPropertyChanged;
+        Closed += (_, _) => viewModel.Dispose();
 
         // Briefly set Topmost to appear above TIA Portal, then release
         // so other windows (non-TIA) can go in front.

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -20,8 +20,11 @@ namespace BlockParam.UI;
 /// Main ViewModel for the BulkChange dialog.
 /// Uses a flat list (via FlatTreeManager) for proper column alignment in ListView/GridView.
 /// </summary>
-public class BulkChangeViewModel : ViewModelBase
+public class BulkChangeViewModel : ViewModelBase, IDisposable
 {
+    private EventHandler? _licenseStateChangedHandler;
+    private bool _disposed;
+
     private readonly HierarchyAnalyzer _analyzer;
     private readonly BulkChangeService _bulkChangeService;
     private readonly IUsageTracker _usageTracker;
@@ -184,8 +187,9 @@ public class BulkChangeViewModel : ViewModelBase
 
         if (_licenseService != null)
         {
-            _licenseService.LicenseStateChanged += (_, __) =>
+            _licenseStateChangedHandler = (_, __) =>
                 _dispatcher.BeginInvoke(new Action(() => UpdateUsageStatus()));
+            _licenseService.LicenseStateChanged += _licenseStateChangedHandler;
         }
 
         // Apply initial filter and build flat list
@@ -2590,6 +2594,25 @@ public class BulkChangeViewModel : ViewModelBase
         catch
         {
             // Fallback: silently ignore if browser cannot be opened
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _valueDebounceTimer?.Dispose();
+        _valueDebounceTimer = null;
+        _searchDebounceTimer?.Dispose();
+        _searchDebounceTimer = null;
+
+        // Unsubscribe so the lambda's `this` capture stops keeping the VM alive.
+        // We do NOT dispose _licenseService — the caller that constructed it owns it.
+        if (_licenseService != null && _licenseStateChangedHandler != null)
+        {
+            _licenseService.LicenseStateChanged -= _licenseStateChangedHandler;
+            _licenseStateChangedHandler = null;
         }
     }
 }


### PR DESCRIPTION
## Summary

- **#1** — `BulkChangeViewModel` now implements `IDisposable`. `BulkChangeDialog` calls `Dispose` on `Window.Closed`, which tears down `_valueDebounceTimer` and `_searchDebounceTimer` so their `this` capture stops rooting the VM, and unsubscribes from `ILicenseService.LicenseStateChanged`. The license service itself is constructed and disposed by `BulkChangeContextMenu` — the VM is a borrower, not the owner.
- **#6** — Comment cleanup pass:
  - Drop stale `(#19)` issue ref in `BulkChangeContextMenu` (keep the WHY about `ImportBlock` disposing the old `DataBlock`).
  - Drop the LemonSqueezy `TODO` + the class-level "before launch" note in `ShopUrls` — the URL is set, the TODO was rot.
  - Remove numbered step markers (`// 1.`, `// 2.`, `// 3.`) in `ValueConstraint.Validate`; method structure is already clear.
  - Trim the multi-paragraph `ParseMembers` docstring in `SimaticMLParser` to a one-line summary.
  - Delete the misleading "atomicity" comment in `LocalUsageTracker.WriteData` (the rename sequence is not actually atomic — see #5).
  - Delete the redundant "Auto-detect TIA project path and language settings" comment; surrounding code makes it obvious.

## Test plan

- [x] `dotnet build src/BlockParam -c Debug` — succeeds, 0 errors (warnings are pre-existing nullable-reference warnings, untouched here)
- [x] `dotnet test src/BlockParam.Tests` — 432/432 pass
- [ ] Manual sanity check: open + close the BulkChange dialog in TIA Portal, confirm no regression in pending-edit save prompt or commit flow

Closes #1
Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)