### PR TITLE
Detect TIA inconsistency errors on non-English installs

### DIFF
--- a/src/BlockParam.Tests/InconsistencyDetectorTests.cs
+++ b/src/BlockParam.Tests/InconsistencyDetectorTests.cs
@@ -1,0 +1,74 @@
+using System;
+using BlockParam.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+public class InconsistencyDetectorTests
+{
+    [Theory]
+    // English — actual TIA Portal phrasing on en-US installs.
+    [InlineData("The block is inconsistent and cannot be exported.")]
+    [InlineData("Inconsistent block")]
+    [InlineData("INCONSISTENT BLOCK")] // case-insensitive match
+    // German — actual TIA Portal phrasing on de-DE installs (#51).
+    [InlineData("Der Baustein ist inkonsistent und kann nicht exportiert werden.")]
+    [InlineData("Inkonsistenter Baustein")]
+    [InlineData("INKONSISTENT")]
+    public void Matches_OnLocalizedInconsistencyMessage_ReturnsTrue(string message)
+    {
+        var ex = new InvalidOperationException(message);
+        InconsistencyDetector.Matches(ex).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_WhenInnerExceptionCarriesTheMarker_ReturnsTrue()
+    {
+        var inner = new InvalidOperationException("Der Baustein ist inkonsistent.");
+        var outer = new Exception("Export failed", inner);
+
+        InconsistencyDetector.Matches(outer).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_WalksFullInnerExceptionChain_NotJustOneLevel()
+    {
+        // TIA's EngineeringTargetInvocationException can wrap multiple times before
+        // the originating "Inconsistent" message is reached.
+        var deep = new InvalidOperationException("inkonsistent");
+        var middle = new Exception("Wrapper layer", deep);
+        var outer = new Exception("Export failed", middle);
+
+        InconsistencyDetector.Matches(outer).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_OnUnrelatedExportError_ReturnsFalse()
+    {
+        // Disk-full / permission / not-found should NOT trigger the compile prompt.
+        var ex = new System.IO.IOException("Access to the path is denied.");
+        InconsistencyDetector.Matches(ex).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Matches_OnMessageMentioningConsistency_DoesNotFalseMatch()
+    {
+        // "consistent" alone is not an inconsistency marker — guard against an over-broad match.
+        var ex = new InvalidOperationException("Project metadata is consistent.");
+        InconsistencyDetector.Matches(ex).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Matches_OnNullException_ReturnsFalse()
+    {
+        InconsistencyDetector.Matches(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Matches_OnExceptionWithEmptyMessage_ReturnsFalse()
+    {
+        var ex = new Exception(string.Empty);
+        InconsistencyDetector.Matches(ex).Should().BeFalse();
+    }
+}

--- a/src/BlockParam/AddIn/BulkChangeContextMenu.cs
+++ b/src/BlockParam/AddIn/BulkChangeContextMenu.cs
@@ -507,8 +507,7 @@ public class BulkChangeContextMenu : ContextMenuAddIn
     }
 
     private static bool IsInconsistencyError(Exception ex) =>
-        (ex.Message?.Contains("Inconsistent") == true)
-        || (ex.InnerException?.Message?.Contains("Inconsistent") == true);
+        InconsistencyDetector.Matches(ex);
 
     private static System.Windows.MessageBoxResult ShowMessageBox(
         string message, string title,

--- a/src/BlockParam/BlockParam.csproj
+++ b/src/BlockParam/BlockParam.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>BlockParam</RootNamespace>
     <AssemblyName>BlockParam</AssemblyName>
-    <Version>0.16.4</Version>
+    <Version>0.16.5</Version>
     <Authors>Sawascwoolf</Authors>
     <Description>TIA Portal Add-In for editing Data Block start values and parameters — single and in bulk</Description>
     <ApplicationIcon>Resources\BlockParam_logo.ico</ApplicationIcon>

--- a/src/BlockParam/Services/InconsistencyDetector.cs
+++ b/src/BlockParam/Services/InconsistencyDetector.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace BlockParam.Services;
+
+/// <summary>
+/// Recognises TIA Openness "block/UDT is inconsistent" exceptions across locales.
+/// Openness throws <c>EngineeringTargetInvocationException</c> for many unrelated
+/// failures too (read-only library, create not possible, ...) so type alone is not
+/// a reliable signal — we still need to inspect the message. The message itself is
+/// localized to the TIA UI language, so a pure English substring match misses
+/// non-English installs (#51).
+///
+/// Strategy: walk the full inner-exception chain and look for any locale-specific
+/// "inconsistent" marker. Markers are intentionally narrow (full words, not "consistent")
+/// to avoid false positives from messages that mention consistency in passing.
+/// </summary>
+internal static class InconsistencyDetector
+{
+    // Add a locale here only after confirming on a real TIA install of that language.
+    // The strings are matched case-insensitively, so a single form per language is enough
+    // to catch noun/adjective variants ("Inconsistent" / "inconsistent" / "is inconsistent").
+    private static readonly string[] Markers =
+    {
+        "inconsistent",   // English  (e.g. "The block is inconsistent")
+        "inkonsistent",   // German   (e.g. "Der Baustein ist inkonsistent")
+    };
+
+    public static bool Matches(Exception? ex)
+    {
+        for (var current = ex; current != null; current = current.InnerException)
+        {
+            if (ContainsMarker(current.Message)) return true;
+        }
+        return false;
+    }
+
+    private static bool ContainsMarker(string? message)
+    {
+        if (string.IsNullOrEmpty(message)) return false;
+        foreach (var marker in Markers)
+        {
+            if (message!.IndexOf(marker, StringComparison.OrdinalIgnoreCase) >= 0)
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/BlockParam/addin-publisher-v20.xml
+++ b/src/BlockParam/addin-publisher-v20.xml
@@ -6,7 +6,7 @@
   <Product>
     <Name>BlockParam</Name>
     <Id>BlockParam</Id>
-    <Version>0.16.4</Version>
+    <Version>0.16.5</Version>
   </Product>
   <FeatureAssembly>
     <AssemblyInfo>

--- a/src/BlockParam/addin-publisher-v21.xml
+++ b/src/BlockParam/addin-publisher-v21.xml
@@ -6,7 +6,7 @@
   <Product>
     <Name>BlockParam</Name>
     <Id>BlockParam</Id>
-    <Version>0.16.4</Version>
+    <Version>0.16.5</Version>
   </Product>
   <FeatureAssembly>
     <AssemblyInfo>


### PR DESCRIPTION
## Summary

- `BulkChangeContextMenu.IsInconsistencyError` only matched the English literal `"Inconsistent"`, so the compile-and-retry prompt never fired on German TIA installs — users saw a raw stack trace instead (#51).
- Extracted the detector into `Services/InconsistencyDetector.cs`, walks the full inner-exception chain, and matches en + de variants case-insensitively (`inconsistent` / `inkonsistent`).
- Both call sites (`TryExportWithCompilePrompt` for the DB export and `ExportIfStale` for the UDT cache refresh) now go through the new detector — same fix applies to both paths the issue calls out.

## Why substring match instead of typed exception

TIA throws `EngineeringTargetInvocationException` for consistency check failures, but the same type is also thrown for unrelated cases (read-only library, "create not possible", etc., per `Siemens.Engineering.xml`). Type alone is too broad. `ExceptionMessageData.Text` is also localized — there is no public locale-independent error key in V20. Substring match across known locales is the pragmatic choice; new languages can be added as users report them.

## Test plan

- [x] 12 new unit tests in `InconsistencyDetectorTests.cs` cover en + de phrasings, case-insensitivity, deep inner-exception chain, null/empty messages, and false-positive guard ("consistent" alone must not match).
- [x] Full suite green: 444 tests pass.
- [ ] Verify on a German TIA Portal V20 install that the compile prompt fires for an inconsistent DB and an inconsistent UDT (acceptance criteria from the issue — needs hardware).

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)