### PR TITLE
Localize MessageBox dialogs + pre-1.0 cleanup

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -114,8 +114,10 @@ C:\Program Files\Siemens\Automation\Portal V20\AddIns\\
 %APPDATA%\Siemens\Automation\Portal V21\UserAddIns\\
 \`\`\`
 
-Restart TIA Portal and confirm the Add-In load prompt. Right-click any Data
-Block in the project tree &rarr; **BlockParam&hellip;**
+TIA Portal can stay open &mdash; the AddIns folder is rescanned live. Open the
+**Add-ins** task card (right edge of the window), enable **BlockParam**, and
+confirm the permission prompt. Then right-click any Data Block in the project
+tree &rarr; **BlockParam&hellip;**
 EOF
 
 # --- create or update release --------------------------------------------------

--- a/src/BlockParam/AddIn/BulkChangeContextMenu.cs
+++ b/src/BlockParam/AddIn/BulkChangeContextMenu.cs
@@ -251,7 +251,7 @@ public class BulkChangeContextMenu : ContextMenuAddIn
             Log.Error(ex, "Error in Bulk Change OnClick");
             ShowMessageBox(
                 ex.ToString(),
-                "BlockParam Error",
+                Res.Get("Rollback_Title"),
                 System.Windows.MessageBoxButton.OK,
                 System.Windows.MessageBoxImage.Error);
         }
@@ -489,10 +489,8 @@ public class BulkChangeContextMenu : ContextMenuAddIn
         {
             Log.Warning("DB {Name} is inconsistent, asking user to compile", block.Name);
             var answer = ShowMessageBox(
-                $"The data block '{block.Name}' is inconsistent and cannot be exported.\n\n" +
-                "This usually happens after editing start values or UDT changes.\n\n" +
-                "Compile the block now?",
-                "BlockParam — Compilation Required",
+                Res.Format("Db_InconsistentPrompt", block.Name),
+                Res.Get("Udt_InconsistentPromptTitle"),
                 System.Windows.MessageBoxButton.YesNo,
                 System.Windows.MessageBoxImage.Question);
 

--- a/src/BlockParam/Config/BulkChangeConfig.cs
+++ b/src/BlockParam/Config/BulkChangeConfig.cs
@@ -38,14 +38,14 @@ public class BulkChangeConfig
         {
             // Datatype filter
             if (!string.IsNullOrEmpty(r.Datatype)
-                && !string.Equals(r.Datatype.Trim('"'), member.Datatype.Trim('"'),
+                && !string.Equals(r.Datatype!.Trim('"'), member.Datatype.Trim('"'),
                     StringComparison.OrdinalIgnoreCase))
                 continue;
 
             // PathPattern required
             if (string.IsNullOrEmpty(r.PathPattern))
                 continue;
-            if (!PathPatternMatcher.IsMatch(member, r.PathPattern))
+            if (!PathPatternMatcher.IsMatch(member, r.PathPattern!))
                 continue;
 
             // Calculate specificity — most specific wins, source bonus as tiebreaker
@@ -77,7 +77,7 @@ public class BulkChangeConfig
                 continue;
             if (string.IsNullOrEmpty(r.PathPattern))
                 continue;
-            if (!PathPatternMatcher.IsMatch(udtInstance, r.PathPattern, includeSelf: true))
+            if (!PathPatternMatcher.IsMatch(udtInstance, r.PathPattern!, includeSelf: true))
                 continue;
 
             var score = PathPatternMatcher.CalculateSpecificity(

--- a/src/BlockParam/Config/ConfigLoader.cs
+++ b/src/BlockParam/Config/ConfigLoader.cs
@@ -84,7 +84,7 @@ public class ConfigLoader
         LoadResult sharedResult = new();
         if (!string.IsNullOrEmpty(sharedRulesDir))
         {
-            var resolvedSharedDir = ResolveRulesDirectory(sharedRulesDir);
+            var resolvedSharedDir = ResolveRulesDirectory(sharedRulesDir!);
 
             sharedResult = dirLoader.LoadFromDirectory(resolvedSharedDir,
                 skipFileNames: localFileNames, ruleSource: RuleSource.Shared);

--- a/src/BlockParam/Config/RulesDirectoryLoader.cs
+++ b/src/BlockParam/Config/RulesDirectoryLoader.cs
@@ -74,7 +74,7 @@ public class RulesDirectoryLoader
                 {
                     if (!string.IsNullOrEmpty(rule.PathPattern))
                     {
-                        var error = PathPatternMatcher.ValidatePattern(rule.PathPattern);
+                        var error = PathPatternMatcher.ValidatePattern(rule.PathPattern!);
                         if (error != null)
                         {
                             result.Warnings.Add($"Skipped rule with invalid pattern in {Path.GetFileName(file)}: {error}");

--- a/src/BlockParam/Config/ValueConstraint.cs
+++ b/src/BlockParam/Config/ValueConstraint.cs
@@ -117,7 +117,7 @@ public class ValueConstraint
         if (limit is string s)
         {
             if (!string.IsNullOrEmpty(datatype)
-                && TiaDataTypeValidator.TryParseNumericValue(s, datatype, out result))
+                && TiaDataTypeValidator.TryParseNumericValue(s, datatype!, out result))
                 return true;
 
             // Fallback: plain numeric string

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -260,6 +260,17 @@ Beispiele: en-US, de-DE. Leer lassen für Standardsprache.</value></data>
 {1}
 
 Jetzt kompilieren? Andernfalls bleiben die Kommentare dieser UDT-Mitglieder in der Anzeige leer.</value></data>
+  <!-- Inkonsistente DB Kompilier-Abfrage (#50/#51) -->
+  <data name="Db_InconsistentPrompt" xml:space="preserve"><value>Der Datenbaustein '{0}' ist inkonsistent und kann nicht exportiert werden.
+
+Dies tritt meist nach dem Bearbeiten von Startwerten oder UDT-Änderungen auf.
+
+Datenbaustein jetzt kompilieren?</value></data>
+  <!-- Ungespeicherte-Änderungen-Abfrage beim Schließen des Dialogs -->
+  <data name="Dialog_UnsavedChanges_Title" xml:space="preserve"><value>Ungespeicherte Änderungen</value></data>
+  <data name="Dialog_UnsavedChanges_Prompt" xml:space="preserve"><value>Möchten Sie {0} ausstehende Änderung(en) vor dem Schließen speichern?</value></data>
+  <!-- Fallback bei unbekanntem Aktivierungs-Status -->
+  <data name="License_UnknownError" xml:space="preserve"><value>Unbekannter Fehler</value></data>
   <!-- Zoom-Anzeige (#28) -->
   <data name="Zoom_Tooltip" xml:space="preserve"><value>Zoom (Strg + Mausrad, Strg + / Strg −, Strg + 0 zum Zurücksetzen)</value></data>
 </root>

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -655,6 +655,27 @@ Examples: en-US, de-DE. Leave empty for the default language.</value>
 Compile them now? Member comments from these UDTs will otherwise appear blank.</value>
     <comment>{0} = count, {1} = comma-separated list of UDT names</comment>
   </data>
+  <!-- Inconsistent DB compile prompt (#50/#51) — same flow as Udt_*, applied to a single Data Block. -->
+  <data name="Db_InconsistentPrompt" xml:space="preserve">
+    <value>The data block '{0}' is inconsistent and cannot be exported.
+
+This usually happens after editing start values or UDT changes.
+
+Compile the block now?</value>
+    <comment>{0} = DB name</comment>
+  </data>
+  <!-- Unsaved-changes prompt fired by BulkChangeDialog.OnClosing when pending inline edits exist. -->
+  <data name="Dialog_UnsavedChanges_Title" xml:space="preserve">
+    <value>Unsaved Changes</value>
+  </data>
+  <data name="Dialog_UnsavedChanges_Prompt" xml:space="preserve">
+    <value>Do you want to save {0} pending change(s) before closing?</value>
+    <comment>{0} = number of pending inline edits</comment>
+  </data>
+  <!-- Fallback shown if license activation returns an unrecognised status (defensive — switch is exhaustive today). -->
+  <data name="License_UnknownError" xml:space="preserve">
+    <value>Unknown error</value>
+  </data>
   <!-- Zoom indicator (#28): tooltip teaches the keyboard shortcuts so the
        widget makes the existing Ctrl+scroll / Ctrl +/- feature discoverable. -->
   <data name="Zoom_Tooltip" xml:space="preserve">

--- a/src/BlockParam/Services/PathPatternMatcher.cs
+++ b/src/BlockParam/Services/PathPatternMatcher.cs
@@ -97,7 +97,7 @@ public static class PathPatternMatcher
 
         int score = 0;
 
-        var pattern = pathPattern;
+        var pattern = pathPattern!;
 
         // Strip {udt:} and {childUdt:} tokens and count them
         var udtTokens = UdtTokenRegex.Matches(pattern);

--- a/src/BlockParam/Services/TiaPortalAdapter.cs
+++ b/src/BlockParam/Services/TiaPortalAdapter.cs
@@ -18,51 +18,6 @@ public class TiaPortalAdapter : ITiaPortalAdapter
         _tiaPortal = tiaPortal;
     }
 
-    /// <summary>
-    /// Checks if the block needs compilation and asks the user to compile if needed.
-    /// Returns true if export can proceed, false if user cancelled.
-    /// </summary>
-    public bool TryEnsureCompiled(object dataBlock)
-    {
-        var block = (PlcBlock)dataBlock;
-
-        if (block is ICompilable compilable)
-        {
-            // Try export to a temp location to detect inconsistency
-            var testDir = Path.Combine(Path.GetTempPath(), "BlockParam", "_check");
-            Directory.CreateDirectory(testDir);
-            var testPath = Path.Combine(testDir, $"{block.Name}_check.xml");
-            if (File.Exists(testPath)) File.Delete(testPath);
-
-            try
-            {
-                block.Export(new FileInfo(testPath), ExportOptions.WithDefaults);
-                if (File.Exists(testPath)) File.Delete(testPath);
-                return true; // Export works fine
-            }
-            catch
-            {
-                // Export failed — block needs compilation
-                Log.Warning("DB {Name} cannot be exported, needs compilation", block.Name);
-
-                var result = System.Windows.MessageBox.Show(
-                    $"The data block '{block.Name}' needs to be compiled before it can be edited.\n\nCompile now?",
-                    "Bulk Change — Compilation Required",
-                    System.Windows.MessageBoxButton.YesNo,
-                    System.Windows.MessageBoxImage.Question);
-
-                if (result != System.Windows.MessageBoxResult.Yes)
-                    return false;
-
-                var compileResult = compilable.Compile();
-                Log.Information("Compile result for {Block}: {State}", block.Name, compileResult.State);
-                return true;
-            }
-        }
-
-        return true;
-    }
-
     public void CompileBlock(object dataBlock)
     {
         var block = (PlcBlock)dataBlock;

--- a/src/BlockParam/Services/XmlFileTagTableReader.cs
+++ b/src/BlockParam/Services/XmlFileTagTableReader.cs
@@ -52,14 +52,14 @@ public class XmlFileTagTableReader : ITagTableReader
                     var culture = textItem.Element("AttributeList")?.Element("Culture")?.Value;
                     var text = textItem.Element("AttributeList")?.Element("Text")?.Value;
                     if (culture != null && !string.IsNullOrEmpty(text))
-                        comments[culture] = text;
+                        comments[culture] = text!;
                 }
 
                 // Default comment: preferred culture, or first available
                 var defaultComment = comments.TryGetValue(_commentCulture, out var dc) ? dc
                     : comments.Values.FirstOrDefault();
 
-                entries.Add(new TagTableEntry(name, value, dataType, defaultComment, comments));
+                entries.Add(new TagTableEntry(name!, value, dataType, defaultComment, comments));
             }
 
             return entries;

--- a/src/BlockParam/UI/BulkChangeDialog.xaml.cs
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml.cs
@@ -891,8 +891,8 @@ public partial class BulkChangeDialog : Window
         if (vm.PendingInlineEditCount > 0)
         {
             var result = MessageBox.Show(
-                $"Do you want to save {vm.PendingInlineEditCount} pending change(s) before closing?",
-                "Unsaved Changes",
+                Res.Format("Dialog_UnsavedChanges_Prompt", vm.PendingInlineEditCount),
+                Res.Get("Dialog_UnsavedChanges_Title"),
                 MessageBoxButton.YesNoCancel,
                 MessageBoxImage.Warning);
 

--- a/src/BlockParam/UI/LicenseKeyDialog.xaml.cs
+++ b/src/BlockParam/UI/LicenseKeyDialog.xaml.cs
@@ -137,7 +137,7 @@ public partial class LicenseKeyDialog : Window
                 LicenseActivationStatus.InvalidKey => Res.Get("License_Invalid"),
                 LicenseActivationStatus.TooManySessions => result.ErrorMessage ?? Res.Get("License_TooManySessions"),
                 LicenseActivationStatus.ServerError => Res.Get("License_ServerError"),
-                _ => result.ErrorMessage ?? "Unknown error"
+                _ => result.ErrorMessage ?? Res.Get("License_UnknownError")
             };
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary

- Localize three MessageBox dialogs that bypassed `Res` (unsaved-changes prompt on dialog close, inconsistent-DB compile prompt, error dialog title). Adds 4 new resource keys (`Db_InconsistentPrompt`, `Dialog_UnsavedChanges_Title`, `Dialog_UnsavedChanges_Prompt`, `License_UnknownError`) to both `Strings.resx` and `Strings.de.resx` — 176/176, in sync. Reuses `Rollback_Title` and `Udt_InconsistentPromptTitle` where the wording was identical.
- Delete `TiaPortalAdapter.TryEnsureCompiled` — dead code, not on `ITiaPortalAdapter`, no callers.
- Annotate the 8 nullable-reference warnings in `Config/*` and `Services/*`. Build is now warning-clean under `-p:TreatWarningsAsErrors=true`.
- `release.sh` release-notes header no longer tells users to restart TIA Portal (the AddIns folder is rescanned live; README already says so).

Closes #52. Partially addresses #50 — the mechanical localization is in; the runtime language switcher remains as a separate piece of work.

Out of scope: #51 (TIA inconsistency detection only matches the English error string).

## Test plan
- [x] `dotnet test src/BlockParam.Tests/BlockParam.Tests.csproj -c Release` — 432/432 pass
- [x] `dotnet build src/BlockParam/BlockParam.csproj -c Release -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors
- [x] en/de resx key sets diff is empty (176 each)
- [ ] Smoke-test in TIA Portal V20: trigger the unsaved-changes dialog and the inconsistent-DB compile prompt, verify English on en-US and German on de-DE

🤖 Generated with [Claude Code](https://claude.com/claude-code)