### PR TITLE
Fix illegal-path crash and surface tag tables nested >1 level deep (v1.0.2)

### DIFF
--- a/src/BlockParam.Tests/SafeFileNameTests.cs
+++ b/src/BlockParam.Tests/SafeFileNameTests.cs
@@ -1,0 +1,71 @@
+using BlockParam.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+public class SafeFileNameTests
+{
+    [Theory]
+    // Each char from Path.GetInvalidFileNameChars() that customer TIA names plausibly use.
+    [InlineData("UDT:Setpoint", "UDT_Setpoint")]
+    [InlineData("Valve<1>", "Valve_1_")]
+    [InlineData("a|b", "a_b")]
+    [InlineData("what?", "what_")]
+    [InlineData("star*name", "star_name")]
+    [InlineData("with/slash", "with_slash")]
+    [InlineData("with\\back", "with_back")]
+    [InlineData("quote\"name", "quote_name")]
+    public void Sanitize_ReplacesInvalidCharsWithUnderscore(string input, string expected)
+    {
+        SafeFileName.Sanitize(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("PlainName", "PlainName")]
+    [InlineData("Name_With_Underscores", "Name_With_Underscores")]
+    [InlineData("Name.With.Dots", "Name.With.Dots")]
+    [InlineData("Name With Spaces", "Name With Spaces")]
+    public void Sanitize_LeavesValidNamesUnchanged(string input, string expected)
+    {
+        SafeFileName.Sanitize(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Sanitize_OnNullOrEmpty_ReturnsUnderscore(string? input)
+    {
+        SafeFileName.Sanitize(input).Should().Be("_");
+    }
+
+    [Fact]
+    public void Sanitize_OnAllInvalidChars_ReturnsUnderscoresOnly()
+    {
+        // Real customer scenario: a UDT named entirely from forbidden characters
+        // must still produce a usable filename rather than throwing.
+        SafeFileName.Sanitize("<>|?*").Should().Be("_____");
+    }
+
+    [Theory]
+    // Windows rejects trailing dots and spaces in filenames even though they are
+    // not in Path.GetInvalidFileNameChars(). Trim them so File.Create succeeds.
+    [InlineData("Name.", "Name")]
+    [InlineData("Name ", "Name")]
+    [InlineData("Name. . .", "Name")]
+    public void Sanitize_TrimsTrailingDotsAndSpaces(string input, string expected)
+    {
+        SafeFileName.Sanitize(input).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Sanitize_IsDeterministic_SoStalenessChecksKeepWorking()
+    {
+        // The on-disk UDT cache compares File.GetLastWriteTime(<sanitized>.xml) to
+        // type.ModifiedDate; if the same UDT name produced different filenames on
+        // different runs we would re-export every click.
+        var first = SafeFileName.Sanitize("Setpoint:Limits");
+        var second = SafeFileName.Sanitize("Setpoint:Limits");
+        first.Should().Be(second);
+    }
+}

--- a/src/BlockParam/AddIn/BulkChangeContextMenu.cs
+++ b/src/BlockParam/AddIn/BulkChangeContextMenu.cs
@@ -263,7 +263,7 @@ public class BulkChangeContextMenu : ContextMenuAddIn
                         throw new OperationCanceledException("User declined to compile the inconsistent block.");
                     }
 
-                    var modifiedPath = Path.Combine(tempDir, $"{dbInfo.Name}_modified.xml");
+                    var modifiedPath = Path.Combine(tempDir, $"{SafeFileName.Sanitize(dbInfo.Name)}_modified.xml");
                     File.WriteAllText(modifiedPath, modifiedXml);
                     var blockGroup = (PlcBlockGroup)adapter.GetBlockGroup(selection);
                     adapter.ImportBlock(blockGroup, modifiedPath);
@@ -318,29 +318,42 @@ public class BulkChangeContextMenu : ContextMenuAddIn
     {
         Directory.CreateDirectory(exportDir);
 
-        var tagGroup = plcSoftware.TagTableGroup;
-        int count = 0;
-
-        foreach (var table in tagGroup.TagTables)
+        // Wipe stale exports from previous runs so renamed/moved/deleted tables
+        // don't linger as ghost constants in the validator cache.
+        foreach (var stale in Directory.GetFiles(exportDir, "*.xml"))
         {
-            var filePath = Path.Combine(exportDir, $"{table.Name}.xml");
-            if (File.Exists(filePath)) File.Delete(filePath);
+            try { File.Delete(stale); }
+            catch (Exception ex) { Log.Warning(ex, "Could not delete stale tag table cache file {Path}", stale); }
+        }
+
+        int count = 0;
+        foreach (var table in EnumerateTagTablesRecursive(plcSoftware.TagTableGroup))
+        {
+            // TIA enforces tag-table name uniqueness across the PLC, so a flat
+            // <table.Name>.xml layout has no collisions and lets rule references
+            // by table name match the file regardless of nesting depth (#63).
+            var filePath = Path.Combine(exportDir, $"{SafeFileName.Sanitize(table.Name)}.xml");
             table.Export(new FileInfo(filePath), ExportOptions.WithDefaults);
             count++;
         }
-
-        foreach (var subGroup in tagGroup.Groups)
-        {
-            foreach (var table in subGroup.TagTables)
-            {
-                var filePath = Path.Combine(exportDir, $"{subGroup.Name}_{table.Name}.xml");
-                if (File.Exists(filePath)) File.Delete(filePath);
-                table.Export(new FileInfo(filePath), ExportOptions.WithDefaults);
-                count++;
-            }
-        }
-
         return count;
+    }
+
+    /// <summary>
+    /// Walks the tag-table group tree depth-first, yielding every table at any
+    /// nesting depth. The previous implementation only handled root + one
+    /// subgroup level, silently dropping anything deeper — real customer
+    /// projects nest 4+ levels and the missing constants surfaced as ~200
+    /// false "value out of range" inspector entries (#63).
+    /// </summary>
+    private static IEnumerable<PlcTagTable> EnumerateTagTablesRecursive(PlcTagTableGroup group)
+    {
+        foreach (var table in group.TagTables)
+            yield return table;
+
+        foreach (var sub in group.Groups)
+            foreach (var table in EnumerateTagTablesRecursive(sub))
+                yield return table;
     }
 
     private static IEnumerable<(PlcType type, string? groupPath)> EnumerateTypesRecursive(
@@ -358,7 +371,10 @@ public class BulkChangeContextMenu : ContextMenuAddIn
     }
 
     private static string FileNameFor(PlcType type, string? groupPath)
-        => groupPath == null ? type.Name : $"{groupPath.Replace('/', '_')}_{type.Name}";
+    {
+        var raw = groupPath == null ? type.Name : $"{groupPath.Replace('/', '_')}_{type.Name}";
+        return SafeFileName.Sanitize(raw);
+    }
 
     /// <summary>
     /// Re-exports any UDT whose TIA <c>ModifiedDate</c> (or <c>InterfaceModifiedDate</c>)

--- a/src/BlockParam/BlockParam.csproj
+++ b/src/BlockParam/BlockParam.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>BlockParam</RootNamespace>
     <AssemblyName>BlockParam</AssemblyName>
-    <Version>1.0.0</Version>
+    <Version>1.0.2</Version>
     <Authors>Sawascwoolf</Authors>
     <Description>TIA Portal Add-In for editing Data Block start values and parameters — single and in bulk</Description>
     <ApplicationIcon>Resources\BlockParam_logo.ico</ApplicationIcon>

--- a/src/BlockParam/Services/SafeFileName.cs
+++ b/src/BlockParam/Services/SafeFileName.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Linq;
+
+namespace BlockParam.Services;
+
+/// <summary>
+/// Maps an arbitrary TIA-derived name (UDT, group, tag table, DB) to a Windows-safe
+/// filename. TIA permits characters in symbol names that <see cref="Path.Combine"/>
+/// rejects (<c>&lt; &gt; : " | ? *</c> plus control chars). Without sanitization,
+/// real customer projects throw <c>ArgumentException("Illegal characters in path")</c>
+/// the first time we try to cache one of their UDTs to disk.
+///
+/// Replacement is per-character and deterministic so the same input always produces
+/// the same filename — the on-disk staleness check (<c>File.GetLastWriteTime</c> vs.
+/// <c>type.ModifiedDate</c>) keeps working across runs.
+/// </summary>
+internal static class SafeFileName
+{
+    private static readonly char[] InvalidChars = Path.GetInvalidFileNameChars();
+
+    public static string Sanitize(string? name)
+    {
+        if (string.IsNullOrEmpty(name)) return "_";
+
+        var chars = name!.Select(c => InvalidChars.Contains(c) ? '_' : c).ToArray();
+        var cleaned = new string(chars).TrimEnd('.', ' ');
+
+        return cleaned.Length == 0 ? "_" : cleaned;
+    }
+}

--- a/src/BlockParam/addin-publisher-v20.xml
+++ b/src/BlockParam/addin-publisher-v20.xml
@@ -6,7 +6,7 @@
   <Product>
     <Name>BlockParam</Name>
     <Id>BlockParam</Id>
-    <Version>1.0.0</Version>
+    <Version>1.0.2</Version>
   </Product>
   <FeatureAssembly>
     <AssemblyInfo>

--- a/src/BlockParam/addin-publisher-v21.xml
+++ b/src/BlockParam/addin-publisher-v21.xml
@@ -6,7 +6,7 @@
   <Product>
     <Name>BlockParam</Name>
     <Id>BlockParam</Id>
-    <Version>1.0.0</Version>
+    <Version>1.0.2</Version>
   </Product>
   <FeatureAssembly>
     <AssemblyInfo>


### PR DESCRIPTION
## Summary
Two bugs surfaced when running v1.0.0 against a real customer V20 project:

- **Right-click → Bulk Change crashed** with `System.ArgumentException: Illegal characters in path` the first time TIA exposed a UDT/tag-table/DB whose name contained a Windows-reserved character (`< > : " | ? *` or control chars). Demo project never hit this; real projects do.
- **Inspector showed ~200 false "value out of range" entries** because `ExportTagTables` only walked the root tag-table group plus one subgroup level, silently dropping any table nested deeper. The customer project nests its `CcModule` constants table 4 folders deep, so the validator never saw those names.

## Changes
- New `SafeFileName.Sanitize` helper applied at every site that turns a TIA-derived name into a filename: UDT cache files, tag-table cache files, modified-DB write path. Deterministic per-character replacement so the on-disk staleness check (`File.GetLastWriteTime` vs. `type.ModifiedDate`) still works across runs.
- `ExportTagTables` rewritten with a recursive `EnumerateTagTablesRecursive` walk, no depth limit. Filename simplified to plain `<table.Name>.xml` — TIA enforces tag-table name uniqueness across the PLC, so the previous `<subgroup>_<table>.xml` prefix was unnecessary and broke rule references that named the table directly.
- Stale `*.xml` in the cache dir are wiped at the start of each export, so renamed/moved/deleted tables don't linger as ghost constants.
- Bumped to v1.0.2.

## Verified
- 19 new `SafeFileNameTests` pass; full suite green (463 / 463).
- Packaged v1.0.2 manually copied into the V20 AddIns folder; user confirmed both bugs gone in their real project.

## Refs
Refs #63 — partially closes the validator issue (system constants, expression values, and UDT-local constants remain open).

## Test plan
- [x] Unit tests pass (463/463)
- [x] Right-click → Bulk Change on a DB whose UDT names contain reserved chars → no crash
- [x] Inspector shows 0 false "value out of range" entries on a DB referencing constants from a deeply-nested tag table

🤖 Generated with [Claude Code](https://claude.com/claude-code)