### PR TITLE
Inspector: bidirectional sticky section headers + click-to-scroll

### DIFF
--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -15,6 +15,7 @@
         <local:NullToVisibilityConverter x:Key="NullToVis"/>
         <local:StringNotEmptyToVisibilityConverter x:Key="StringToVis"/>
         <local:InvertBoolConverter x:Key="InvertBool"/>
+        <local:BoolToGridLengthConverter x:Key="BoolToGridLength"/>
 
         <!-- Suggestion row style: hover-preview paints the entry as if the
              mouse were over it. Set by capture scripts so a still frame
@@ -559,14 +560,31 @@
                         </Grid>
                     </StackPanel>
 
-                    <!-- Expanded content: three stacked sections -->
-                    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled"
-                                  Visibility="{Binding IsInspectorExpanded, Converter={StaticResource BoolToVis}}">
-                        <StackPanel>
+                    <!-- Expanded content: per-section header/body row pairs (#64).
+                         Section headers always sit in Auto rows so they stay pinned
+                         regardless of how long any one body grows. List bodies share
+                         remaining vertical space (* rows) and scroll inside their
+                         own bounded ScrollViewer instead of pushing other section
+                         headers off the top. -->
+                    <Grid Visibility="{Binding IsInspectorExpanded, Converter={StaticResource BoolToVis}}">
+                        <Grid.RowDefinitions>
+                            <!-- Section 1: BULK EDIT — Auto-sized form (header + body
+                                 collapse together inside the section's own Grid) -->
+                            <RowDefinition Height="Auto"/>
+                            <!-- Section 2: BULK PREVIEW — header (Auto) + body (* / 0) -->
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="{Binding IsBulkPreviewExpanded, Converter={StaticResource BoolToGridLength}}" MinHeight="0"/>
+                            <!-- Section 3: PENDING EDITS — header (Auto) + body (* / 0) -->
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="{Binding IsPendingExpanded, Converter={StaticResource BoolToGridLength}}" MinHeight="0"/>
+                            <!-- Section 4: ISSUES — header (Auto) + body (* / 0) -->
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="{Binding IsIssuesExpanded, Converter={StaticResource BoolToGridLength}}" MinHeight="0"/>
+                        </Grid.RowDefinitions>
                             <!-- =========================================================
                                  Section 1 — BULK EDIT (input)
                                  ========================================================= -->
-                            <Grid>
+                            <Grid Grid.Row="0">
                                 <StackPanel>
                                     <Border Background="#EEF0F3" BorderBrush="#B9BEC6"
                                             BorderThickness="0,0,0,1">
@@ -783,7 +801,7 @@
                             <!-- =========================================================
                                  Section 2 — BULK PREVIEW (live)
                                  ========================================================= -->
-                            <Border Background="#EEF0F3" BorderBrush="#B9BEC6"
+                            <Border Grid.Row="1" Background="#EEF0F3" BorderBrush="#B9BEC6"
                                     BorderThickness="0,1,0,1">
                                 <DockPanel>
                                     <Button DockPanel.Dock="Left"
@@ -822,6 +840,12 @@
                                                VerticalAlignment="Center" Margin="0,0,10,0"/>
                                 </DockPanel>
                             </Border>
+                            <!-- Body (#64): own ScrollViewer bounded to row 2 so a long
+                                 preview list scrolls inside this section instead of
+                                 pushing the Pending Edits and Issues headers off the top. -->
+                            <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto"
+                                          HorizontalScrollBarVisibility="Disabled">
+                                <Grid>
                             <!-- Empty state -->
                             <Border Background="White" Padding="12,10" MinHeight="52">
                                 <Border.Style>
@@ -859,8 +883,6 @@
                                         </Style.Triggers>
                                     </Style>
                                 </ItemsControl.Style>
-                                <!-- No inner ScrollViewer: the sidebar's outer ScrollViewer
-                                     handles wheel events for the whole inspector. -->
                                 <ItemsControl.Template>
                                     <ControlTemplate TargetType="ItemsControl">
                                         <Border Background="White">
@@ -913,11 +935,13 @@
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>
+                                </Grid>
+                            </ScrollViewer>
 
                             <!-- =========================================================
                                  Section 3 — PENDING EDITS
                                  ========================================================= -->
-                            <Border Background="#EEF0F3" BorderBrush="#B9BEC6"
+                            <Border Grid.Row="3" Background="#EEF0F3" BorderBrush="#B9BEC6"
                                     BorderThickness="0,1,0,1">
                                 <DockPanel>
                                     <Button DockPanel.Dock="Left"
@@ -968,6 +992,10 @@
                                             Visibility="{Binding HasPendingEdits, Converter={StaticResource BoolToVis}}"/>
                                 </DockPanel>
                             </Border>
+                            <!-- Body (#64): own ScrollViewer bounded to row 4. -->
+                            <ScrollViewer Grid.Row="4" VerticalScrollBarVisibility="Auto"
+                                          HorizontalScrollBarVisibility="Disabled">
+                                <Grid>
                             <!-- Empty state -->
                             <Border Background="White" Padding="12,10" MinHeight="52">
                                 <Border.Style>
@@ -1006,8 +1034,6 @@
                                         </Style.Triggers>
                                     </Style>
                                 </ItemsControl.Style>
-                                <!-- No inner ScrollViewer: the sidebar's outer ScrollViewer
-                                     handles wheel events for the whole inspector. -->
                                 <ItemsControl.Template>
                                     <ControlTemplate TargetType="ItemsControl">
                                         <Border Background="White">
@@ -1112,6 +1138,8 @@
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>
+                                </Grid>
+                            </ScrollViewer>
 
                             <!-- =========================================================
                                  Section 4 — ISSUES (#26)
@@ -1119,7 +1147,7 @@
                                  a configured rule. Click a row to jump to the member in the
                                  tree. Does NOT block Apply.
                                  ========================================================= -->
-                            <Border Background="#EEF0F3" BorderBrush="#B9BEC6"
+                            <Border Grid.Row="5" Background="#EEF0F3" BorderBrush="#B9BEC6"
                                     BorderThickness="0,1,0,1">
                                 <DockPanel ToolTip="{loc:Loc Issues_Tooltip}">
                                     <Button DockPanel.Dock="Left"
@@ -1157,6 +1185,10 @@
                                     <Border/>
                                 </DockPanel>
                             </Border>
+                            <!-- Body (#64): own ScrollViewer bounded to row 6. -->
+                            <ScrollViewer Grid.Row="6" VerticalScrollBarVisibility="Auto"
+                                          HorizontalScrollBarVisibility="Disabled">
+                                <Grid>
                             <!-- Empty state -->
                             <Border Background="White" Padding="12,10" MinHeight="52">
                                 <Border.Style>
@@ -1239,8 +1271,9 @@
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>
-                        </StackPanel>
-                    </ScrollViewer>
+                                </Grid>
+                            </ScrollViewer>
+                    </Grid>
                 </DockPanel>
             </Border>
         </Grid>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -15,7 +15,6 @@
         <local:NullToVisibilityConverter x:Key="NullToVis"/>
         <local:StringNotEmptyToVisibilityConverter x:Key="StringToVis"/>
         <local:InvertBoolConverter x:Key="InvertBool"/>
-        <local:BoolToGridLengthConverter x:Key="BoolToGridLength"/>
 
         <!-- Suggestion row style: hover-preview paints the entry as if the
              mouse were over it. Set by capture scripts so a still frame
@@ -560,34 +559,43 @@
                         </Grid>
                     </StackPanel>
 
-                    <!-- Expanded content: per-section header/body row pairs (#64).
-                         Section headers always sit in Auto rows so they stay pinned
-                         regardless of how long any one body grows. List bodies share
-                         remaining vertical space (* rows) and scroll inside their
-                         own bounded ScrollViewer instead of pushing other section
-                         headers off the top. -->
-                    <Grid Visibility="{Binding IsInspectorExpanded, Converter={StaticResource BoolToVis}}">
-                        <Grid.RowDefinitions>
-                            <!-- Section 1: BULK EDIT — Auto-sized form (header + body
-                                 collapse together inside the section's own Grid) -->
-                            <RowDefinition Height="Auto"/>
-                            <!-- Section 2: BULK PREVIEW — header (Auto) + body (* / 0) -->
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="{Binding IsBulkPreviewExpanded, Converter={StaticResource BoolToGridLength}}" MinHeight="0"/>
-                            <!-- Section 3: PENDING EDITS — header (Auto) + body (* / 0) -->
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="{Binding IsPendingExpanded, Converter={StaticResource BoolToGridLength}}" MinHeight="0"/>
-                            <!-- Section 4: ISSUES — header (Auto) + body (* / 0) -->
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="{Binding IsIssuesExpanded, Converter={StaticResource BoolToGridLength}}" MinHeight="0"/>
-                        </Grid.RowDefinitions>
+                    <!-- Expanded content: four stacked sections (#64).
+                         Single outer ScrollViewer scrolls the inspector as one unit.
+                         Each section's header Border is named (StickyHeader{1..4}) and
+                         carries a TranslateTransform so the code-behind can pin it to
+                         the viewport top (when scrolled past) or the viewport bottom
+                         (when not yet reached). All four headers stay visible at every
+                         scroll position. See OnInspectorScrollChanged in the .xaml.cs. -->
+                    <ScrollViewer x:Name="InspectorScroll"
+                                  VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled"
+                                  Visibility="{Binding IsInspectorExpanded, Converter={StaticResource BoolToVis}}">
+                        <StackPanel x:Name="InspectorContent">
                             <!-- =========================================================
                                  Section 1 — BULK EDIT (input)
                                  ========================================================= -->
-                            <Grid Grid.Row="0">
+                            <!-- Wrapper ZIndex=10 (#64): the inner sticky header's own
+                                 ZIndex only orders against its siblings inside this Grid,
+                                 not against later sections' bodies in the OUTER StackPanel.
+                                 Without this, Section 1's header — when translated down to
+                                 stack at the viewport top — is drawn behind Section 2's
+                                 body content. Match the other section headers' ZIndex=10. -->
+                            <Grid Panel.ZIndex="10">
                                 <StackPanel>
-                                    <Border Background="#EEF0F3" BorderBrush="#B9BEC6"
-                                            BorderThickness="0,0,0,1">
+                                    <!-- Inner Panel.ZIndex=10 (#64): the wrapper Grid's
+                                         ZIndex orders Section 1 above other sections' bodies,
+                                         but inside this StackPanel the header is the FIRST
+                                         child and its body the SECOND, so by document order
+                                         the body wins. When the sticky transform pushes the
+                                         header down INTO Section 1's body, this inner ZIndex
+                                         keeps the header drawn on top of its body sibling. -->
+                                    <Border x:Name="StickyHeader1" Panel.ZIndex="10"
+                                            Background="#EEF0F3" BorderBrush="#B9BEC6"
+                                            BorderThickness="0,0,0,1"
+                                            Cursor="Hand"
+                                            MouseLeftButtonUp="OnInspectorHeaderClick">
+                                        <Border.RenderTransform>
+                                            <TranslateTransform x:Name="StickyTransform1"/>
+                                        </Border.RenderTransform>
                                         <DockPanel Margin="0,0,0,0">
                                             <Button DockPanel.Dock="Left"
                                                     Command="{Binding ToggleBulkEditCommand}"
@@ -801,8 +809,14 @@
                             <!-- =========================================================
                                  Section 2 — BULK PREVIEW (live)
                                  ========================================================= -->
-                            <Border Grid.Row="1" Background="#EEF0F3" BorderBrush="#B9BEC6"
-                                    BorderThickness="0,1,0,1">
+                            <Border x:Name="StickyHeader2" Panel.ZIndex="10"
+                                    Background="#EEF0F3" BorderBrush="#B9BEC6"
+                                    BorderThickness="0,1,0,1"
+                                    Cursor="Hand"
+                                    MouseLeftButtonUp="OnInspectorHeaderClick">
+                                <Border.RenderTransform>
+                                    <TranslateTransform x:Name="StickyTransform2"/>
+                                </Border.RenderTransform>
                                 <DockPanel>
                                     <Button DockPanel.Dock="Left"
                                             Command="{Binding ToggleBulkPreviewCommand}"
@@ -840,12 +854,6 @@
                                                VerticalAlignment="Center" Margin="0,0,10,0"/>
                                 </DockPanel>
                             </Border>
-                            <!-- Body (#64): own ScrollViewer bounded to row 2 so a long
-                                 preview list scrolls inside this section instead of
-                                 pushing the Pending Edits and Issues headers off the top. -->
-                            <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto"
-                                          HorizontalScrollBarVisibility="Disabled">
-                                <Grid>
                             <!-- Empty state -->
                             <Border Background="White" Padding="12,10" MinHeight="52">
                                 <Border.Style>
@@ -883,6 +891,8 @@
                                         </Style.Triggers>
                                     </Style>
                                 </ItemsControl.Style>
+                                <!-- No inner ScrollViewer: the sidebar's outer ScrollViewer
+                                     handles wheel events for the whole inspector. -->
                                 <ItemsControl.Template>
                                     <ControlTemplate TargetType="ItemsControl">
                                         <Border Background="White">
@@ -935,14 +945,18 @@
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>
-                                </Grid>
-                            </ScrollViewer>
 
                             <!-- =========================================================
                                  Section 3 — PENDING EDITS
                                  ========================================================= -->
-                            <Border Grid.Row="3" Background="#EEF0F3" BorderBrush="#B9BEC6"
-                                    BorderThickness="0,1,0,1">
+                            <Border x:Name="StickyHeader3" Panel.ZIndex="10"
+                                    Background="#EEF0F3" BorderBrush="#B9BEC6"
+                                    BorderThickness="0,1,0,1"
+                                    Cursor="Hand"
+                                    MouseLeftButtonUp="OnInspectorHeaderClick">
+                                <Border.RenderTransform>
+                                    <TranslateTransform x:Name="StickyTransform3"/>
+                                </Border.RenderTransform>
                                 <DockPanel>
                                     <Button DockPanel.Dock="Left"
                                             Command="{Binding TogglePendingCommand}"
@@ -992,10 +1006,6 @@
                                             Visibility="{Binding HasPendingEdits, Converter={StaticResource BoolToVis}}"/>
                                 </DockPanel>
                             </Border>
-                            <!-- Body (#64): own ScrollViewer bounded to row 4. -->
-                            <ScrollViewer Grid.Row="4" VerticalScrollBarVisibility="Auto"
-                                          HorizontalScrollBarVisibility="Disabled">
-                                <Grid>
                             <!-- Empty state -->
                             <Border Background="White" Padding="12,10" MinHeight="52">
                                 <Border.Style>
@@ -1034,6 +1044,8 @@
                                         </Style.Triggers>
                                     </Style>
                                 </ItemsControl.Style>
+                                <!-- No inner ScrollViewer: the sidebar's outer ScrollViewer
+                                     handles wheel events for the whole inspector. -->
                                 <ItemsControl.Template>
                                     <ControlTemplate TargetType="ItemsControl">
                                         <Border Background="White">
@@ -1138,8 +1150,6 @@
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>
-                                </Grid>
-                            </ScrollViewer>
 
                             <!-- =========================================================
                                  Section 4 — ISSUES (#26)
@@ -1147,8 +1157,14 @@
                                  a configured rule. Click a row to jump to the member in the
                                  tree. Does NOT block Apply.
                                  ========================================================= -->
-                            <Border Grid.Row="5" Background="#EEF0F3" BorderBrush="#B9BEC6"
-                                    BorderThickness="0,1,0,1">
+                            <Border x:Name="StickyHeader4" Panel.ZIndex="10"
+                                    Background="#EEF0F3" BorderBrush="#B9BEC6"
+                                    BorderThickness="0,1,0,1"
+                                    Cursor="Hand"
+                                    MouseLeftButtonUp="OnInspectorHeaderClick">
+                                <Border.RenderTransform>
+                                    <TranslateTransform x:Name="StickyTransform4"/>
+                                </Border.RenderTransform>
                                 <DockPanel ToolTip="{loc:Loc Issues_Tooltip}">
                                     <Button DockPanel.Dock="Left"
                                             Command="{Binding ToggleIssuesCommand}"
@@ -1185,10 +1201,6 @@
                                     <Border/>
                                 </DockPanel>
                             </Border>
-                            <!-- Body (#64): own ScrollViewer bounded to row 6. -->
-                            <ScrollViewer Grid.Row="6" VerticalScrollBarVisibility="Auto"
-                                          HorizontalScrollBarVisibility="Disabled">
-                                <Grid>
                             <!-- Empty state -->
                             <Border Background="White" Padding="12,10" MinHeight="52">
                                 <Border.Style>
@@ -1271,9 +1283,8 @@
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>
-                                </Grid>
-                            </ScrollViewer>
-                    </Grid>
+                        </StackPanel>
+                    </ScrollViewer>
                 </DockPanel>
             </Border>
         </Grid>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml.cs
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
 using BlockParam.Diagnostics;
 using BlockParam.Localization;
 using BlockParam.Services;
@@ -15,6 +16,16 @@ public partial class BulkChangeDialog : Window
         InitializeComponent();
         WindowIconHelper.SetIcon(this);
         ZoomHost.Attach(this);
+
+        // #64: capture sticky-header references once. The handler reads these
+        // on every ScrollChanged to keep all four section headers visible —
+        // pinned at viewport top once scrolled past, pinned at viewport bottom
+        // before reached, in flow when their natural Y is inside the viewport.
+        _stickyHeaders = new FrameworkElement[]
+            { StickyHeader1, StickyHeader2, StickyHeader3, StickyHeader4 };
+        _stickyTransforms = new[]
+            { StickyTransform1, StickyTransform2, StickyTransform3, StickyTransform4 };
+        InspectorScroll.ScrollChanged += OnInspectorScrollChanged;
     }
 
     private bool _suppressSelectionEvents;
@@ -927,6 +938,96 @@ public partial class BulkChangeDialog : Window
         {
             e.Cancel = true;
             return;
+        }
+    }
+
+    // ---- Sticky inspector section headers (#64) ----------------------------
+    private readonly FrameworkElement[] _stickyHeaders;
+    private readonly TranslateTransform[] _stickyTransforms;
+
+    /// <summary>
+    /// Click anywhere on a section header → expand that section and scroll
+    /// it to the top of the inspector so its body is unveiled. The toggle
+    /// caret (a Button inside the header) keeps its independent
+    /// expand-or-collapse behavior; we filter clicks that bubbled up from
+    /// it so the caret remains a true toggle rather than a one-way expander.
+    /// </summary>
+    private void OnInspectorHeaderClick(object sender, MouseButtonEventArgs e)
+    {
+        if (e.OriginalSource is DependencyObject dep && FindAncestor<Button>(dep) != null) return;
+        if (sender is not FrameworkElement header) return;
+        if (DataContext is not BulkChangeViewModel vm) return;
+
+        int idx = Array.IndexOf(_stickyHeaders, header);
+        if (idx < 0) return;
+
+        // Expand the section before scrolling so the body's height counts in
+        // ExtentHeight — otherwise ScrollToVerticalOffset clamps short.
+        switch (idx)
+        {
+            case 0: vm.IsBulkEditExpanded = true; break;
+            case 1: vm.IsBulkPreviewExpanded = true; break;
+            case 2: vm.IsPendingExpanded = true; break;
+            case 3: vm.IsIssuesExpanded = true; break;
+        }
+        UpdateLayout();
+
+        // Compute the header's natural Y in scroll-content coords (back out
+        // the sticky transform that's currently applied to it).
+        var p = header.TransformToVisual(InspectorContent).Transform(new Point(0, 0));
+        double naturalY = p.Y - _stickyTransforms[idx].Y;
+
+        // Scrolling to naturalY would stop with the clicked header at the
+        // viewport top — but the sticky logic then pushes it DOWN by the
+        // combined height of all preceding sticky headers (which stack above),
+        // so those bands cover the start of this section's body. Pre-subtract
+        // sumBefore so the body starts exactly below the full sticky stack.
+        double sumBefore = 0;
+        for (int i = 0; i < idx; i++) sumBefore += _stickyHeaders[i].ActualHeight;
+        InspectorScroll.ScrollToVerticalOffset(naturalY - sumBefore);
+    }
+
+    /// <summary>
+    /// Keeps each inspector section header visible as the user scrolls:
+    /// headers above the viewport stack at the top, headers below the
+    /// viewport stack at the bottom, in-view headers stay in flow. Headers
+    /// preserve document order — preceding headers reserve room above, and
+    /// following headers reserve room below, so their bands never overlap.
+    /// </summary>
+    private void OnInspectorScrollChanged(object sender, ScrollChangedEventArgs e)
+    {
+        var n = _stickyHeaders.Length;
+        var heights = new double[n];
+        var naturalY = new double[n];
+        for (int i = 0; i < n; i++)
+        {
+            heights[i] = _stickyHeaders[i].ActualHeight;
+            // Position with current RenderTransform applied; subtract the
+            // current translate to recover the natural (untransformed) Y.
+            var p = _stickyHeaders[i]
+                .TransformToVisual(InspectorContent)
+                .Transform(new Point(0, 0));
+            naturalY[i] = p.Y - _stickyTransforms[i].Y;
+        }
+
+        double scrollTop = InspectorScroll.VerticalOffset;
+        double scrollBot = scrollTop + InspectorScroll.ViewportHeight;
+
+        double sumBefore = 0;
+        double sumAfter = 0;
+        for (int i = 0; i < n; i++) sumAfter += heights[i];
+
+        for (int i = 0; i < n; i++)
+        {
+            double topLimit = scrollTop + sumBefore;
+            double bottomLimit = scrollBot - sumAfter;
+            // If the viewport is too small to fit all headers, topLimit can
+            // exceed bottomLimit — pinning to the top wins (Math.Max last).
+            double newY = Math.Max(topLimit, Math.Min(bottomLimit, naturalY[i]));
+            _stickyTransforms[i].Y = newY - naturalY[i];
+
+            sumBefore += heights[i];
+            sumAfter -= heights[i];
         }
     }
 }

--- a/src/BlockParam/UI/Converters.cs
+++ b/src/BlockParam/UI/Converters.cs
@@ -72,29 +72,6 @@ public class RuleSourceToBoolConverter : IValueConverter
     }
 }
 
-/// <summary>
-/// Converts a bool to a <see cref="GridLength"/> for binding row/column heights to
-/// expand/collapse state. True → expanded length (parameter, default "*"); false → 0.
-/// Parameter accepts any <see cref="GridLengthConverter"/> string ("*", "Auto", "2*", "150").
-/// </summary>
-public class BoolToGridLengthConverter : IValueConverter
-{
-    private static readonly GridLengthConverter _glc = new();
-
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        if (value is not true)
-            return new GridLength(0);
-        var spec = parameter as string;
-        if (string.IsNullOrEmpty(spec))
-            return new GridLength(1, GridUnitType.Star);
-        return (GridLength)_glc.ConvertFromString(spec)!;
-    }
-
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        => throw new NotSupportedException();
-}
-
 public class StringNotEmptyToVisibilityConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/BlockParam/UI/Converters.cs
+++ b/src/BlockParam/UI/Converters.cs
@@ -72,6 +72,29 @@ public class RuleSourceToBoolConverter : IValueConverter
     }
 }
 
+/// <summary>
+/// Converts a bool to a <see cref="GridLength"/> for binding row/column heights to
+/// expand/collapse state. True → expanded length (parameter, default "*"); false → 0.
+/// Parameter accepts any <see cref="GridLengthConverter"/> string ("*", "Auto", "2*", "150").
+/// </summary>
+public class BoolToGridLengthConverter : IValueConverter
+{
+    private static readonly GridLengthConverter _glc = new();
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is not true)
+            return new GridLength(0);
+        var spec = parameter as string;
+        if (string.IsNullOrEmpty(spec))
+            return new GridLength(1, GridUnitType.Star);
+        return (GridLength)_glc.ConvertFromString(spec)!;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
 public class StringNotEmptyToVisibilityConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)


### PR DESCRIPTION
## Summary

- Replace the per-section `ScrollViewer` approach (commit `7609de3`) with a single outer `ScrollViewer` whose four section headers are pinned to the viewport top once scrolled past *and* to the viewport bottom before reached, so all four are visible at every scroll position.
- Click any header to expand that section and scroll its body into view immediately below the sticky stack.

## How it works

- Each section header `Border` carries a `TranslateTransform`; `OnInspectorScrollChanged` clamps each header between `scrollTop + sumOfPrecedingHeights` and `scrollBottom - sumOfFollowingHeights`.
- Section 1 (BULK EDIT) is nested inside a wrapper `Grid`, so it needs `Panel.ZIndex=10` in two places: on the wrapper (beats other sections' bodies in the outer `StackPanel`) *and* on the header itself (beats its own body sibling inside the inner `StackPanel`).
- Click handler pre-subtracts `sumOfPrecedingHeights` from the scroll target so the body starts right below the sticky stack instead of being clipped by it. Clicks that bubbled from the toggle caret button are filtered so the caret keeps its expand/collapse role.
- `BoolToGridLengthConverter` (introduced in `7609de3`, now unused) is removed.

Closes #64

## Test plan

- [x] `dotnet test` — 444/444 pass
- [x] DevLauncher: scroll inspector → all four headers stay visible (stacked at top above viewport, stacked at bottom below viewport)
- [x] DevLauncher: click each header → that section expands and its body's first line is fully visible below the sticky stack
- [x] DevLauncher: click the caret button on a header → only toggles expand/collapse, no scroll jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)