### PR TITLE
Freemium UX: single 200/day cap + Apply-tooltip cost line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Target: Siemens Xcelerator Marketplace / App Store distribution.
 - **Language**: C# / .NET Framework 4.8 (LangVersion=latest for modern syntax)
 - **UI Language**: English (with i18n architecture via resource files for future localization)
 - **License**: Open Source + commercial dual license (Freemium)
-- **Monetization**: 3 free bulk operations per calendar day, then paid
+- **Monetization**: 200 free value changes per calendar day, charged on successful Apply (one quota unit per individual change written, whether bulk-staged or inline). Pro tier removes the cap.
 - **Target Users**: PLC programmers & commissioning engineers for efficient parameter management
 
 ## Technology Stack

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ release notes: [Releases page](https://github.com/Sawascwoolf/BlockParam/release
 
 | Tier | Daily limit | Features | Price |
 |---|---|---|---|
-| **Free** | 3 bulk operations, 50 inline edits | All features included | &euro; 0 |
+| **Free** | 200 value changes per day | All features included | &euro; 0 |
 | **Pro** | Unlimited | All features + priority email support | 15 &euro; / year (net) |
 
 All features work in both tiers &mdash; the Pro tier lifts the daily quota and funds further
@@ -161,8 +161,8 @@ Reference:
 
 ## Licensing
 
-Source code is published under the [MIT License](LICENSE). The Pro tier (unlimited bulk operations
-and inline edits) requires a valid license key &mdash; see [Pricing](#pricing).
+Source code is published under the [MIT License](LICENSE). The Pro tier (unlimited daily changes)
+requires a valid license key &mdash; see [Pricing](#pricing).
 
 ## Trademarks
 

--- a/docs/user/licensing.md
+++ b/docs/user/licensing.md
@@ -5,41 +5,37 @@ the daily quota and funds further development.
 
 | Tier | Daily limit | Price |
 |---|---|---|
-| **Free** | 3 bulk operations + 50 inline edits per calendar day | € 0 |
+| **Free** | 200 value changes per calendar day | € 0 |
 | **Pro** | Unlimited | 15 € / year (net) |
 
 The daily counter resets at **local midnight**.
 
-## What counts as one bulk operation
+## What counts as one change
 
-A "bulk operation" is **one click of Apply** that writes more than one change.
-The full pending queue counts as one operation, regardless of how many target
-members it touched.
+One "change" is **one individual start-value write** to the DB. Whether the
+change came from a bulk-staged scope or from typing directly into a cell, it
+costs the same: one quota unit per value actually written. The counter is
+charged on **successful Apply** — staging edits in the dialog is free, and
+failed / cancelled Applies don't count.
 
 | Action | Counts as |
 |---|---|
-| Stage 1 change, click Apply | 1 inline edit |
-| Stage 50 changes, click Apply | 1 bulk operation |
-| Stage 5 changes, click Apply, then stage 5 more, Apply again | **2 bulk operations** |
+| Stage 1 value, click Apply | 1 change |
+| Bulk-stage 50 values, click Apply | 50 changes |
+| Stage 5, Apply, then stage 5 more, Apply again | 10 changes |
 | Discard a pending queue without applying | 0 (nothing was written) |
-| Edit a value, hit Apply, undo via TIA Ctrl+Z | 1 inline / bulk (the undo doesn't refund the quota) |
+| Update comments via the comment template | 0 (comments don't draw from the quota) |
+| Edit a value, hit Apply, undo via TIA Ctrl+Z | 1 (the undo doesn't refund the quota) |
 
-> Tip: if you're on the Free tier, **stage all your edits first**, then click
-> Apply once. Multiple Apply clicks burn multiple operations.
-
-## What counts as one inline edit
-
-Anything that gets written to the DB through the Bulk Change dialog and isn't
-already a bulk operation. Practically: changing a single value via the dialog.
-
-The 50 inline edits per day are independent of the 3 bulk operations.
+> Tip: if a single Apply would exceed your remaining quota, the button is
+> disabled — drop some edits or upgrade. The dialog won't half-apply.
 
 ## Activating Pro
 
 1. Buy a license at [blockparam.lemonsqueezy.com](https://blockparam.lemonsqueezy.com).
    You'll receive a key by email (format: `PRO-XXXX-XXXX-XXXX`).
 2. In the Bulk Change dialog, click the **License button** in the bottom bar
-   (it shows your current tier, e.g. *"Free License — 2 of 3 bulk operations used"*).
+   (it shows your current tier, e.g. *"Remaining: 173/200 free changes today"*).
 3. Paste the key into the field and click **Activate**.
 
 <p align="center">

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -69,17 +69,17 @@ A handful of root causes:
 - The pending queue is empty. The status bar shows *"0 pending edits"*.
 - All pending values are invalid (red rows). The Apply button is disabled until
   you fix them.
-- You hit the **Free-tier daily quota** (3 bulk operations or 50 inline edits).
-  The status bar shows *"Daily limit reached — upgrade to Pro for unlimited"*.
-  See [Licensing](licensing.md).
+- You hit the **Free-tier daily quota** (200 value changes per day) — or your
+  pending batch would push past it. Apply is disabled with a tooltip; the
+  status bar shows *"This Apply would write N changes, but only M are left
+  today."* See [Licensing](licensing.md).
 
 ## "Daily limit reached"
 
-You've used your 3 free bulk operations or 50 free inline edits for the calendar
-day. Options:
+You've used all 200 free value changes for the calendar day. Options:
 
 - Wait until **local midnight** for the counter to reset.
-- Upgrade to [Pro](licensing.md#activating-pro) for unlimited operations.
+- Upgrade to [Pro](licensing.md#activating-pro) for unlimited changes.
 
 The counter is local — there's no way to "borrow" tomorrow's quota by changing
 the system clock (the Add-In detects backwards clock changes and the counter

--- a/src/BlockParam.DevLauncher/Program.cs
+++ b/src/BlockParam.DevLauncher/Program.cs
@@ -180,8 +180,7 @@ class Program
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
             "BlockParam");
         var freeTracker = new LocalUsageTracker(
-            Path.Combine(Path.GetTempPath(), "BlockParam_dev_usage.dat"),
-            dailyLimit: 3);
+            Path.Combine(Path.GetTempPath(), "BlockParam_dev_usage.dat"));
 
         var serverUrl = configLoader.ReadLicenseServerUrl() ?? OnlineLicenseService.DefaultServerUrl;
         var licenseService = new OnlineLicenseService(

--- a/src/BlockParam.Tests/BulkChangeViewModelTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelTests.cs
@@ -1,3 +1,6 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Threading;
 using BlockParam.Config;
 using BlockParam.Licensing;
 using BlockParam.Services;
@@ -274,33 +277,86 @@ public class BulkChangeViewModelTests : IDisposable
     }
 
     /// <summary>
+    /// Pins UI culture to en-US for the body of <paramref name="action"/> so
+    /// assertions on localized resource phrases are deterministic regardless of
+    /// the dev/CI machine's OS language. Tests that don't read string values
+    /// from <c>Res</c> don't need this.
+    /// </summary>
+    private static void WithEnglishUICulture(Action action)
+    {
+        var prevUI = Thread.CurrentThread.CurrentUICulture;
+        var prev = Thread.CurrentThread.CurrentCulture;
+        Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
+        Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+        try { action(); }
+        finally
+        {
+            Thread.CurrentThread.CurrentUICulture = prevUI;
+            Thread.CurrentThread.CurrentCulture = prev;
+        }
+    }
+
+    /// <summary>
     /// #62 UX: Two or more pending changes warrant the cost line even with full
     /// headroom — bulk Apply on free tier should always preview the cost.
     /// </summary>
     [Fact]
     public void ApplyTooltip_MultipleEdits_AppendsCostLine()
     {
-        var vm = CreateViewModelWithUsage(new UsageStatus(0, 200));
-        vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
-        vm.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
+        WithEnglishUICulture(() =>
+        {
+            var vm = CreateViewModelWithUsage(new UsageStatus(0, 200));
+            vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+            vm.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
 
-        vm.PendingInlineEditCount.Should().Be(2);
-        vm.ApplyTooltip.Should().Contain("2").And.Contain("200");
+            vm.PendingInlineEditCount.Should().Be(2);
+            vm.ApplyTooltip.Should()
+                .Contain("free changes remaining today",
+                    "the cost line — not just any '2 of 200' substring — must be present")
+                .And.Contain("2 of 200");
+        });
     }
 
     /// <summary>
     /// #62 UX: Even a single edit gets the cost line once headroom drops below
-    /// the tight-threshold (50) — that's exactly when surfacing remaining quota
+    /// the tight-threshold — that's exactly when surfacing remaining quota
     /// is most useful.
     /// </summary>
     [Fact]
     public void ApplyTooltip_TightHeadroom_AppendsCostLine()
     {
-        var vm = CreateViewModelWithUsage(new UsageStatus(170, 200)); // 30 remaining
-        vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+        WithEnglishUICulture(() =>
+        {
+            var vm = CreateViewModelWithUsage(new UsageStatus(170, 200)); // 30 remaining
+            vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
 
-        vm.PendingInlineEditCount.Should().Be(1);
-        vm.ApplyTooltip.Should().Contain("1").And.Contain("30",
-            "tight remaining quota deserves the cost line even for a single change");
+            vm.PendingInlineEditCount.Should().Be(1);
+            vm.ApplyTooltip.Should()
+                .Contain("free changes remaining today",
+                    "tight remaining quota deserves the cost line even for a single change")
+                .And.Contain("1 of 30");
+        });
+    }
+
+    /// <summary>
+    /// #62 UX: <see cref="BulkChangeViewModel.ApplyTooltip"/> is bound directly in
+    /// XAML — staging an inline edit must raise PropertyChanged for it, otherwise
+    /// the binding never re-evaluates and the cost line goes stale. Without this
+    /// test, a future refactor that drops the notification line from
+    /// <c>RefreshPendingAndPreview</c> would silently break the feature.
+    /// </summary>
+    [Fact]
+    public void ApplyTooltip_RaisesPropertyChanged_WhenPendingEditStaged()
+    {
+        var vm = CreateViewModelWithUsage(new UsageStatus(0, 200));
+        var changedProps = new List<string?>();
+        ((INotifyPropertyChanged)vm).PropertyChanged += (_, e) => changedProps.Add(e.PropertyName);
+
+        // Stage two edits — both transitions (0 → 1 and 1 → 2) should re-fire ApplyTooltip.
+        vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+        vm.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
+
+        changedProps.Should().Contain(nameof(BulkChangeViewModel.ApplyTooltip),
+            "the binding can't re-evaluate without this notification");
     }
 }

--- a/src/BlockParam.Tests/BulkChangeViewModelTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelTests.cs
@@ -146,4 +146,62 @@ public class BulkChangeViewModelTests : IDisposable
         vm.ApplyCommand.CanExecute(null).Should().BeTrue(
             "a pre-existing violation on Speed must not block applying a valid pending edit on Enable");
     }
+
+    /// <summary>
+    /// #62: Free-tier cap is per-change, not per-Apply. When the user stages
+    /// more pending edits than they have quota left, Apply must be disabled
+    /// (no partial apply, no silent over-cap write).
+    /// </summary>
+    [Fact]
+    public void ApplyCommand_Disabled_WhenPendingExceedsRemainingQuota()
+    {
+        var xml = TestFixtures.LoadXml("flat-db.xml");
+        var parser = new SimaticMLParser();
+        var db = parser.Parse(xml);
+        var analyzer = new HierarchyAnalyzer();
+        var configLoader = new ConfigLoader(null);
+        var bulkService = new BulkChangeService(new ChangeLogger(), configLoader);
+
+        // Free-tier with only 1 change left today.
+        var usageTracker = Substitute.For<IUsageTracker>();
+        usageTracker.GetStatus().Returns(new UsageStatus(199, 200));
+        usageTracker.RecordUsage(Arg.Any<int>()).Returns(true);
+
+        var vm = new BulkChangeViewModel(db, xml, analyzer, bulkService, usageTracker, configLoader);
+
+        // Stage two pending edits — one would fit (remaining=1), two will not.
+        vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+        vm.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
+
+        vm.PendingInlineEditCount.Should().Be(2);
+        vm.ApplyCommand.CanExecute(null).Should().BeFalse(
+            "Apply must be blocked when pending count > remaining quota — no partial-apply state");
+    }
+
+    /// <summary>
+    /// #62 follow-up: when remaining quota covers the pending batch, Apply
+    /// stays enabled. Sanity check that the over-cap gate doesn't false-positive.
+    /// </summary>
+    [Fact]
+    public void ApplyCommand_Enabled_WhenPendingFitsUnderQuota()
+    {
+        var xml = TestFixtures.LoadXml("flat-db.xml");
+        var parser = new SimaticMLParser();
+        var db = parser.Parse(xml);
+        var analyzer = new HierarchyAnalyzer();
+        var configLoader = new ConfigLoader(null);
+        var bulkService = new BulkChangeService(new ChangeLogger(), configLoader);
+
+        var usageTracker = Substitute.For<IUsageTracker>();
+        usageTracker.GetStatus().Returns(new UsageStatus(190, 200));
+        usageTracker.RecordUsage(Arg.Any<int>()).Returns(true);
+
+        var vm = new BulkChangeViewModel(db, xml, analyzer, bulkService, usageTracker, configLoader);
+
+        vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+        vm.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
+
+        vm.ApplyCommand.CanExecute(null).Should().BeTrue(
+            "two pending edits fit under remaining=10");
+    }
 }

--- a/src/BlockParam.Tests/BulkChangeViewModelTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelTests.cs
@@ -30,8 +30,8 @@ public class BulkChangeViewModelTests : IDisposable
         var configLoader = new ConfigLoader(null);
         var bulkService = new BulkChangeService(new ChangeLogger(), configLoader);
         var usageTracker = Substitute.For<IUsageTracker>();
-        usageTracker.GetStatus().Returns(new UsageStatus(0, 3));
-        usageTracker.GetInlineStatus().Returns(new UsageStatus(0, 10));
+        usageTracker.GetStatus().Returns(new UsageStatus(0, 200));
+        usageTracker.RecordUsage(Arg.Any<int>()).Returns(true);
 
         return new BulkChangeViewModel(db, xml, analyzer, bulkService, usageTracker, configLoader);
     }
@@ -61,10 +61,8 @@ public class BulkChangeViewModelTests : IDisposable
         var configLoader = CreateConfigLoaderWithRule(ruleJson);
         var bulkService = new BulkChangeService(new ChangeLogger(), configLoader);
         var usageTracker = Substitute.For<IUsageTracker>();
-        usageTracker.GetStatus().Returns(new UsageStatus(0, 3));
-        usageTracker.GetInlineStatus().Returns(new UsageStatus(0, 10));
-        usageTracker.RecordInlineEdit().Returns(true);
-        usageTracker.RecordUsage().Returns(true);
+        usageTracker.GetStatus().Returns(new UsageStatus(0, 200));
+        usageTracker.RecordUsage(Arg.Any<int>()).Returns(true);
 
         return new BulkChangeViewModel(db, xml, analyzer, bulkService, usageTracker, configLoader);
     }

--- a/src/BlockParam.Tests/BulkChangeViewModelTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelTests.cs
@@ -204,4 +204,103 @@ public class BulkChangeViewModelTests : IDisposable
         vm.ApplyCommand.CanExecute(null).Should().BeTrue(
             "two pending edits fit under remaining=10");
     }
+
+    /// <summary>
+    /// Builds a VM with a configurable usage status and optional license service —
+    /// the ApplyTooltip tests vary remaining quota and Pro state, so the standard
+    /// helper isn't flexible enough.
+    /// </summary>
+    private static BulkChangeViewModel CreateViewModelWithUsage(
+        UsageStatus status, ILicenseService? licenseService = null)
+    {
+        var xml = TestFixtures.LoadXml("flat-db.xml");
+        var parser = new SimaticMLParser();
+        var db = parser.Parse(xml);
+        var analyzer = new HierarchyAnalyzer();
+        var configLoader = new ConfigLoader(null);
+        var bulkService = new BulkChangeService(new ChangeLogger(), configLoader);
+        var usageTracker = Substitute.For<IUsageTracker>();
+        usageTracker.GetStatus().Returns(status);
+        usageTracker.RecordUsage(Arg.Any<int>()).Returns(true);
+
+        return new BulkChangeViewModel(db, xml, analyzer, bulkService, usageTracker,
+            configLoader, licenseService: licenseService);
+    }
+
+    /// <summary>
+    /// #62 UX: Pro users never see the cost line in the Apply tooltip — quota
+    /// doesn't apply to them, surfacing it would just be noise.
+    /// </summary>
+    [Fact]
+    public void ApplyTooltip_Pro_OmitsCostLine()
+    {
+        var license = Substitute.For<ILicenseService>();
+        license.IsProActive.Returns(true);
+        var vm = CreateViewModelWithUsage(new UsageStatus(150, 200), license);
+
+        vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+        vm.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
+
+        vm.ApplyTooltip.Should().NotContain(
+            "remaining today",
+            "Pro tier has no daily cap — surfacing remaining quota would be misleading");
+    }
+
+    /// <summary>
+    /// #62 UX: With nothing pending, the Apply button is disabled and the tooltip
+    /// has no cost to surface — fall back to the plain advisory.
+    /// </summary>
+    [Fact]
+    public void ApplyTooltip_NoPending_OmitsCostLine()
+    {
+        var vm = CreateViewModelWithUsage(new UsageStatus(0, 200));
+        vm.PendingInlineEditCount.Should().Be(0);
+        vm.ApplyTooltip.Should().NotContain("remaining today");
+    }
+
+    /// <summary>
+    /// #62 UX: A single inline edit with plenty of headroom is the unsurprising
+    /// case — the cost line would just be noise. Stays as the plain advisory.
+    /// </summary>
+    [Fact]
+    public void ApplyTooltip_SingleEditWithHeadroom_OmitsCostLine()
+    {
+        var vm = CreateViewModelWithUsage(new UsageStatus(0, 200)); // 200 remaining
+        vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+
+        vm.PendingInlineEditCount.Should().Be(1);
+        vm.ApplyTooltip.Should().NotContain("remaining today",
+            "1 change with 200 left is the unsurprising case — keep the tooltip quiet");
+    }
+
+    /// <summary>
+    /// #62 UX: Two or more pending changes warrant the cost line even with full
+    /// headroom — bulk Apply on free tier should always preview the cost.
+    /// </summary>
+    [Fact]
+    public void ApplyTooltip_MultipleEdits_AppendsCostLine()
+    {
+        var vm = CreateViewModelWithUsage(new UsageStatus(0, 200));
+        vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+        vm.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
+
+        vm.PendingInlineEditCount.Should().Be(2);
+        vm.ApplyTooltip.Should().Contain("2").And.Contain("200");
+    }
+
+    /// <summary>
+    /// #62 UX: Even a single edit gets the cost line once headroom drops below
+    /// the tight-threshold (50) — that's exactly when surfacing remaining quota
+    /// is most useful.
+    /// </summary>
+    [Fact]
+    public void ApplyTooltip_TightHeadroom_AppendsCostLine()
+    {
+        var vm = CreateViewModelWithUsage(new UsageStatus(170, 200)); // 30 remaining
+        vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+
+        vm.PendingInlineEditCount.Should().Be(1);
+        vm.ApplyTooltip.Should().Contain("1").And.Contain("30",
+            "tight remaining quota deserves the cost line even for a single change");
+    }
 }

--- a/src/BlockParam.Tests/LocalUsageTrackerTests.cs
+++ b/src/BlockParam.Tests/LocalUsageTrackerTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using BlockParam.Licensing;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace BlockParam.Tests;
@@ -27,7 +28,7 @@ public class LocalUsageTrackerTests : IDisposable
     {
         var tracker = CreateTracker();
 
-        tracker.RecordUsage().Should().BeTrue();
+        tracker.RecordUsage(1).Should().BeTrue();
         var status = tracker.GetStatus();
 
         status.UsedToday.Should().Be(1);
@@ -40,9 +41,9 @@ public class LocalUsageTrackerTests : IDisposable
     {
         var tracker = CreateTracker();
 
-        tracker.RecordUsage();
-        tracker.RecordUsage();
-        tracker.RecordUsage().Should().BeTrue();
+        tracker.RecordUsage(1);
+        tracker.RecordUsage(1);
+        tracker.RecordUsage(1).Should().BeTrue();
 
         var status = tracker.GetStatus();
         status.UsedToday.Should().Be(3);
@@ -55,10 +56,10 @@ public class LocalUsageTrackerTests : IDisposable
     {
         var tracker = CreateTracker();
 
-        tracker.RecordUsage();
-        tracker.RecordUsage();
-        tracker.RecordUsage();
-        tracker.RecordUsage().Should().BeFalse();
+        tracker.RecordUsage(1);
+        tracker.RecordUsage(1);
+        tracker.RecordUsage(1);
+        tracker.RecordUsage(1).Should().BeFalse();
 
         tracker.GetStatus().UsedToday.Should().Be(3);
     }
@@ -69,9 +70,9 @@ public class LocalUsageTrackerTests : IDisposable
         var currentDate = new DateTime(2024, 1, 1);
         var tracker = CreateTracker(dateProvider: () => currentDate);
 
-        tracker.RecordUsage();
-        tracker.RecordUsage();
-        tracker.RecordUsage();
+        tracker.RecordUsage(1);
+        tracker.RecordUsage(1);
+        tracker.RecordUsage(1);
         tracker.GetStatus().IsLimitReached.Should().BeTrue();
 
         // Simulate next day with a new tracker instance
@@ -102,7 +103,7 @@ public class LocalUsageTrackerTests : IDisposable
         File.Exists(_storagePath).Should().BeFalse();
 
         var tracker = CreateTracker();
-        tracker.RecordUsage();
+        tracker.RecordUsage(1);
 
         File.Exists(_storagePath).Should().BeTrue();
     }
@@ -113,8 +114,8 @@ public class LocalUsageTrackerTests : IDisposable
         var date = new DateTime(2024, 6, 15);
 
         var tracker1 = CreateTracker(dateProvider: () => date);
-        tracker1.RecordUsage();
-        tracker1.RecordUsage();
+        tracker1.RecordUsage(1);
+        tracker1.RecordUsage(1);
 
         // New instance, same file, same day
         var tracker2 = CreateTracker(dateProvider: () => date);
@@ -122,6 +123,64 @@ public class LocalUsageTrackerTests : IDisposable
 
         status.UsedToday.Should().Be(2);
         status.RemainingToday.Should().Be(1);
+    }
+
+    [Fact]
+    public void RecordUsage_BatchFitsUnderCap_Charges()
+    {
+        var tracker = CreateTracker(dailyLimit: 200);
+
+        tracker.RecordUsage(50).Should().BeTrue();
+        tracker.RecordUsage(120).Should().BeTrue();
+
+        tracker.GetStatus().UsedToday.Should().Be(170);
+        tracker.GetStatus().RemainingToday.Should().Be(30);
+    }
+
+    [Fact]
+    public void RecordUsage_BatchOverflowsCap_Atomic_Reject()
+    {
+        var tracker = CreateTracker(dailyLimit: 200);
+        tracker.RecordUsage(180);
+
+        // 30 more would push to 210 — should reject the WHOLE batch, not write 20.
+        tracker.RecordUsage(30).Should().BeFalse();
+        tracker.GetStatus().UsedToday.Should().Be(180);
+        tracker.GetStatus().RemainingToday.Should().Be(20);
+
+        // The remaining 20 still fit and should succeed.
+        tracker.RecordUsage(20).Should().BeTrue();
+        tracker.GetStatus().IsLimitReached.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RecordUsage_ZeroOrNegative_NoOp()
+    {
+        var tracker = CreateTracker();
+
+        tracker.RecordUsage(0).Should().BeTrue();
+        tracker.RecordUsage(-5).Should().BeTrue();
+        tracker.GetStatus().UsedToday.Should().Be(0);
+    }
+
+    [Fact]
+    public void Read_LegacyFileWithInlineCount_IgnoresAndKeepsCount()
+    {
+        // Simulate a saved file from the old dual-counter version.
+        var date = new DateTime(2024, 6, 15);
+        var legacyJson = JsonConvert.SerializeObject(new
+        {
+            Date = date.ToString("yyyy-MM-dd"),
+            Count = 3,
+            InlineCount = 17
+        });
+        File.WriteAllBytes(_storagePath, Obfuscation.Obfuscate(legacyJson));
+
+        var tracker = CreateTracker(dailyLimit: 200, dateProvider: () => date);
+        var status = tracker.GetStatus();
+
+        // Legacy InlineCount is dropped; Count is preserved.
+        status.UsedToday.Should().Be(3);
     }
 
     private LocalUsageTracker CreateTracker(

--- a/src/BlockParam/AddIn/BulkChangeContextMenu.cs
+++ b/src/BlockParam/AddIn/BulkChangeContextMenu.cs
@@ -229,7 +229,7 @@ public class BulkChangeContextMenu : ContextMenuAddIn
                 Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
                 "BlockParam");
             var usagePath = Path.Combine(appDataDir, "usage.dat");
-            var freeTracker = new LocalUsageTracker(usagePath, dailyLimit: 3);
+            var freeTracker = new LocalUsageTracker(usagePath);
 
             // License service: heartbeat-based concurrent session validation.
             // #20: probe the machine-wide managed key file first so multi-seat

--- a/src/BlockParam/Licensing/IUsageTracker.cs
+++ b/src/BlockParam/Licensing/IUsageTracker.cs
@@ -1,28 +1,28 @@
 namespace BlockParam.Licensing;
 
 /// <summary>
-/// Tracks daily usage of bulk and inline operations (Freemium model).
-/// Abstracted as interface for future swap to online licensing.
+/// Tracks daily usage of value changes (Freemium model).
+/// Free tier: 200 individual value changes per calendar day, charged on
+/// successful Apply. Bulk-staged and inline-edited changes count the same
+/// — every committed value-write is one unit. Abstracted as interface for
+/// future swap to online licensing.
 /// </summary>
 public interface IUsageTracker
 {
-    /// <summary>Returns the current bulk operation usage status.</summary>
+    /// <summary>Returns the current usage status (count vs daily limit).</summary>
     UsageStatus GetStatus();
 
-    /// <summary>Records one bulk operation. Returns false if limit is reached.</summary>
-    bool RecordUsage();
+    /// <summary>
+    /// Records <paramref name="count"/> value-changes against today's quota.
+    /// Atomic: returns true and increments only if the full <paramref name="count"/>
+    /// fits under <see cref="DailyLimit"/>; otherwise returns false and leaves
+    /// the counter untouched (callers must block the entire Apply, not write a
+    /// partial batch).
+    /// </summary>
+    bool RecordUsage(int count);
 
-    /// <summary>Maximum bulk operations per day.</summary>
+    /// <summary>Maximum value-changes per day for the free tier.</summary>
     int DailyLimit { get; }
-
-    /// <summary>Returns the current inline edit usage status.</summary>
-    UsageStatus GetInlineStatus();
-
-    /// <summary>Records one inline edit. Returns false if limit is reached.</summary>
-    bool RecordInlineEdit();
-
-    /// <summary>Maximum inline edits per day.</summary>
-    int InlineEditDailyLimit { get; }
 }
 
 public class UsageStatus

--- a/src/BlockParam/Licensing/LicensedUsageTracker.cs
+++ b/src/BlockParam/Licensing/LicensedUsageTracker.cs
@@ -16,7 +16,6 @@ public class LicensedUsageTracker : IUsageTracker
     }
 
     public int DailyLimit => _licenseService.IsProActive ? int.MaxValue : _freeTracker.DailyLimit;
-    public int InlineEditDailyLimit => _licenseService.IsProActive ? int.MaxValue : _freeTracker.InlineEditDailyLimit;
 
     public UsageStatus GetStatus()
     {
@@ -26,27 +25,11 @@ public class LicensedUsageTracker : IUsageTracker
         return _freeTracker.GetStatus();
     }
 
-    public UsageStatus GetInlineStatus()
-    {
-        if (_licenseService.IsProActive)
-            return new UsageStatus(0, int.MaxValue);
-
-        return _freeTracker.GetInlineStatus();
-    }
-
-    public bool RecordUsage()
+    public bool RecordUsage(int count)
     {
         if (_licenseService.IsProActive)
             return true;
 
-        return _freeTracker.RecordUsage();
-    }
-
-    public bool RecordInlineEdit()
-    {
-        if (_licenseService.IsProActive)
-            return true;
-
-        return _freeTracker.RecordInlineEdit();
+        return _freeTracker.RecordUsage(count);
     }
 }

--- a/src/BlockParam/Licensing/LocalUsageTracker.cs
+++ b/src/BlockParam/Licensing/LocalUsageTracker.cs
@@ -10,21 +10,20 @@ namespace BlockParam.Licensing;
 /// </summary>
 public class LocalUsageTracker : IUsageTracker
 {
+    public const int DefaultDailyLimit = 200;
+
     private readonly string _storagePath;
     private readonly Func<DateTime> _dateProvider;
 
     public int DailyLimit { get; }
-    public int InlineEditDailyLimit { get; }
 
     public LocalUsageTracker(
         string storagePath,
-        int dailyLimit = 3,
-        int inlineEditDailyLimit = 50,
+        int dailyLimit = DefaultDailyLimit,
         Func<DateTime>? dateProvider = null)
     {
         _storagePath = storagePath;
         DailyLimit = dailyLimit;
-        InlineEditDailyLimit = inlineEditDailyLimit;
         _dateProvider = dateProvider ?? (() => DateTime.Now);
     }
 
@@ -34,30 +33,15 @@ public class LocalUsageTracker : IUsageTracker
         return new UsageStatus(data.Count, DailyLimit);
     }
 
-    public UsageStatus GetInlineStatus()
+    public bool RecordUsage(int count)
     {
-        var data = ReadData();
-        return new UsageStatus(data.InlineCount, InlineEditDailyLimit);
-    }
+        if (count <= 0) return true;
 
-    public bool RecordUsage()
-    {
         var data = ReadData();
-        if (data.Count >= DailyLimit)
+        if (data.Count + count > DailyLimit)
             return false;
 
-        data.Count++;
-        WriteData(data);
-        return true;
-    }
-
-    public bool RecordInlineEdit()
-    {
-        var data = ReadData();
-        if (data.InlineCount >= InlineEditDailyLimit)
-            return false;
-
-        data.InlineCount++;
+        data.Count += count;
         WriteData(data);
         return true;
     }
@@ -79,11 +63,10 @@ public class LocalUsageTracker : IUsageTracker
                 return new UsageData { Date = TodayString(), Count = 0 };
             }
 
-            // Basic tamper detection: counts should be within limits
-            if (data.Count < 0 || data.Count > DailyLimit + 10
-                || data.InlineCount < 0 || data.InlineCount > InlineEditDailyLimit + 10)
+            // Basic tamper detection: count must be within a sane range.
+            if (data.Count < 0 || data.Count > DailyLimit + 100)
             {
-                return new UsageData { Date = TodayString(), Count = 0, InlineCount = 0 };
+                return new UsageData { Date = TodayString(), Count = 0 };
             }
 
             return data;
@@ -137,10 +120,11 @@ public class LocalUsageTracker : IUsageTracker
 
     // Public so Newtonsoft.Json can reach the constructor under TIA's
     // partial-trust CAS sandbox — see UiZoomService.UiSettingsDto for context.
+    // Legacy "InlineCount" fields in saved JSON are silently ignored on read
+    // (Newtonsoft drops unknown properties) and dropped on next write.
     public class UsageData
     {
         public string Date { get; set; } = "";
         public int Count { get; set; }
-        public int InlineCount { get; set; }
     }
 }

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -154,6 +154,7 @@ Dies kann nicht rückgängig gemacht werden.</value></data>
   <data name="Dialog_SetManualCount" xml:space="preserve"><value>{0} ausgewählte setzen</value></data>
   <data name="Validation_MixedDatatypes" xml:space="preserve"><value>Auswahl enthält verschiedene Datentypen — auf einen Datentyp einschränken, um einen gemeinsamen Wert zu setzen.</value></data>
   <data name="Dialog_ApplyTooltip" xml:space="preserve"><value>Es werden nur Startwerte geändert. Aktualwerte müssen separat über 'Startwerte in Aktualwerte kopieren' in TIA Portal aktualisiert werden.</value></data>
+  <data name="Dialog_ApplyTooltip_CostLine" xml:space="preserve"><value>Dieses Übernehmen verbraucht {0} von {1} verbleibenden kostenlosen Änderungen heute.</value></data>
   <data name="Dialog_EditConfig" xml:space="preserve"><value>Konfiguration...</value></data>
   <data name="Column_Comment" xml:space="preserve"><value>Kommentar</value></data>
   <!-- ConfigEditorDialog -->

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -97,6 +97,7 @@ Nein = Aktuelles (möglicherweise unvollständiges) Ergebnis behalten</value></d
   <data name="Status_LimitReached" xml:space="preserve"><value>Tageslimit erreicht. Upgrade für unbegrenzte Nutzung.</value></data>
   <data name="Status_Remaining" xml:space="preserve"><value>Verbleibend: {0}/{1} kostenlose Änderungen heute</value></data>
   <data name="Status_WouldExceedLimit" xml:space="preserve"><value>Dieses Übernehmen würde {0} Änderungen schreiben, aber nur {1} sind heute übrig. Auswahl reduzieren oder auf Pro upgraden für unbegrenzte Nutzung.</value></data>
+  <data name="Status_AppliedOverCap" xml:space="preserve"><value>{0} Werte in '{1}' geschrieben — Tageslimit überschritten (parallele Nutzung). Upgrade für unbegrenzte Nutzung.</value></data>
   <data name="LimitReached_Modal_Title" xml:space="preserve"><value>Kostenloses Tageslimit erreicht</value></data>
   <data name="LimitReached_Modal_Message" xml:space="preserve"><value>Sie haben alle heutigen kostenlosen Änderungen aufgebraucht. Sie können weiter Änderungen vorbereiten, aber Übernehmen ist bis morgen deaktiviert — oder upgraden Sie auf Pro für unbegrenzte Nutzung.</value></data>
   <data name="Status_Ready" xml:space="preserve"><value>Bereit</value></data>

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -95,9 +95,10 @@ Nein = Aktuelles (möglicherweise unvollständiges) Ergebnis behalten</value></d
   <data name="Status_ErrorPartialKept" xml:space="preserve"><value>Fehler aufgetreten, teilweise Änderungen beibehalten: {0}</value></data>
   <data name="Status_ErrorNoBackup" xml:space="preserve"><value>Fehler: {0} (kein Backup für Rückgängig verfügbar)</value></data>
   <data name="Status_LimitReached" xml:space="preserve"><value>Tageslimit erreicht. Upgrade für unbegrenzte Nutzung.</value></data>
-  <data name="Status_Remaining" xml:space="preserve"><value>Verbleibend: {0}/{1} kostenlose Operationen</value></data>
-  <data name="Status_RemainingBoth" xml:space="preserve"><value>Massenbearbeitung: {0}/{1}  |  Inline-Änderungen: {2}/{3}</value></data>
-  <data name="Status_InlineLimitReached" xml:space="preserve"><value>Tägliches Inline-Limit erreicht. Upgrade für unbegrenzte Nutzung.</value></data>
+  <data name="Status_Remaining" xml:space="preserve"><value>Verbleibend: {0}/{1} kostenlose Änderungen heute</value></data>
+  <data name="Status_WouldExceedLimit" xml:space="preserve"><value>Dieses Übernehmen würde {0} Änderungen schreiben, aber nur {1} sind heute übrig. Auswahl reduzieren oder auf Pro upgraden für unbegrenzte Nutzung.</value></data>
+  <data name="LimitReached_Modal_Title" xml:space="preserve"><value>Kostenloses Tageslimit erreicht</value></data>
+  <data name="LimitReached_Modal_Message" xml:space="preserve"><value>Sie haben alle heutigen kostenlosen Änderungen aufgebraucht. Sie können weiter Änderungen vorbereiten, aber Übernehmen ist bis morgen deaktiviert — oder upgraden Sie auf Pro für unbegrenzte Nutzung.</value></data>
   <data name="Status_Ready" xml:space="preserve"><value>Bereit</value></data>
   <!-- Lizenzierung -->
   <data name="Status_Pro" xml:space="preserve"><value>Pro-Lizenz — Unbegrenzte Operationen</value></data>

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -173,6 +173,10 @@ No = Keep the current (possibly partial) result</value>
     <value>This Apply would write {0} changes, but only {1} are left today. Reduce the selection or upgrade for unlimited use.</value>
     <comment>{0} = pending changes count, {1} = remaining quota today</comment>
   </data>
+  <data name="Status_AppliedOverCap" xml:space="preserve">
+    <value>{0} values written in '{1}' — daily limit exceeded (parallel use). Upgrade for unlimited use.</value>
+    <comment>{0} = applied count, {1} = DB name. Shown only on the rare cross-instance race.</comment>
+  </data>
   <data name="LimitReached_Modal_Title" xml:space="preserve">
     <value>Free daily limit reached</value>
   </data>

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -166,15 +166,18 @@ No = Keep the current (possibly partial) result</value>
     <value>Daily limit reached. Upgrade for unlimited use.</value>
   </data>
   <data name="Status_Remaining" xml:space="preserve">
-    <value>Remaining: {0}/{1} free operations</value>
+    <value>Remaining: {0}/{1} free changes today</value>
     <comment>{0} = remaining, {1} = daily limit</comment>
   </data>
-  <data name="Status_RemainingBoth" xml:space="preserve">
-    <value>Bulk operations: {0}/{1}  |  Inline edits: {2}/{3}</value>
-    <comment>{0}/{1} = bulk remaining/limit, {2}/{3} = inline remaining/limit</comment>
+  <data name="Status_WouldExceedLimit" xml:space="preserve">
+    <value>This Apply would write {0} changes, but only {1} are left today. Reduce the selection or upgrade for unlimited use.</value>
+    <comment>{0} = pending changes count, {1} = remaining quota today</comment>
   </data>
-  <data name="Status_InlineLimitReached" xml:space="preserve">
-    <value>Daily inline edit limit reached. Upgrade for unlimited use.</value>
+  <data name="LimitReached_Modal_Title" xml:space="preserve">
+    <value>Free daily limit reached</value>
+  </data>
+  <data name="LimitReached_Modal_Message" xml:space="preserve">
+    <value>You've used all of today's free changes. You can keep staging edits, but Apply is disabled until tomorrow — or upgrade to Pro for unlimited use.</value>
   </data>
   <data name="Status_Ready" xml:space="preserve">
     <value>Ready</value>

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -388,6 +388,10 @@ This cannot be undone.</value>
   <data name="Dialog_ApplyTooltip" xml:space="preserve">
     <value>Only start values are modified. To update actual values, use 'Copy start values to actual values' in TIA Portal.</value>
   </data>
+  <data name="Dialog_ApplyTooltip_CostLine" xml:space="preserve">
+    <value>This Apply will use {0} of {1} free changes remaining today.</value>
+    <comment>{0} = pending change count, {1} = remaining quota. Appended to Dialog_ApplyTooltip when not Pro and (count &gt; 1 OR remaining tight).</comment>
+  </data>
   <data name="Dialog_EditConfig" xml:space="preserve">
     <value>Edit Config...</value>
   </data>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -104,11 +104,11 @@
                 <Button x:Name="ApplyButton"
                         Content="{loc:Loc Dialog_Apply}" Command="{Binding ApplyCommand}"
                         MinWidth="70" Height="26" Margin="0,0,4,0" Padding="8,0"
-                        ToolTip="{loc:Loc Dialog_ApplyTooltip}"/>
+                        ToolTip="{Binding ApplyTooltip}"/>
                 <Button Content="{loc:Loc Dialog_ApplyAndClose}"
                         Command="{Binding ApplyAndCloseCommand}"
                         MinWidth="100" Height="26" Margin="0,0,4,0" Padding="8,0"
-                        ToolTip="{loc:Loc Dialog_ApplyTooltip}"/>
+                        ToolTip="{Binding ApplyTooltip}"/>
                 <Button Content="{loc:Loc Dialog_Close}" Click="OnClose"
                         MinWidth="60" Height="26" Padding="8,0"/>
             </StackPanel>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -104,11 +104,13 @@
                 <Button x:Name="ApplyButton"
                         Content="{loc:Loc Dialog_Apply}" Command="{Binding ApplyCommand}"
                         MinWidth="70" Height="26" Margin="0,0,4,0" Padding="8,0"
-                        ToolTip="{Binding ApplyTooltip}"/>
+                        ToolTip="{Binding ApplyTooltip}"
+                        ToolTipService.ShowOnDisabled="True"/>
                 <Button Content="{loc:Loc Dialog_ApplyAndClose}"
                         Command="{Binding ApplyAndCloseCommand}"
                         MinWidth="100" Height="26" Margin="0,0,4,0" Padding="8,0"
-                        ToolTip="{Binding ApplyTooltip}"/>
+                        ToolTip="{Binding ApplyTooltip}"
+                        ToolTipService.ShowOnDisabled="True"/>
                 <Button Content="{loc:Loc Dialog_Close}" Click="OnClose"
                         MinWidth="60" Height="26" Padding="8,0"/>
             </StackPanel>

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -2008,11 +2008,22 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             }
 
             // Charge the daily quota — one unit per value actually written.
-            // We pre-checked above, but re-check here in case parallel writes
-            // from another instance consumed quota in the meantime.
+            // We pre-checked above, but the post-write call can still reject
+            // if a parallel writer (other Add-In instance, same machine)
+            // consumed quota between pre-check and write. The TIA mutation is
+            // already committed at this point, so we can't roll back — but we
+            // CAN consume whatever quota remains so the next Apply is blocked
+            // by CanExecuteApply, and warn the user that they're over-cap.
             if (totalChanged > 0 && !_usageTracker.RecordUsage(totalChanged))
             {
-                Log.Warning("ExecuteApply: quota race — wrote {N} but RecordUsage rejected", totalChanged);
+                var remaining = _usageTracker.GetStatus().RemainingToday;
+                if (remaining > 0)
+                    _usageTracker.RecordUsage(remaining);
+                StatusText = Res.Format("Status_AppliedOverCap",
+                    totalChanged, _dataBlockInfo.Name);
+                Log.Warning(
+                    "ExecuteApply: quota race — wrote {N} past cap; counter pinned to limit",
+                    totalChanged);
             }
 
             // Re-export from TIA to get the canonical XML after import

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -74,6 +74,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private bool _suppressSuggestions;
     private bool _lastApplySucceeded;
     private bool _hasPendingChanges;
+    private bool _limitWarningShown;
     private bool _isInspectorCollapsed;
     private bool _isBulkEditExpanded = true;
     private bool _isBulkPreviewExpanded = true;
@@ -646,8 +647,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         _licenseService?.IsProActive == true
             ? Res.Get("License_ManageKey")
             : Res.Get("License_EnterKey");
-    public bool IsLimitReached => _usageTracker.GetStatus().IsLimitReached
-                               || _usageTracker.GetInlineStatus().IsLimitReached;
+    public bool IsLimitReached => _usageTracker.GetStatus().IsLimitReached;
 
     /// <summary>Number of individual inline edits waiting to be applied.</summary>
     public int PendingInlineEditCount => CountPendingInlineEdits(RootMembers);
@@ -1732,9 +1732,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// <summary>Can stage bulk scope or manual-selection values as pending.</summary>
     private bool CanExecuteSetPending()
     {
-        if (string.IsNullOrWhiteSpace(_newValue)
-            || HasValidationError
-            || _usageTracker.GetStatus().IsLimitReached)
+        if (string.IsNullOrWhiteSpace(_newValue) || HasValidationError)
             return false;
 
         if (IsManualMode)
@@ -1788,12 +1786,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         if (_selectedScope == null) return;
 
-        if (!_usageTracker.RecordUsage())
-        {
-            StatusText = Res.Get("Status_LimitReached");
-            UpdateUsageStatus();
-            return;
-        }
+        MaybeWarnLimitReachedOnce();
 
         var affectedPaths = new HashSet<string>(
             _selectedScope.MatchingMembers.Select(m => m.Path));
@@ -1823,12 +1816,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// </summary>
     private void ExecuteSetPendingManual()
     {
-        if (!_usageTracker.RecordUsage())
-        {
-            StatusText = Res.Get("Status_LimitReached");
-            UpdateUsageStatus();
-            return;
-        }
+        MaybeWarnLimitReachedOnce();
 
         int count = 0;
         foreach (var path in _manualSelectedPaths)
@@ -1894,8 +1882,15 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// <summary>Can apply when there are any pending changes (inline or bulk-staged).</summary>
     private bool CanExecuteApply()
     {
-        return (PendingInlineEditCount > 0 || HasPendingChanges)
-            && !HasInlineErrors;
+        if (HasInlineErrors) return false;
+        if (PendingInlineEditCount == 0 && !HasPendingChanges) return false;
+
+        // Free-tier cap: block Apply when the pending batch would push past
+        // the daily quota. The user has to drop some edits or upgrade.
+        var status = _usageTracker.GetStatus();
+        if (PendingInlineEditCount > status.RemainingToday) return false;
+
+        return true;
     }
 
     public bool HasInlineErrors => HasInlineErrorsRecursive(RootMembers);
@@ -1939,6 +1934,20 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         if (pendingEdits.Count == 0 && !_hasPendingChanges)
             return;
+
+        // Pre-check the daily cap: each pending edit is charged as one unit
+        // against the free-tier quota on Apply. Block the entire batch if it
+        // would push past the limit — partial Apply leaves the user in a
+        // confusing half-applied state. Pro tier always passes (DailyLimit
+        // is int.MaxValue via LicensedUsageTracker).
+        var status = _usageTracker.GetStatus();
+        if (pendingEdits.Count > status.RemainingToday)
+        {
+            StatusText = Res.Format("Status_WouldExceedLimit",
+                pendingEdits.Count, status.RemainingToday);
+            UpdateUsageStatus();
+            return;
+        }
 
         Log.Information("ExecuteApply: {Count} pending changes", pendingEdits.Count);
 
@@ -1998,6 +2007,14 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                 return;
             }
 
+            // Charge the daily quota — one unit per value actually written.
+            // We pre-checked above, but re-check here in case parallel writes
+            // from another instance consumed quota in the meantime.
+            if (totalChanged > 0 && !_usageTracker.RecordUsage(totalChanged))
+            {
+                Log.Warning("ExecuteApply: quota race — wrote {N} but RecordUsage rejected", totalChanged);
+            }
+
             // Re-export from TIA to get the canonical XML after import
             RefreshTree(_currentXml);
 
@@ -2030,13 +2047,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         var config = _configLoader.GetConfig();
         if (config == null || _selectedScope == null) return;
         if (!config.Rules.Any(r => !string.IsNullOrEmpty(r.CommentTemplate))) return;
-
-        if (!_usageTracker.RecordUsage())
-        {
-            StatusText = Res.Get("Status_LimitReached");
-            UpdateUsageStatus();
-            return;
-        }
 
         try
         {
@@ -2073,7 +2083,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
     private bool CanExecuteUpdateComments()
     {
-        return HasScope && HasCommentConfig && !_usageTracker.GetStatus().IsLimitReached;
+        return HasScope && HasCommentConfig;
     }
 
     /// <summary>
@@ -2170,23 +2180,12 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             return;
         }
 
-        // Only count against inline limit if this is a new edit, not a correction of an existing pending value
+        // Single counter (issue #62): inline edits are free to stage. Quota is
+        // charged per-change on successful Apply, not per keystroke. Warn once
+        // per dialog open if the user starts editing while already at 0 left,
+        // so they aren't blindsided when Apply is disabled.
         if (!memberVm.IsPendingInlineEdit)
-        {
-            if (_usageTracker.GetInlineStatus().IsLimitReached)
-            {
-                StatusText = Res.Get("Status_InlineLimitReached");
-                UpdateUsageStatus();
-                return;
-            }
-
-            if (!_usageTracker.RecordInlineEdit())
-            {
-                StatusText = Res.Get("Status_InlineLimitReached");
-                UpdateUsageStatus();
-                return;
-            }
-        }
+            MaybeWarnLimitReachedOnce();
 
         // Shared validator → same rule language as the bulk inspector (#7).
         var error = BuildValidator().Validate(memberVm.Model, newValue);
@@ -2405,10 +2404,8 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         else
         {
             var status = _usageTracker.GetStatus();
-            var inlineStatus = _usageTracker.GetInlineStatus();
-            UsageStatusText = Res.Format("Status_RemainingBoth",
-                status.RemainingToday, status.DailyLimit,
-                inlineStatus.RemainingToday, inlineStatus.DailyLimit);
+            UsageStatusText = Res.Format("Status_Remaining",
+                status.RemainingToday, status.DailyLimit);
             LicenseTierText = Res.Get("License_Tier_Free");
         }
 
@@ -2417,6 +2414,23 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         OnPropertyChanged(nameof(ShowLicenseKeyButton));
         OnPropertyChanged(nameof(LicenseKeyButtonText));
         OnPropertyChanged(nameof(IsLimitReached));
+    }
+
+    /// <summary>
+    /// Shows the daily-cap-reached modal once per dialog open, when the user
+    /// first attempts to stage or edit a change while at 0 remaining quota.
+    /// Staging itself isn't blocked — Apply is the choke point — but a single
+    /// proactive heads-up beats discovering it via a disabled Apply button.
+    /// </summary>
+    private void MaybeWarnLimitReachedOnce()
+    {
+        if (_limitWarningShown) return;
+        if (!_usageTracker.GetStatus().IsLimitReached) return;
+
+        _limitWarningShown = true;
+        _messageBox.ShowInfo(
+            Res.Get("LimitReached_Modal_Message"),
+            Res.Get("LimitReached_Modal_Title"));
     }
 
     private void ExecuteEnterLicenseKey()

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -650,12 +650,17 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     public bool IsLimitReached => _usageTracker.GetStatus().IsLimitReached;
 
     /// <summary>
+    /// Picked so a few back-to-back bulk applies on a normal day stay quiet, but
+    /// the user gets a nudge once they're close enough that the next batch could
+    /// push them over. Tied to the 200/day free-tier cap; revisit if that changes.
+    /// </summary>
+    private const int TightHeadroomThreshold = 50;
+
+    /// <summary>
     /// Tooltip for the Apply button(s). Pro tier and the unsurprising free-tier
     /// case (single change, plenty of headroom) get the plain advisory; otherwise
     /// the cost line is appended so users see "this Apply uses N of M" before
-    /// they click. Tight-headroom threshold is 50 — picked so a few back-to-back
-    /// bulk applies on a normal day stay quiet, but the user gets a nudge once
-    /// they're close enough that the next batch could push them over.
+    /// they click.
     /// </summary>
     public string ApplyTooltip
     {
@@ -668,9 +673,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             if (cost == 0) return baseText;
 
             var remaining = _usageTracker.GetStatus().RemainingToday;
-            if (cost <= 1 && remaining >= 50) return baseText;
+            if (cost <= 1 && remaining >= TightHeadroomThreshold) return baseText;
 
-            return baseText + "\n\n" +
+            return baseText + Environment.NewLine + Environment.NewLine +
                 Res.Format("Dialog_ApplyTooltip_CostLine", cost, remaining);
         }
     }

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -649,6 +649,32 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             : Res.Get("License_EnterKey");
     public bool IsLimitReached => _usageTracker.GetStatus().IsLimitReached;
 
+    /// <summary>
+    /// Tooltip for the Apply button(s). Pro tier and the unsurprising free-tier
+    /// case (single change, plenty of headroom) get the plain advisory; otherwise
+    /// the cost line is appended so users see "this Apply uses N of M" before
+    /// they click. Tight-headroom threshold is 50 — picked so a few back-to-back
+    /// bulk applies on a normal day stay quiet, but the user gets a nudge once
+    /// they're close enough that the next batch could push them over.
+    /// </summary>
+    public string ApplyTooltip
+    {
+        get
+        {
+            var baseText = Res.Get("Dialog_ApplyTooltip");
+            if (_licenseService?.IsProActive == true) return baseText;
+
+            var cost = PendingInlineEditCount;
+            if (cost == 0) return baseText;
+
+            var remaining = _usageTracker.GetStatus().RemainingToday;
+            if (cost <= 1 && remaining >= 50) return baseText;
+
+            return baseText + "\n\n" +
+                Res.Format("Dialog_ApplyTooltip_CostLine", cost, remaining);
+        }
+    }
+
     /// <summary>Number of individual inline edits waiting to be applied.</summary>
     public int PendingInlineEditCount => CountPendingInlineEdits(RootMembers);
 
@@ -1127,6 +1153,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     {
         OnPropertyChanged(nameof(PendingInlineEditCount));
         OnPropertyChanged(nameof(PendingStatusText));
+        OnPropertyChanged(nameof(ApplyTooltip));
         ComputeBulkPreview();
         RebuildPendingEdits();
     }
@@ -2425,6 +2452,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         OnPropertyChanged(nameof(ShowLicenseKeyButton));
         OnPropertyChanged(nameof(LicenseKeyButtonText));
         OnPropertyChanged(nameof(IsLimitReached));
+        OnPropertyChanged(nameof(ApplyTooltip));
     }
 
     /// <summary>

--- a/src/BlockParam/UI/IMessageBoxService.cs
+++ b/src/BlockParam/UI/IMessageBoxService.cs
@@ -8,6 +8,7 @@ public interface IMessageBoxService
 {
     bool AskYesNo(string message, string title);
     void ShowError(string message, string title);
+    void ShowInfo(string message, string title);
 }
 
 /// <summary>
@@ -30,5 +31,13 @@ public class WpfMessageBoxService : IMessageBoxService
             message, title,
             System.Windows.MessageBoxButton.OK,
             System.Windows.MessageBoxImage.Error);
+    }
+
+    public void ShowInfo(string message, string title)
+    {
+        System.Windows.MessageBox.Show(
+            message, title,
+            System.Windows.MessageBoxButton.OK,
+            System.Windows.MessageBoxImage.Information);
     }
 }


### PR DESCRIPTION
## Summary
- Consolidate the freemium counters into a single 200-changes-per-day cap, charged on successful Apply (one unit per individual change written).
- Drop the legacy `dailyLimit:3` overrides and refresh user-facing copy to match the new model.
- Surface an over-cap race-condition path (parallel writers can push past the cap; we now pin the counter and warn instead of silently overshooting). Tightened Apply-gate tests cover both the gate and the race.
- New: append a cost line ("This Apply will use N of M free changes remaining today.") to the Apply button tooltip when the user is on the free tier and the click is non-trivial — multiple pending edits, or remaining quota under 50. Pro and the unsurprising single-edit-with-headroom case stay quiet so the tooltip doesn't become wallpaper. Localized en + de.

Closes #62

## Test plan
- [x] `dotnet build BlockParam.sln -c Debug` — 0 warnings, 0 errors
- [x] `dotnet test` — 474/474 passing (5 new ApplyTooltip tests cover Pro / no-pending / single-edit-headroom / multi-edit / tight-headroom)
- [ ] Manual: stage 2+ edits in DevLauncher, hover Apply → cost line appears
- [ ] Manual: stage 1 edit with full quota → tooltip stays as the plain advisory
- [ ] Manual: simulate tight quota (UsedToday near limit) → cost line appears even on a single edit