### PR TITLE
release: ship stable-named .addin copies + point docs at latest-download URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,13 @@ single action.
 
 Each release ships two `.addin` files &mdash; pick the one that matches your TIA Portal version:
 
-| TIA Portal | File | Direct link |
-|---|---|---|
-| **V20** | `BlockParam-v<version>-TIA-V20.addin` | [Latest release](https://github.com/Sawascwoolf/BlockParam/releases/latest) |
-| **V21** | `BlockParam-v<version>-TIA-V21.addin` | [Latest release](https://github.com/Sawascwoolf/BlockParam/releases/latest) |
+| TIA Portal | Direct download (always latest) |
+|---|---|
+| **V20** | [`BlockParam-TIA-V20.addin`](https://github.com/Sawascwoolf/BlockParam/releases/latest/download/BlockParam-TIA-V20.addin) |
+| **V21** | [`BlockParam-TIA-V21.addin`](https://github.com/Sawascwoolf/BlockParam/releases/latest/download/BlockParam-TIA-V21.addin) |
 
-All releases: [Releases page](https://github.com/Sawascwoolf/BlockParam/releases).
+These URLs always resolve to the most recent release. Older versions and
+release notes: [Releases page](https://github.com/Sawascwoolf/BlockParam/releases).
 
 ## Installation
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -11,10 +11,13 @@ This page walks you from a fresh download to your first bulk edit.
 
 Each release ships two `.addin` files — pick the one that matches your TIA Portal version.
 
-| TIA Portal | File | Where to get it |
-|---|---|---|
-| **V20** | `BlockParam-v<version>-TIA-V20.addin` | [Latest release](https://github.com/Sawascwoolf/BlockParam/releases/latest) |
-| **V21** | `BlockParam-v<version>-TIA-V21.addin` | [Latest release](https://github.com/Sawascwoolf/BlockParam/releases/latest) |
+| TIA Portal | Direct download (always latest) |
+|---|---|
+| **V20** | [`BlockParam-TIA-V20.addin`](https://github.com/Sawascwoolf/BlockParam/releases/latest/download/BlockParam-TIA-V20.addin) |
+| **V21** | [`BlockParam-TIA-V21.addin`](https://github.com/Sawascwoolf/BlockParam/releases/latest/download/BlockParam-TIA-V21.addin) |
+
+Both URLs always resolve to the most recent release. Older versions live on
+the [Releases page](https://github.com/Sawascwoolf/BlockParam/releases).
 
 A `.addin` for the wrong TIA version will not load (and TIA will not tell you why).
 If the Add-in never appears in the task card after enabling, double-check the version match.

--- a/release.sh
+++ b/release.sh
@@ -77,10 +77,18 @@ stage_asset() {
     echo "  run 'bash bump-version.sh $VERSION --tia=$tia' first" >&2
     exit 1
   fi
-  local dst="$STAGE/BlockParam-v$VERSION-TIA-V$tia.addin"
-  cp "$src" "$dst"
-  ASSETS+=("$dst")
-  echo "  V$tia: $(basename "$dst")"
+  # Versioned copy — stable archival name in the release's asset list.
+  local dst_versioned="$STAGE/BlockParam-v$VERSION-TIA-V$tia.addin"
+  cp "$src" "$dst_versioned"
+  ASSETS+=("$dst_versioned")
+  echo "  V$tia: $(basename "$dst_versioned")"
+  # Stable-named copy — lets external links use
+  # https://github.com/$REPO/releases/latest/download/BlockParam-TIA-V$tia.addin
+  # which GitHub redirects to the latest release's asset of that name.
+  local dst_stable="$STAGE/BlockParam-TIA-V$tia.addin"
+  cp "$src" "$dst_stable"
+  ASSETS+=("$dst_stable")
+  echo "  V$tia: $(basename "$dst_stable")"
 }
 
 TAG="v$VERSION"
@@ -97,10 +105,10 @@ NOTES_HEADER_FILE="$STAGE/notes-header.md"
 cat > "$NOTES_HEADER_FILE" <<EOF
 ## Download
 
-| TIA Portal version | File |
-|---|---|
-| **V20** | [\`BlockParam-v$VERSION-TIA-V20.addin\`](https://github.com/$REPO/releases/download/$TAG/BlockParam-v$VERSION-TIA-V20.addin) |
-| **V21** | [\`BlockParam-v$VERSION-TIA-V21.addin\`](https://github.com/$REPO/releases/download/$TAG/BlockParam-v$VERSION-TIA-V21.addin) |
+| TIA Portal version | This release | Always-latest |
+|---|---|---|
+| **V20** | [\`BlockParam-v$VERSION-TIA-V20.addin\`](https://github.com/$REPO/releases/download/$TAG/BlockParam-v$VERSION-TIA-V20.addin) | [\`BlockParam-TIA-V20.addin\`](https://github.com/$REPO/releases/latest/download/BlockParam-TIA-V20.addin) |
+| **V21** | [\`BlockParam-v$VERSION-TIA-V21.addin\`](https://github.com/$REPO/releases/download/$TAG/BlockParam-v$VERSION-TIA-V21.addin) | [\`BlockParam-TIA-V21.addin\`](https://github.com/$REPO/releases/latest/download/BlockParam-TIA-V21.addin) |
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- `release.sh` now stages an extra version-less copy of each `.addin` (`BlockParam-TIA-V20.addin`, `BlockParam-TIA-V21.addin`) so GitHub's `releases/latest/download/<asset-name>` URL pattern works.
- `README.md` and `docs/user/getting-started.md` download tables now point at those stable URLs instead of the `releases/latest` page link.
- Release-notes table grew an "Always-latest" column for the same URLs.

## Why
External links (website in another repo, README, getting-started) previously linked to the `releases/latest` page or version-pinned URLs that break every release. Switching to GitHub's stable `releases/latest/download/<asset-name>` redirect means a single URL keeps working across every future bump (incl. the upcoming 1.0.0).

v0.16.4 has already been re-published with both forms of the asset, so the stable URLs resolve today:
- https://github.com/Sawascwoolf/BlockParam/releases/latest/download/BlockParam-TIA-V20.addin
- https://github.com/Sawascwoolf/BlockParam/releases/latest/download/BlockParam-TIA-V21.addin

## Test plan
- [ ] `curl -ILf https://github.com/Sawascwoolf/BlockParam/releases/latest/download/BlockParam-TIA-V20.addin` returns 302 → asset
- [ ] Same for V21
- [ ] README + getting-started download tables render correctly on GitHub
- [ ] Next `bash release.sh` for 1.0.0 produces 4 assets per release (verify locally before tagging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)