### PR TITLE
LocalUsageTracker: harden file rename with File.Replace

### DIFF
--- a/src/BlockParam/Licensing/LocalUsageTracker.cs
+++ b/src/BlockParam/Licensing/LocalUsageTracker.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using BlockParam.Diagnostics;
 using Newtonsoft.Json;
 
 namespace BlockParam.Licensing;
@@ -87,9 +88,11 @@ public class LocalUsageTracker : IUsageTracker
 
             return data;
         }
-        catch
+        catch (Exception ex)
         {
-            // Corrupt file: reset gracefully
+            // Corrupt file: reset gracefully. Log so repeated resets don't
+            // stay silent — they could signal tampering or a real read bug.
+            Log.Warning(ex, "LocalUsageTracker: resetting corrupt usage file {Path}", _storagePath);
             return new UsageData { Date = TodayString(), Count = 0 };
         }
     }
@@ -105,9 +108,29 @@ public class LocalUsageTracker : IUsageTracker
 
         var tempPath = _storagePath + ".tmp";
         File.WriteAllBytes(tempPath, bytes);
-        if (File.Exists(_storagePath))
-            File.Delete(_storagePath);
-        File.Move(tempPath, _storagePath);
+
+        try
+        {
+            // File.Replace is atomic on NTFS via the Win32 ReplaceFile API —
+            // no gap between deleting the destination and renaming the temp
+            // file where another writer (or another Add-In instance) could
+            // create the destination and make our Move throw. .NET 5+ has
+            // File.Move(overwrite: true); we target net48 and don't want
+            // P/Invoke MoveFileEx just for this counter.
+            if (File.Exists(_storagePath))
+                File.Replace(tempPath, _storagePath, destinationBackupFileName: null);
+            else
+                File.Move(tempPath, _storagePath);
+        }
+        catch (IOException ex)
+        {
+            // ReplaceFile fails across volumes and on non-NTFS filesystems.
+            // Fall back to overwrite-copy — non-atomic but FS-agnostic, and
+            // a torn write here just resets the counter on next read.
+            Log.Warning(ex, "LocalUsageTracker: File.Replace fell back to overwrite-copy for {Path}", _storagePath);
+            File.Copy(tempPath, _storagePath, overwrite: true);
+            try { File.Delete(tempPath); } catch (IOException) { /* best-effort cleanup */ }
+        }
     }
 
     private string TodayString() => _dateProvider().ToString("yyyy-MM-dd");


### PR DESCRIPTION
## Summary
- Replace the `Delete` + `Move` sequence in `LocalUsageTracker.WriteData` with `File.Replace`, which is atomic on NTFS via the Win32 `ReplaceFile` API. No P/Invoke needed.
- Falls back to `File.Copy(overwrite: true)` + `File.Delete(tempPath)` for cross-volume / non-NTFS edge cases.
- Log corrupt-file resets in `ReadData` at `Warning` so the silent reset isn't completely undiagnosable (no `Debug` level in the project's `Log` shim, so `Warning` is the closest fit).

The previous gap between `File.Delete(_storagePath)` and `File.Move(tempPath, _storagePath)` could let another writer create the destination and make the `Move` throw `IOException` — dropping a usage increment at the freemium enforcement point.

`File.Replace` requires the destination to exist, so the no-existing-file branch still uses plain `File.Move`.

Closes #5

## Test plan
- [x] `dotnet build src/BlockParam -c Debug` — succeeds, no new warnings
- [x] `dotnet test src/BlockParam.Tests` — 432/432 pass, including all 7 `LocalUsageTrackerTests`
- [ ] Manual smoke: install the new addin, exercise the freemium counter through one cycle (record usage, reach limit, hit next day) — counter persists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)