### PR TITLE
feat: in-app "Update available" notice

### DIFF
--- a/src/BlockParam.DevLauncher/Program.cs
+++ b/src/BlockParam.DevLauncher/Program.cs
@@ -14,6 +14,7 @@ using BlockParam.Licensing;
 using BlockParam.Services;
 using BlockParam.SimaticML;
 using BlockParam.UI;
+using BlockParam.Updates;
 
 namespace BlockParam.DevLauncher;
 
@@ -190,6 +191,17 @@ class Program
             sharedLicenseFilePath: OnlineLicenseService.DefaultSharedLicenseFilePath);
         var usageTracker = new LicensedUsageTracker(licenseService, freeTracker);
 
+        // Update check (#61): mirror BulkChangeContextMenu wiring so the badge
+        // and dialog are exercisable without TIA. Uses the BlockParam assembly
+        // version (not DevLauncher's) so the badge text reads e.g. "v1.0.2 → vX.Y.Z".
+        var blockParamVersion = typeof(BulkChangeViewModel).Assembly.GetName().Version
+            ?? new Version(0, 0, 0);
+        var updateCheckService = new UpdateCheckService(
+            fetcher: new GitHubReleaseFetcher(),
+            currentVersion: VersionTag.FromSystemVersion(blockParamVersion),
+            cachePath: Path.Combine(appDataDir, "update-check.json"),
+            readSettings: () => configLoader.ReadUpdateCheckSettings());
+
         // 5. Show dialog
         var app = new Application();
         app.DispatcherUnhandledException += (_, e) =>
@@ -212,7 +224,8 @@ class Program
             licenseService: licenseService,
             udtDir: udtDir,
             udtResolver: udtResolver,
-            commentResolver: commentResolver);
+            commentResolver: commentResolver,
+            updateCheckService: updateCheckService);
 
         licenseService.StartHeartbeat();
         var dialog = new BulkChangeDialog(vm);

--- a/src/BlockParam.Tests/GitHubReleaseFetcherTests.cs
+++ b/src/BlockParam.Tests/GitHubReleaseFetcherTests.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+using BlockParam.Updates;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+public class GitHubReleaseFetcherTests
+{
+    [Fact]
+    public void ParseRelease_HappyPath()
+    {
+        var json = @"{
+            ""tag_name"": ""v0.4.0"",
+            ""name"": ""v0.4.0 — fancy update"",
+            ""html_url"": ""https://github.com/Sawascwoolf/BlockParam/releases/tag/v0.4.0"",
+            ""body"": ""- Added thing\n- Fixed thing"",
+            ""prerelease"": false,
+            ""published_at"": ""2026-05-02T08:00:00Z""
+        }";
+
+        var info = GitHubReleaseFetcher.ParseRelease(json);
+
+        info.Should().NotBeNull();
+        info!.TagName.Should().Be("v0.4.0");
+        info.Name.Should().Be("v0.4.0 — fancy update");
+        info.HtmlUrl.Should().Be("https://github.com/Sawascwoolf/BlockParam/releases/tag/v0.4.0");
+        info.Body.Should().Contain("Added thing");
+        info.PreRelease.Should().BeFalse();
+        info.PublishedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ParseRelease_PreRelease_True()
+    {
+        var json = @"{ ""tag_name"": ""v0.4.0-rc1"", ""prerelease"": true }";
+        var info = GitHubReleaseFetcher.ParseRelease(json);
+        info.Should().NotBeNull();
+        info!.PreRelease.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ParseRelease_MissingTag_ReturnsNull()
+    {
+        // GitHub never returns a release without tag_name, but if they ever
+        // did the service must reject it rather than show "v(empty)".
+        var json = @"{ ""name"": ""untitled"" }";
+        GitHubReleaseFetcher.ParseRelease(json).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not json")]
+    [InlineData("[]")]                // unexpected array root
+    [InlineData("{}")]                // valid JSON but no tag_name
+    [InlineData("null")]
+    public void ParseRelease_GarbageInput_ReturnsNull(string json)
+    {
+        GitHubReleaseFetcher.ParseRelease(json).Should().BeNull();
+    }
+}

--- a/src/BlockParam.Tests/UpdateCheckServiceTests.cs
+++ b/src/BlockParam.Tests/UpdateCheckServiceTests.cs
@@ -161,40 +161,6 @@ public class UpdateCheckServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task SkippedVersion_SuppressesBadge()
-    {
-        var release = new UpdateInfo { TagName = "v0.4.0" };
-        var fetcher = new RecordingFetcher(release);
-        var service = Build(
-            fetcher,
-            current: "v0.3.0",
-            settings: new UpdateCheckSettings
-            {
-                Enabled = true,
-                SkippedVersion = "v0.4.0",
-            });
-
-        (await service.CheckAsync()).Should().BeNull();
-    }
-
-    [Fact]
-    public async Task SkippedVersion_NewerVersionStillSurfaces()
-    {
-        var release = new UpdateInfo { TagName = "v0.5.0" };
-        var fetcher = new RecordingFetcher(release);
-        var service = Build(
-            fetcher,
-            current: "v0.3.0",
-            settings: new UpdateCheckSettings
-            {
-                Enabled = true,
-                SkippedVersion = "v0.4.0",
-            });
-
-        (await service.CheckAsync()).Should().NotBeNull();
-    }
-
-    [Fact]
     public void GetCached_ReturnsCachedReleaseEvenWhenStale()
     {
         // Write a stale cache directly so we don't rely on the fetcher.
@@ -216,22 +182,6 @@ public class UpdateCheckServiceTests : IDisposable
     }
 
     [Fact]
-    public void SkipVersion_PersistsToSettings()
-    {
-        var saved = new UpdateCheckSettings();
-        var fetcher = new RecordingFetcher(null);
-        var service = new UpdateCheckService(
-            fetcher,
-            VersionTag.FromSystemVersion(new System.Version(0, 3, 0)),
-            _cachePath,
-            readSettings: () => saved,
-            writeSettings: s => saved = s);
-
-        service.SkipVersion("v0.4.0");
-        saved.SkippedVersion.Should().Be("v0.4.0");
-    }
-
-    [Fact]
     public async Task CheckAsync_VersionCompareHandlesRcSuffix()
     {
         // current is rc1, latest stable is the same version without suffix:
@@ -243,8 +193,7 @@ public class UpdateCheckServiceTests : IDisposable
             fetcher,
             currentVersion: Parse("v0.4.0-rc1"),
             cachePath: _cachePath,
-            readSettings: () => new UpdateCheckSettings(),
-            writeSettings: _ => { });
+            readSettings: () => new UpdateCheckSettings());
 
         (await service.CheckAsync()).Should().NotBeNull();
     }
@@ -263,7 +212,6 @@ public class UpdateCheckServiceTests : IDisposable
             currentVersion: Parse(current),
             cachePath: _cachePath,
             readSettings: () => settings,
-            writeSettings: _ => { },
             utcNow: () => clock.Now);
     }
 

--- a/src/BlockParam.Tests/UpdateCheckServiceTests.cs
+++ b/src/BlockParam.Tests/UpdateCheckServiceTests.cs
@@ -1,0 +1,302 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using BlockParam.Updates;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+public class UpdateCheckServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _cachePath;
+
+    public UpdateCheckServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"BlockParamUpdateTest_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _cachePath = Path.Combine(_tempDir, "update-check.json");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public async Task CheckAsync_WhenDisabled_ReturnsNull_AndDoesNotFetch()
+    {
+        var fetcher = new RecordingFetcher();
+        var service = Build(
+            fetcher,
+            current: "v0.3.0",
+            settings: new UpdateCheckSettings { Enabled = false });
+
+        var result = await service.CheckAsync();
+
+        result.Should().BeNull();
+        fetcher.Calls.Should().Be(0, "disabled service must not hit the network");
+    }
+
+    [Fact]
+    public async Task CheckAsync_WhenNewerVersion_ReturnsRelease_AndCaches()
+    {
+        var release = new UpdateInfo { TagName = "v0.4.0", HtmlUrl = "https://x", Body = "notes" };
+        var fetcher = new RecordingFetcher(release);
+        var service = Build(fetcher, current: "v0.3.0");
+
+        var result = await service.CheckAsync();
+
+        result.Should().NotBeNull();
+        result!.TagName.Should().Be("v0.4.0");
+        File.Exists(_cachePath).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CheckAsync_WhenOlderOrEqual_ReturnsNull()
+    {
+        var release = new UpdateInfo { TagName = "v0.3.0" };
+        var fetcher = new RecordingFetcher(release);
+        var service = Build(fetcher, current: "v0.3.0");
+
+        (await service.CheckAsync()).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CheckAsync_StableUserHidesPrereleaseByDefault()
+    {
+        var release = new UpdateInfo { TagName = "v0.4.0-rc1", PreRelease = true };
+        var fetcher = new RecordingFetcher(release);
+        var service = Build(fetcher, current: "v0.3.0");
+
+        (await service.CheckAsync()).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CheckAsync_PrereleaseShownWhenIncludePrereleasesIsTrue()
+    {
+        var release = new UpdateInfo { TagName = "v0.4.0-rc1", PreRelease = true };
+        var fetcher = new RecordingFetcher(release);
+        var service = Build(
+            fetcher,
+            current: "v0.3.0",
+            settings: new UpdateCheckSettings { Enabled = true, IncludePrereleases = true });
+
+        (await service.CheckAsync()).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task CheckAsync_UsesCacheWithinTtl_NoRefetch()
+    {
+        var release = new UpdateInfo { TagName = "v0.4.0" };
+        var fetcher = new RecordingFetcher(release);
+        var clock = new TestClock(DateTime.UtcNow);
+        var service = Build(fetcher, current: "v0.3.0", clock: clock);
+
+        // Prime the cache.
+        await service.CheckAsync();
+        fetcher.Calls.Should().Be(1);
+
+        // Move 1 hour forward — well within the 24 h TTL.
+        clock.Now = clock.Now.AddHours(1);
+        await service.CheckAsync();
+        fetcher.Calls.Should().Be(1, "cache hit must not call the fetcher");
+    }
+
+    [Fact]
+    public async Task CheckAsync_RefreshesAfterTtlExpires()
+    {
+        var release = new UpdateInfo { TagName = "v0.4.0" };
+        var fetcher = new RecordingFetcher(release);
+        var clock = new TestClock(DateTime.UtcNow);
+        var service = Build(fetcher, current: "v0.3.0", clock: clock);
+
+        await service.CheckAsync();
+        fetcher.Calls.Should().Be(1);
+
+        clock.Now = clock.Now.AddHours(25);
+        await service.CheckAsync();
+        fetcher.Calls.Should().Be(2, "stale cache must trigger one fresh fetch");
+    }
+
+    [Fact]
+    public async Task CheckAsync_FetchFailureWithCachedHit_ReturnsCache()
+    {
+        // Prime cache with a successful fetch.
+        var release = new UpdateInfo { TagName = "v0.4.0" };
+        var clock = new TestClock(DateTime.UtcNow);
+        var fetcher = new RecordingFetcher(release);
+        var service = Build(fetcher, current: "v0.3.0", clock: clock);
+        await service.CheckAsync();
+
+        // TTL elapses; next fetch fails — should fall back to cache.
+        clock.Now = clock.Now.AddHours(25);
+        fetcher.NextResult = null;
+
+        var result = await service.CheckAsync();
+        result.Should().NotBeNull();
+        result!.TagName.Should().Be("v0.4.0");
+    }
+
+    [Fact]
+    public async Task CheckAsync_FetchFailureNoCache_ReturnsNull_DoesNotCache()
+    {
+        var fetcher = new RecordingFetcher(null);
+        var service = Build(fetcher, current: "v0.3.0");
+
+        (await service.CheckAsync()).Should().BeNull();
+        File.Exists(_cachePath).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CheckAsync_FetcherThrows_ReturnsNull_NeverPropagates()
+    {
+        var fetcher = new ThrowingFetcher();
+        var service = Build(fetcher, current: "v0.3.0");
+
+        var act = async () => await service.CheckAsync();
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task SkippedVersion_SuppressesBadge()
+    {
+        var release = new UpdateInfo { TagName = "v0.4.0" };
+        var fetcher = new RecordingFetcher(release);
+        var service = Build(
+            fetcher,
+            current: "v0.3.0",
+            settings: new UpdateCheckSettings
+            {
+                Enabled = true,
+                SkippedVersion = "v0.4.0",
+            });
+
+        (await service.CheckAsync()).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SkippedVersion_NewerVersionStillSurfaces()
+    {
+        var release = new UpdateInfo { TagName = "v0.5.0" };
+        var fetcher = new RecordingFetcher(release);
+        var service = Build(
+            fetcher,
+            current: "v0.3.0",
+            settings: new UpdateCheckSettings
+            {
+                Enabled = true,
+                SkippedVersion = "v0.4.0",
+            });
+
+        (await service.CheckAsync()).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void GetCached_ReturnsCachedReleaseEvenWhenStale()
+    {
+        // Write a stale cache directly so we don't rely on the fetcher.
+        var info = new UpdateInfo { TagName = "v0.4.0" };
+        var envelope = new UpdateCheckService.CacheEnvelope
+        {
+            CheckedAt = DateTime.UtcNow.AddDays(-30),
+            Release = info,
+        };
+        File.WriteAllText(_cachePath,
+            Newtonsoft.Json.JsonConvert.SerializeObject(envelope));
+
+        var fetcher = new RecordingFetcher(null);
+        var service = Build(fetcher, current: "v0.3.0");
+
+        var cached = service.GetCached();
+        cached.Should().NotBeNull();
+        cached!.TagName.Should().Be("v0.4.0");
+    }
+
+    [Fact]
+    public void SkipVersion_PersistsToSettings()
+    {
+        var saved = new UpdateCheckSettings();
+        var fetcher = new RecordingFetcher(null);
+        var service = new UpdateCheckService(
+            fetcher,
+            VersionTag.FromSystemVersion(new System.Version(0, 3, 0)),
+            _cachePath,
+            readSettings: () => saved,
+            writeSettings: s => saved = s);
+
+        service.SkipVersion("v0.4.0");
+        saved.SkippedVersion.Should().Be("v0.4.0");
+    }
+
+    [Fact]
+    public async Task CheckAsync_VersionCompareHandlesRcSuffix()
+    {
+        // current is rc1, latest stable is the same version without suffix:
+        // 0.4.0-rc1 < 0.4.0 → update should surface.
+        var release = new UpdateInfo { TagName = "v0.4.0" };
+        var fetcher = new RecordingFetcher(release);
+
+        var service = new UpdateCheckService(
+            fetcher,
+            currentVersion: Parse("v0.4.0-rc1"),
+            cachePath: _cachePath,
+            readSettings: () => new UpdateCheckSettings(),
+            writeSettings: _ => { });
+
+        (await service.CheckAsync()).Should().NotBeNull();
+    }
+
+    private UpdateCheckService Build(
+        IReleaseFetcher fetcher,
+        string current,
+        UpdateCheckSettings? settings = null,
+        TestClock? clock = null)
+    {
+        settings ??= new UpdateCheckSettings();
+        clock ??= new TestClock(DateTime.UtcNow);
+
+        return new UpdateCheckService(
+            fetcher,
+            currentVersion: Parse(current),
+            cachePath: _cachePath,
+            readSettings: () => settings,
+            writeSettings: _ => { },
+            utcNow: () => clock.Now);
+    }
+
+    private static VersionTag Parse(string s)
+    {
+        VersionTag.TryParse(s, out var t).Should().BeTrue();
+        return t;
+    }
+
+    private sealed class TestClock
+    {
+        public DateTime Now;
+        public TestClock(DateTime now) { Now = now; }
+    }
+
+    private sealed class RecordingFetcher : IReleaseFetcher
+    {
+        public int Calls;
+        public UpdateInfo? NextResult;
+
+        public RecordingFetcher() { NextResult = null; }
+        public RecordingFetcher(UpdateInfo? next) { NextResult = next; }
+
+        public Task<UpdateInfo?> FetchLatestAsync(CancellationToken ct)
+        {
+            Calls++;
+            return Task.FromResult(NextResult);
+        }
+    }
+
+    private sealed class ThrowingFetcher : IReleaseFetcher
+    {
+        public Task<UpdateInfo?> FetchLatestAsync(CancellationToken ct)
+            => throw new InvalidOperationException("simulated network blow-up");
+    }
+}

--- a/src/BlockParam.Tests/UpdateCheckSettingsConfigTests.cs
+++ b/src/BlockParam.Tests/UpdateCheckSettingsConfigTests.cs
@@ -25,7 +25,7 @@ public class UpdateCheckSettingsConfigTests : IDisposable
 
     private ConfigLoader Build()
     {
-        var loader = Build();
+        var loader = new ConfigLoader(_configPath);
         loader.ManagedConfigPathOverride = _managedPath;
         return loader;
     }
@@ -44,7 +44,6 @@ public class UpdateCheckSettingsConfigTests : IDisposable
 
         settings.Enabled.Should().BeTrue();
         settings.IncludePrereleases.Should().BeFalse();
-        settings.SkippedVersion.Should().BeNull();
     }
 
     [Fact]
@@ -54,8 +53,7 @@ public class UpdateCheckSettingsConfigTests : IDisposable
             ""version"": ""1.0"",
             ""updateCheck"": {
                 ""enabled"": false,
-                ""includePrereleases"": true,
-                ""skippedVersion"": ""v0.4.0""
+                ""includePrereleases"": true
             }
         }");
 
@@ -64,7 +62,6 @@ public class UpdateCheckSettingsConfigTests : IDisposable
 
         settings.Enabled.Should().BeFalse();
         settings.IncludePrereleases.Should().BeTrue();
-        settings.SkippedVersion.Should().Be("v0.4.0");
     }
 
     [Fact]
@@ -72,7 +69,7 @@ public class UpdateCheckSettingsConfigTests : IDisposable
     {
         // User locally has updates ON.
         File.WriteAllText(_configPath, @"{
-            ""updateCheck"": { ""enabled"": true, ""skippedVersion"": ""v0.4.0"" }
+            ""updateCheck"": { ""enabled"": true }
         }");
         // IT pushes a managed config that disables the check.
         File.WriteAllText(_managedPath, @"{
@@ -84,8 +81,6 @@ public class UpdateCheckSettingsConfigTests : IDisposable
 
         // Managed flag wins.
         settings.Enabled.Should().BeFalse();
-        // User's SkippedVersion stays — managed file didn't touch that field.
-        settings.SkippedVersion.Should().Be("v0.4.0");
     }
 
     [Fact]
@@ -101,19 +96,18 @@ public class UpdateCheckSettingsConfigTests : IDisposable
         loader.SaveUpdateCheckSettings(new UpdateCheckSettings
         {
             Enabled = false,
-            SkippedVersion = "v0.4.0",
+            IncludePrereleases = true,
         });
 
         var json = File.ReadAllText(_configPath);
         json.Should().Contain("\"rulesDirectory\"");
         json.Should().Contain("\"language\"");
         json.Should().Contain("\"updateCheck\"");
-        json.Should().Contain("\"skippedVersion\": \"v0.4.0\"");
 
         // Round-trip through the loader
         loader.Invalidate();
         var roundtrip = loader.ReadUpdateCheckSettings();
         roundtrip.Enabled.Should().BeFalse();
-        roundtrip.SkippedVersion.Should().Be("v0.4.0");
+        roundtrip.IncludePrereleases.Should().BeTrue();
     }
 }

--- a/src/BlockParam.Tests/UpdateCheckSettingsConfigTests.cs
+++ b/src/BlockParam.Tests/UpdateCheckSettingsConfigTests.cs
@@ -1,0 +1,119 @@
+using System.IO;
+using FluentAssertions;
+using BlockParam.Config;
+using BlockParam.Updates;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+public class UpdateCheckSettingsConfigTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _configPath;
+    private readonly string _managedPath;
+
+    public UpdateCheckSettingsConfigTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"BlockParamUpdateCfg_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _configPath = Path.Combine(_tempDir, "config.json");
+        // Point the managed-config probe at a non-existent file so a real
+        // %PROGRAMDATA%\BlockParam\config.json on the host machine cannot
+        // taint the test outcome.
+        _managedPath = Path.Combine(_tempDir, "managed-config.json");
+    }
+
+    private ConfigLoader Build()
+    {
+        var loader = Build();
+        loader.ManagedConfigPathOverride = _managedPath;
+        return loader;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void ReadUpdateCheckSettings_DefaultsWhenFileMissing()
+    {
+        var loader = Build();
+        var settings = loader.ReadUpdateCheckSettings();
+
+        settings.Enabled.Should().BeTrue();
+        settings.IncludePrereleases.Should().BeFalse();
+        settings.SkippedVersion.Should().BeNull();
+    }
+
+    [Fact]
+    public void ReadUpdateCheckSettings_FromUserConfig()
+    {
+        File.WriteAllText(_configPath, @"{
+            ""version"": ""1.0"",
+            ""updateCheck"": {
+                ""enabled"": false,
+                ""includePrereleases"": true,
+                ""skippedVersion"": ""v0.4.0""
+            }
+        }");
+
+        var loader = Build();
+        var settings = loader.ReadUpdateCheckSettings();
+
+        settings.Enabled.Should().BeFalse();
+        settings.IncludePrereleases.Should().BeTrue();
+        settings.SkippedVersion.Should().Be("v0.4.0");
+    }
+
+    [Fact]
+    public void ReadUpdateCheckSettings_ManagedOverride_DisablesEnabledFlag()
+    {
+        // User locally has updates ON.
+        File.WriteAllText(_configPath, @"{
+            ""updateCheck"": { ""enabled"": true, ""skippedVersion"": ""v0.4.0"" }
+        }");
+        // IT pushes a managed config that disables the check.
+        File.WriteAllText(_managedPath, @"{
+            ""updateCheck"": { ""enabled"": false }
+        }");
+
+        var loader = Build();
+        var settings = loader.ReadUpdateCheckSettings();
+
+        // Managed flag wins.
+        settings.Enabled.Should().BeFalse();
+        // User's SkippedVersion stays — managed file didn't touch that field.
+        settings.SkippedVersion.Should().Be("v0.4.0");
+    }
+
+    [Fact]
+    public void SaveUpdateCheckSettings_PreservesOtherKeys()
+    {
+        File.WriteAllText(_configPath, @"{
+            ""version"": ""1.0"",
+            ""rulesDirectory"": ""C:\\rules"",
+            ""language"": ""de""
+        }");
+
+        var loader = Build();
+        loader.SaveUpdateCheckSettings(new UpdateCheckSettings
+        {
+            Enabled = false,
+            SkippedVersion = "v0.4.0",
+        });
+
+        var json = File.ReadAllText(_configPath);
+        json.Should().Contain("\"rulesDirectory\"");
+        json.Should().Contain("\"language\"");
+        json.Should().Contain("\"updateCheck\"");
+        json.Should().Contain("\"skippedVersion\": \"v0.4.0\"");
+
+        // Round-trip through the loader
+        loader.Invalidate();
+        var roundtrip = loader.ReadUpdateCheckSettings();
+        roundtrip.Enabled.Should().BeFalse();
+        roundtrip.SkippedVersion.Should().Be("v0.4.0");
+    }
+}

--- a/src/BlockParam.Tests/VersionTagTests.cs
+++ b/src/BlockParam.Tests/VersionTagTests.cs
@@ -1,0 +1,96 @@
+using FluentAssertions;
+using BlockParam.Updates;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+public class VersionTagTests
+{
+    [Theory]
+    [InlineData("v0.4.0", 0, 4, 0, "")]
+    [InlineData("0.4.0", 0, 4, 0, "")]
+    [InlineData("V1.2.3", 1, 2, 3, "")]
+    [InlineData("v0.4.0-rc1", 0, 4, 0, "rc1")]
+    [InlineData("0.4.0-beta.2", 0, 4, 0, "beta.2")]
+    [InlineData("1.0.0+build.42", 1, 0, 0, "")]
+    [InlineData("1.0.0-rc1+build.7", 1, 0, 0, "rc1")]
+    [InlineData("v1", 1, 0, 0, "")]
+    [InlineData("v1.2", 1, 2, 0, "")]
+    public void TryParse_AcceptsCommonForms(string input, int major, int minor, int patch, string pre)
+    {
+        VersionTag.TryParse(input, out var tag).Should().BeTrue();
+        tag.Major.Should().Be(major);
+        tag.Minor.Should().Be(minor);
+        tag.Patch.Should().Be(patch);
+        tag.PreRelease.Should().Be(pre);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-version")]
+    [InlineData("v.")]
+    [InlineData("vX.Y.Z")]
+    [InlineData("1.2.3.4")]
+    public void TryParse_RejectsGarbage(string? input)
+    {
+        VersionTag.TryParse(input, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Compare_NewerPatchWins()
+    {
+        Parse("v0.4.0").CompareTo(Parse("v0.3.9")).Should().BePositive();
+    }
+
+    [Fact]
+    public void Compare_NewerMinorWins()
+    {
+        Parse("v0.4.0").CompareTo(Parse("v0.3.99")).Should().BePositive();
+    }
+
+    [Fact]
+    public void Compare_PreReleaseSortsBeforeStable()
+    {
+        // Per SemVer 2.0: 0.4.0-rc1 < 0.4.0
+        Parse("v0.4.0-rc1").CompareTo(Parse("v0.4.0")).Should().BeNegative();
+    }
+
+    [Fact]
+    public void Compare_PreReleaseOrdering_NumericalIds()
+    {
+        // rc1 < rc2 (numerical ids compared numerically)
+        Parse("v0.4.0-rc1").CompareTo(Parse("v0.4.0-rc2")).Should().BeNegative();
+    }
+
+    [Fact]
+    public void Compare_PreReleaseOrdering_DotSeparated()
+    {
+        // beta.2 < beta.10  — numeric segments compared as numbers
+        Parse("v1.0.0-beta.2").CompareTo(Parse("v1.0.0-beta.10")).Should().BeNegative();
+    }
+
+    [Fact]
+    public void Compare_StableEqualsPlain()
+    {
+        Parse("v1.2.3").CompareTo(Parse("1.2.3")).Should().Be(0);
+    }
+
+    [Fact]
+    public void FromSystemVersion_Roundtrip()
+    {
+        var tag = VersionTag.FromSystemVersion(new System.Version(1, 2, 3, 0));
+        tag.Major.Should().Be(1);
+        tag.Minor.Should().Be(2);
+        tag.Patch.Should().Be(3);
+        tag.PreRelease.Should().BeEmpty();
+        tag.IsPreRelease.Should().BeFalse();
+    }
+
+    private static VersionTag Parse(string s)
+    {
+        VersionTag.TryParse(s, out var t).Should().BeTrue($"input '{s}' must parse");
+        return t;
+    }
+}

--- a/src/BlockParam/AddIn/BulkChangeContextMenu.cs
+++ b/src/BlockParam/AddIn/BulkChangeContextMenu.cs
@@ -14,6 +14,7 @@ using BlockParam.Localization;
 using BlockParam.Services;
 using BlockParam.SimaticML;
 using BlockParam.UI;
+using BlockParam.Updates;
 
 namespace BlockParam.AddIn;
 
@@ -246,6 +247,26 @@ public class BulkChangeContextMenu : ContextMenuAddIn
             // Tag table export: lazy (only when needed by autocomplete). Scoped per project (#14).
             var tagTableDir = Path.Combine(tempDir, "TagTables");
 
+            // Update check (#61). Single shared service per dialog session;
+            // cache TTL gates the GitHub call so opening multiple DBs in a
+            // session does not multiply network traffic.
+            IUpdateCheckService? updateCheckService = null;
+            try
+            {
+                var current = typeof(BulkChangeContextMenu).Assembly.GetName().Version
+                    ?? new Version(0, 0, 0);
+                updateCheckService = new UpdateCheckService(
+                    fetcher: new GitHubReleaseFetcher(),
+                    currentVersion: VersionTag.FromSystemVersion(current),
+                    cachePath: Path.Combine(appDataDir, "update-check.json"),
+                    readSettings: () => configLoader.ReadUpdateCheckSettings(),
+                    writeSettings: s => configLoader.SaveUpdateCheckSettings(s));
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "UpdateCheck: cannot construct service — feature disabled this session");
+            }
+
             // Open dialog
             var vm = new BulkChangeViewModel(
                 dbInfo, xml, analyzer, bulkService, usageTracker, configLoader,
@@ -295,7 +316,8 @@ public class BulkChangeContextMenu : ContextMenuAddIn
                 udtResolver: udtResolver,
                 commentResolver: commentResolver,
                 editingLanguage: editingLanguage,
-                referenceLanguage: referenceLanguage);
+                referenceLanguage: referenceLanguage,
+                updateCheckService: updateCheckService);
 
             licenseService.StartHeartbeat();
             var dialog = new BulkChangeDialog(vm);

--- a/src/BlockParam/AddIn/BulkChangeContextMenu.cs
+++ b/src/BlockParam/AddIn/BulkChangeContextMenu.cs
@@ -259,8 +259,7 @@ public class BulkChangeContextMenu : ContextMenuAddIn
                     fetcher: new GitHubReleaseFetcher(),
                     currentVersion: VersionTag.FromSystemVersion(current),
                     cachePath: Path.Combine(appDataDir, "update-check.json"),
-                    readSettings: () => configLoader.ReadUpdateCheckSettings(),
-                    writeSettings: s => configLoader.SaveUpdateCheckSettings(s));
+                    readSettings: () => configLoader.ReadUpdateCheckSettings());
             }
             catch (Exception ex)
             {

--- a/src/BlockParam/Config/BulkChangeConfig.cs
+++ b/src/BlockParam/Config/BulkChangeConfig.cs
@@ -1,6 +1,7 @@
 using Newtonsoft.Json;
 using BlockParam.Models;
 using BlockParam.Services;
+using BlockParam.Updates;
 
 namespace BlockParam.Config;
 
@@ -31,6 +32,13 @@ public class BulkChangeConfig
     /// </summary>
     [JsonProperty("language")]
     public string? Language { get; set; }
+
+    /// <summary>
+    /// In-app update check settings (#61). Optional — when null, defaults
+    /// apply (enabled, no pre-releases, nothing skipped).
+    /// </summary>
+    [JsonProperty("updateCheck")]
+    public UpdateCheckSettings? UpdateCheck { get; set; }
 
     /// <summary>Copy-on-write metadata: tracks where this file was copied from.</summary>
     [JsonProperty("_copiedFrom")]

--- a/src/BlockParam/Config/ConfigLoader.cs
+++ b/src/BlockParam/Config/ConfigLoader.cs
@@ -157,9 +157,6 @@ public class ConfigLoader
     /// the licensing pattern from #20 — IT can deploy a single
     /// <c>{"updateCheck":{"enabled":false}}</c> file to disable checks
     /// fleet-wide on air-gapped engineering networks.
-    ///
-    /// User-set fields the admin file doesn't override (e.g.
-    /// <c>skippedVersion</c>) are preserved.
     /// </summary>
     public UpdateCheckSettings ReadUpdateCheckSettings()
     {
@@ -168,13 +165,10 @@ public class ConfigLoader
         var managed = ReadManagedUpdateCheckSettings();
         if (managed != null)
         {
-            // Only fields the admin actually set should win — leaving the
-            // user's SkippedVersion alone, for example.
+            // Only fields the admin actually set should win.
             if (managed.EnabledExplicit) settings.Enabled = managed.Settings.Enabled;
             if (managed.IncludePrereleasesExplicit)
                 settings.IncludePrereleases = managed.Settings.IncludePrereleases;
-            if (managed.SkippedExplicit)
-                settings.SkippedVersion = managed.Settings.SkippedVersion;
         }
         return settings;
     }
@@ -245,7 +239,6 @@ public class ConfigLoader
                 Settings = settings,
                 EnabledExplicit = node.Property("enabled") != null,
                 IncludePrereleasesExplicit = node.Property("includePrereleases") != null,
-                SkippedExplicit = node.Property("skippedVersion") != null,
             };
         }
         catch (Exception ex)
@@ -260,7 +253,6 @@ public class ConfigLoader
         public UpdateCheckSettings Settings { get; set; } = new();
         public bool EnabledExplicit { get; set; }
         public bool IncludePrereleasesExplicit { get; set; }
-        public bool SkippedExplicit { get; set; }
     }
 
     private BulkChangeConfig? TryReadConfig(string context)

--- a/src/BlockParam/Config/ConfigLoader.cs
+++ b/src/BlockParam/Config/ConfigLoader.cs
@@ -2,6 +2,7 @@ using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using BlockParam.Diagnostics;
+using BlockParam.Updates;
 
 namespace BlockParam.Config;
 
@@ -16,6 +17,13 @@ public class ConfigLoader
     private string? _tiaProjectPath;
     private BulkChangeConfig? _cachedConfig;
     private bool _loaded;
+
+    /// <summary>
+    /// Override the managed-config probe path (default
+    /// <c>%PROGRAMDATA%\BlockParam\config.json</c>). Tests set this so a
+    /// real machine-wide file on the dev/CI box can't taint the result.
+    /// </summary>
+    internal string? ManagedConfigPathOverride { get; set; }
 
     public ConfigLoader(string? configPath = null)
     {
@@ -140,6 +148,119 @@ public class ConfigLoader
     {
         var raw = TryReadConfig("language")?.Language;
         return string.IsNullOrWhiteSpace(raw) ? null : raw!.Trim();
+    }
+
+    /// <summary>
+    /// Reads the in-app update-check settings (#61) merging in this order
+    /// (later wins): user config → managed override at
+    /// <c>%PROGRAMDATA%\BlockParam\config.json</c>. The managed file mirrors
+    /// the licensing pattern from #20 — IT can deploy a single
+    /// <c>{"updateCheck":{"enabled":false}}</c> file to disable checks
+    /// fleet-wide on air-gapped engineering networks.
+    ///
+    /// User-set fields the admin file doesn't override (e.g.
+    /// <c>skippedVersion</c>) are preserved.
+    /// </summary>
+    public UpdateCheckSettings ReadUpdateCheckSettings()
+    {
+        var settings = TryReadConfig("update-check")?.UpdateCheck ?? new UpdateCheckSettings();
+
+        var managed = ReadManagedUpdateCheckSettings();
+        if (managed != null)
+        {
+            // Only fields the admin actually set should win — leaving the
+            // user's SkippedVersion alone, for example.
+            if (managed.EnabledExplicit) settings.Enabled = managed.Settings.Enabled;
+            if (managed.IncludePrereleasesExplicit)
+                settings.IncludePrereleases = managed.Settings.IncludePrereleases;
+            if (managed.SkippedExplicit)
+                settings.SkippedVersion = managed.Settings.SkippedVersion;
+        }
+        return settings;
+    }
+
+    /// <summary>
+    /// Persists user-edited update-check settings to the user config file.
+    /// Preserves all other config keys (rules directory, language, ...).
+    /// </summary>
+    public void SaveUpdateCheckSettings(UpdateCheckSettings settings)
+    {
+        var targetPath = _configPath
+            ?? Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "BlockParam", "config.json");
+
+        BulkChangeConfig config;
+        if (File.Exists(targetPath))
+        {
+            try { config = Deserialize(File.ReadAllText(targetPath)) ?? new BulkChangeConfig(); }
+            catch { config = new BulkChangeConfig(); }
+        }
+        else
+        {
+            config = new BulkChangeConfig();
+        }
+
+        config.UpdateCheck = settings;
+        if (string.IsNullOrEmpty(config.Version)) config.Version = "1.0";
+
+        var dir = Path.GetDirectoryName(targetPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        var json = JsonConvert.SerializeObject(config, Formatting.Indented, new JsonSerializerSettings
+        {
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            NullValueHandling = NullValueHandling.Ignore
+        });
+        File.WriteAllText(targetPath, json);
+        Invalidate();
+    }
+
+    private ManagedUpdateOverride? ReadManagedUpdateCheckSettings()
+    {
+        try
+        {
+            string? managedPath;
+            if (ManagedConfigPathOverride != null)
+            {
+                managedPath = ManagedConfigPathOverride;
+            }
+            else
+            {
+                var programData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+                if (string.IsNullOrEmpty(programData)) return null;
+                managedPath = Path.Combine(programData, "BlockParam", "config.json");
+            }
+            if (!File.Exists(managedPath)) return null;
+
+            var json = File.ReadAllText(managedPath);
+            var token = JsonConvert.DeserializeObject<Newtonsoft.Json.Linq.JObject>(json);
+            var node = token?["updateCheck"] as Newtonsoft.Json.Linq.JObject;
+            if (node == null) return null;
+
+            var settings = node.ToObject<UpdateCheckSettings>() ?? new UpdateCheckSettings();
+            return new ManagedUpdateOverride
+            {
+                Settings = settings,
+                EnabledExplicit = node.Property("enabled") != null,
+                IncludePrereleasesExplicit = node.Property("includePrereleases") != null,
+                SkippedExplicit = node.Property("skippedVersion") != null,
+            };
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "UpdateCheck: cannot read managed override");
+            return null;
+        }
+    }
+
+    private sealed class ManagedUpdateOverride
+    {
+        public UpdateCheckSettings Settings { get; set; } = new();
+        public bool EnabledExplicit { get; set; }
+        public bool IncludePrereleasesExplicit { get; set; }
+        public bool SkippedExplicit { get; set; }
     }
 
     private BulkChangeConfig? TryReadConfig(string context)

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -284,7 +284,6 @@ Datenbaustein jetzt kompilieren?</value></data>
   <data name="Update_NoChangelog" xml:space="preserve"><value>(Zu dieser Version sind keine Versionshinweise hinterlegt.)</value></data>
   <data name="Update_OpenDownload" xml:space="preserve"><value>Download-Seite öffnen</value></data>
   <data name="Update_RemindLater" xml:space="preserve"><value>Später erinnern</value></data>
-  <data name="Update_SkipVersion" xml:space="preserve"><value>Diese Version überspringen</value></data>
   <data name="Update_CheckEnabled" xml:space="preserve"><value>Nach Updates suchen</value></data>
   <data name="Update_CheckEnabledTooltip" xml:space="preserve"><value>Wenn aktiviert, fragt BlockParam höchstens einmal pro Tag GitHub Releases nach neuen Versionen ab. Es werden keine Telemetriedaten gesendet.</value></data>
   <data name="Update_IncludePrereleases" xml:space="preserve"><value>Vorabversionen einbeziehen</value></data>

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -274,4 +274,20 @@ Datenbaustein jetzt kompilieren?</value></data>
   <data name="License_UnknownError" xml:space="preserve"><value>Unbekannter Fehler</value></data>
   <!-- Zoom-Anzeige (#28) -->
   <data name="Zoom_Tooltip" xml:space="preserve"><value>Zoom (Strg + Mausrad, Strg + / Strg −, Strg + 0 zum Zurücksetzen)</value></data>
+  <!-- In-App-Update-Hinweis (#61) -->
+  <data name="Update_BadgeText" xml:space="preserve"><value>{0} → {1} verfügbar</value></data>
+  <data name="Update_BadgeTooltip" xml:space="preserve"><value>Eine neuere Version ist verfügbar: {0}. Klicken Sie für Änderungen und Download.</value></data>
+  <data name="Update_DialogTitle" xml:space="preserve"><value>Update verfügbar</value></data>
+  <data name="Update_VersionDelta" xml:space="preserve"><value>Sie verwenden {0}. Die aktuelle Version ist {1}.</value></data>
+  <data name="Update_PublishedAt" xml:space="preserve"><value>Veröffentlicht am {0}</value></data>
+  <data name="Update_PublishedAtPrerelease" xml:space="preserve"><value>Veröffentlicht am {0} (Vorabversion)</value></data>
+  <data name="Update_NoChangelog" xml:space="preserve"><value>(Zu dieser Version sind keine Versionshinweise hinterlegt.)</value></data>
+  <data name="Update_OpenDownload" xml:space="preserve"><value>Download-Seite öffnen</value></data>
+  <data name="Update_RemindLater" xml:space="preserve"><value>Später erinnern</value></data>
+  <data name="Update_SkipVersion" xml:space="preserve"><value>Diese Version überspringen</value></data>
+  <data name="Update_CheckEnabled" xml:space="preserve"><value>Nach Updates suchen</value></data>
+  <data name="Update_CheckEnabledTooltip" xml:space="preserve"><value>Wenn aktiviert, fragt BlockParam höchstens einmal pro Tag GitHub Releases nach neuen Versionen ab. Es werden keine Telemetriedaten gesendet.</value></data>
+  <data name="Update_IncludePrereleases" xml:space="preserve"><value>Vorabversionen einbeziehen</value></data>
+  <data name="Update_IncludePrereleasesTooltip" xml:space="preserve"><value>Release-Candidate- / Beta-Versionen (z. B. v0.4.0-rc1) als Updates anzeigen.</value></data>
+  <data name="Update_ManagedHint" xml:space="preserve"><value>Die Update-Prüfung wird zentral verwaltet und kann lokal nicht geändert werden.</value></data>
 </root>

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -685,4 +685,56 @@ Compile the block now?</value>
   <data name="Zoom_Tooltip" xml:space="preserve">
     <value>Zoom (Ctrl + mouse wheel, Ctrl + / Ctrl −, Ctrl + 0 to reset)</value>
   </data>
+  <!-- In-app update notice (#61). The badge is intentionally compact —
+       full release notes live in the details popup. -->
+  <data name="Update_BadgeText" xml:space="preserve">
+    <value>{0} → {1} available</value>
+    <comment>{0} = current version (e.g. "v0.3.0"), {1} = latest version (e.g. "v0.4.0")</comment>
+  </data>
+  <data name="Update_BadgeTooltip" xml:space="preserve">
+    <value>A newer release is available: {0}. Click for changelog and download.</value>
+    <comment>{0} = release name or tag</comment>
+  </data>
+  <data name="Update_DialogTitle" xml:space="preserve">
+    <value>Update available</value>
+  </data>
+  <data name="Update_VersionDelta" xml:space="preserve">
+    <value>You are running {0}. Latest release is {1}.</value>
+    <comment>{0} = current version, {1} = latest version</comment>
+  </data>
+  <data name="Update_PublishedAt" xml:space="preserve">
+    <value>Published on {0}</value>
+    <comment>{0} = local date, e.g. "2026-05-02"</comment>
+  </data>
+  <data name="Update_PublishedAtPrerelease" xml:space="preserve">
+    <value>Published on {0} (pre-release)</value>
+    <comment>{0} = local date, e.g. "2026-05-02"</comment>
+  </data>
+  <data name="Update_NoChangelog" xml:space="preserve">
+    <value>(No release notes were attached to this release.)</value>
+  </data>
+  <data name="Update_OpenDownload" xml:space="preserve">
+    <value>Open download page</value>
+  </data>
+  <data name="Update_RemindLater" xml:space="preserve">
+    <value>Remind me later</value>
+  </data>
+  <data name="Update_SkipVersion" xml:space="preserve">
+    <value>Skip this version</value>
+  </data>
+  <data name="Update_CheckEnabled" xml:space="preserve">
+    <value>Check for updates</value>
+  </data>
+  <data name="Update_CheckEnabledTooltip" xml:space="preserve">
+    <value>When enabled, BlockParam queries GitHub Releases at most once per day to detect new versions. No telemetry is sent.</value>
+  </data>
+  <data name="Update_IncludePrereleases" xml:space="preserve">
+    <value>Include pre-releases</value>
+  </data>
+  <data name="Update_IncludePrereleasesTooltip" xml:space="preserve">
+    <value>Show release-candidate / beta builds (e.g. v0.4.0-rc1) as updates.</value>
+  </data>
+  <data name="Update_ManagedHint" xml:space="preserve">
+    <value>Update-check policy is managed by IT and cannot be changed locally.</value>
+  </data>
 </root>

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -719,9 +719,6 @@ Compile the block now?</value>
   <data name="Update_RemindLater" xml:space="preserve">
     <value>Remind me later</value>
   </data>
-  <data name="Update_SkipVersion" xml:space="preserve">
-    <value>Skip this version</value>
-  </data>
   <data name="Update_CheckEnabled" xml:space="preserve">
     <value>Check for updates</value>
   </data>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -84,6 +84,16 @@
                      buttons so the persistent percentage label and shortcut
                      tooltip stay in the user's peripheral vision. -->
                 <local:ZoomIndicator Margin="0,0,12,0" VerticalAlignment="Center"/>
+                <!-- Update-available badge (#61). Hidden until the async
+                     check resolves with a newer release; clicking opens the
+                     details popup with changelog + "Open download page". -->
+                <Button Content="{Binding UpdateBadgeText}" FontSize="10"
+                        Command="{Binding ShowUpdateDetailsCommand}"
+                        Visibility="{Binding HasUpdateAvailable, Converter={StaticResource BoolToVis}}"
+                        Background="#FFF4DA" BorderBrush="#E0A030" BorderThickness="1"
+                        Foreground="#7A5200" Cursor="Hand" Padding="6,2"
+                        VerticalAlignment="Center" Margin="0,0,12,0" FontWeight="SemiBold"
+                        ToolTip="{Binding UpdateBadgeTooltip}"/>
                 <!-- License / usage summary — clickable to open the license dialog.
                      Single control replaces the old tier badge + separate Manage link. -->
                 <Button Content="{Binding UsageStatusText}" FontSize="10"

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -2515,13 +2515,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         var info = _availableUpdate;
         if (info == null || _updateCheckService == null) return;
 
-        var dialog = new UpdateAvailableDialog(info, _updateCheckService);
+        var dialog = new UpdateAvailableDialog(info);
         dialog.Owner = Application.Current?.Windows.OfType<Window>().FirstOrDefault(w => w.IsActive);
         dialog.ShowDialog();
-
-        // The user may have skipped the version — re-evaluate the badge.
-        try { AvailableUpdate = _updateCheckService.GetCached(); }
-        catch (Exception ex) { Log.Warning(ex, "UpdateCheck: post-dialog GetCached threw"); }
     }
 
     /// <summary>

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Threading;
@@ -13,6 +14,7 @@ using BlockParam.Localization;
 using BlockParam.Models;
 using BlockParam.Services;
 using BlockParam.SimaticML;
+using BlockParam.Updates;
 
 namespace BlockParam.UI;
 
@@ -84,6 +86,8 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private readonly CommentLanguagePolicy _commentLanguagePolicy;
     private readonly Dispatcher _dispatcher;
     private readonly ILicenseService? _licenseService;
+    private readonly IUpdateCheckService? _updateCheckService;
+    private UpdateInfo? _availableUpdate;
 
     public BulkChangeViewModel(
         DataBlockInfo dataBlockInfo,
@@ -106,7 +110,8 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         UdtSetPointResolver? udtResolver = null,
         UdtCommentResolver? commentResolver = null,
         string? editingLanguage = null,
-        string? referenceLanguage = null)
+        string? referenceLanguage = null,
+        IUpdateCheckService? updateCheckService = null)
     {
         _dispatcher = Dispatcher.CurrentDispatcher;
         _projectLanguages = projectLanguages is { Count: > 0 } ? projectLanguages : new[] { "en-GB" };
@@ -129,6 +134,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         _udtResolver = udtResolver;
         _commentResolver = commentResolver;
         _licenseService = licenseService;
+        _updateCheckService = updateCheckService;
         _autocompleteProvider = tagTableCache != null
             ? new AutocompleteProvider(configLoader, tagTableCache)
             : null;
@@ -174,6 +180,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         EditConfigCommand = new RelayCommand(ExecuteEditConfig);
         RefreshConstantsCommand = new RelayCommand(ExecuteRefreshConstants);
         EnterLicenseKeyCommand = new RelayCommand(ExecuteEnterLicenseKey);
+        ShowUpdateDetailsCommand = new RelayCommand(ExecuteShowUpdateDetails, () => HasUpdateAvailable);
         UpgradeToProCommand = new RelayCommand(ExecuteUpgradeToPro);
         ExpandAllCommand = new RelayCommand(ExecuteExpandAll);
         CollapseAllCommand = new RelayCommand(ExecuteCollapseAll);
@@ -196,6 +203,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         ApplyAllFilters();
         RefreshFlatList();
         UpdateUsageStatus();
+        InitializeUpdateCheck();
 
         // #26: Surface pre-existing rule violations on dialog load. Runs after
         // RefreshRuleHints so RuleHint is available for the issue tooltip.
@@ -579,6 +587,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     public ICommand EditConfigCommand { get; }
     public ICommand EnterLicenseKeyCommand { get; }
     public ICommand UpgradeToProCommand { get; }
+    public ICommand ShowUpdateDetailsCommand { get; }
     public ICommand ExpandAllCommand { get; }
     public ICommand CollapseAllCommand { get; }
     public ICommand ClearManualSelectionCommand { get; }
@@ -2423,10 +2432,96 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     {
         if (_licenseService == null) return;
 
-        var dialog = new LicenseKeyDialog(_licenseService);
+        var dialog = new LicenseKeyDialog(_licenseService, _updateCheckService, _configLoader);
         dialog.Owner = Application.Current?.Windows.OfType<Window>().FirstOrDefault(w => w.IsActive);
         dialog.ShowDialog();
         UpdateUsageStatus();
+        // The user may have toggled "Check for updates" — re-evaluate the badge.
+        InitializeUpdateCheck(forceRefresh: false);
+    }
+
+    /// <summary>
+    /// Update available (#61). Null when no newer version is on offer
+    /// (offline / opted out / already on latest / skipped).
+    /// </summary>
+    public UpdateInfo? AvailableUpdate
+    {
+        get => _availableUpdate;
+        private set
+        {
+            if (ReferenceEquals(_availableUpdate, value)) return;
+            _availableUpdate = value;
+            OnPropertyChanged(nameof(AvailableUpdate));
+            OnPropertyChanged(nameof(HasUpdateAvailable));
+            OnPropertyChanged(nameof(UpdateBadgeText));
+            OnPropertyChanged(nameof(UpdateBadgeTooltip));
+            (ShowUpdateDetailsCommand as RelayCommand)?.RaiseCanExecuteChanged();
+        }
+    }
+
+    public bool HasUpdateAvailable => _availableUpdate != null;
+
+    public string UpdateBadgeText
+    {
+        get
+        {
+            if (_availableUpdate == null) return "";
+            var current = typeof(BulkChangeViewModel).Assembly.GetName().Version;
+            var currentText = current != null
+                ? $"v{current.Major}.{Math.Max(0, current.Minor)}.{Math.Max(0, current.Build)}"
+                : "v?";
+            var latest = _availableUpdate.TagName;
+            if (latest.Length > 0 && latest[0] != 'v' && latest[0] != 'V') latest = "v" + latest;
+            return Res.Format("Update_BadgeText", currentText, latest);
+        }
+    }
+
+    public string UpdateBadgeTooltip => _availableUpdate == null
+        ? ""
+        : Res.Format("Update_BadgeTooltip",
+            string.IsNullOrEmpty(_availableUpdate.Name)
+                ? _availableUpdate.TagName
+                : _availableUpdate.Name);
+
+    private void InitializeUpdateCheck(bool forceRefresh = true)
+    {
+        if (_updateCheckService == null) return;
+
+        // Synchronous cached read so the badge shows up the moment the
+        // dialog opens — no flash where it appears half a second later.
+        try { AvailableUpdate = _updateCheckService.GetCached(); }
+        catch (Exception ex) { Log.Warning(ex, "UpdateCheck: GetCached threw"); }
+
+        if (!forceRefresh) return;
+
+        // Fire-and-forget refresh — never blocks the UI thread, never
+        // surfaces an error. Cache TTL gates the actual network hit.
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                var info = await _updateCheckService.CheckAsync().ConfigureAwait(false);
+                _dispatcher.BeginInvoke(new Action(() => AvailableUpdate = info));
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "UpdateCheck: background CheckAsync threw");
+            }
+        });
+    }
+
+    private void ExecuteShowUpdateDetails()
+    {
+        var info = _availableUpdate;
+        if (info == null || _updateCheckService == null) return;
+
+        var dialog = new UpdateAvailableDialog(info, _updateCheckService);
+        dialog.Owner = Application.Current?.Windows.OfType<Window>().FirstOrDefault(w => w.IsActive);
+        dialog.ShowDialog();
+
+        // The user may have skipped the version — re-evaluate the badge.
+        try { AvailableUpdate = _updateCheckService.GetCached(); }
+        catch (Exception ex) { Log.Warning(ex, "UpdateCheck: post-dialog GetCached threw"); }
     }
 
     /// <summary>

--- a/src/BlockParam/UI/LicenseKeyDialog.xaml
+++ b/src/BlockParam/UI/LicenseKeyDialog.xaml
@@ -3,13 +3,14 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:loc="clr-namespace:BlockParam.Localization"
         Title="{loc:Loc License_DialogTitle}"
-                Width="460" Height="300"
+                Width="460" Height="400"
         ResizeMode="NoResize"
         WindowStartupLocation="CenterOwner"
         FontFamily="Segoe UI" FontSize="12">
 
     <Grid Margin="16">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -75,11 +76,30 @@
                     Click="OnBuyLicenseClick"/>
         </StackPanel>
 
-        <!-- Spacer -->
-        <Grid Grid.Row="6"/>
+        <!-- Update-check preferences (#61). Hidden when update checks
+             aren't wired (e.g. unit tests) so the dialog stays compact. -->
+        <StackPanel Grid.Row="6" x:Name="UpdateCheckPanel" Orientation="Vertical"
+                    Margin="0,8,0,0" Visibility="Collapsed">
+            <Separator Margin="0,0,0,8"/>
+            <CheckBox x:Name="UpdateCheckEnabledBox"
+                      Content="{loc:Loc Update_CheckEnabled}"
+                      ToolTip="{loc:Loc Update_CheckEnabledTooltip}"
+                      Checked="OnUpdateSettingsChanged" Unchecked="OnUpdateSettingsChanged"/>
+            <CheckBox x:Name="UpdateIncludePrereleasesBox"
+                      Content="{loc:Loc Update_IncludePrereleases}"
+                      ToolTip="{loc:Loc Update_IncludePrereleasesTooltip}"
+                      Margin="20,4,0,0"
+                      Checked="OnUpdateSettingsChanged" Unchecked="OnUpdateSettingsChanged"/>
+            <TextBlock x:Name="UpdateManagedHint" Foreground="#0D47A1" FontSize="11"
+                       TextWrapping="Wrap" Margin="0,4,0,0" Visibility="Collapsed"
+                       Text="{loc:Loc Update_ManagedHint}"/>
+        </StackPanel>
+
+        <!-- Spacer pushes the bottom buttons to the bottom of the dialog. -->
+        <Grid Grid.Row="7"/>
 
         <!-- Bottom buttons -->
-        <StackPanel Grid.Row="7" Orientation="Horizontal" HorizontalAlignment="Right">
+        <StackPanel Grid.Row="8" Orientation="Horizontal" HorizontalAlignment="Right">
             <Button x:Name="RemoveButton" Content="{loc:Loc License_RemoveKey}"
                     Width="120" Height="28" Margin="0,0,8,0"
                     Click="OnRemoveClick" Visibility="Collapsed"/>

--- a/src/BlockParam/UI/LicenseKeyDialog.xaml.cs
+++ b/src/BlockParam/UI/LicenseKeyDialog.xaml.cs
@@ -1,28 +1,84 @@
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Media;
+using BlockParam.Config;
 using BlockParam.Diagnostics;
 using BlockParam.Licensing;
 using BlockParam.Localization;
+using BlockParam.Updates;
 
 namespace BlockParam.UI;
 
 public partial class LicenseKeyDialog : Window
 {
     private readonly ILicenseService _licenseService;
+    private readonly IUpdateCheckService? _updateCheckService;
+    private readonly ConfigLoader? _configLoader;
+    private bool _updateSettingsLoading;
 
     public LicenseKeyDialog(ILicenseService licenseService)
+        : this(licenseService, updateCheckService: null, configLoader: null) { }
+
+    public LicenseKeyDialog(
+        ILicenseService licenseService,
+        IUpdateCheckService? updateCheckService,
+        ConfigLoader? configLoader = null)
     {
         InitializeComponent();
         WindowIconHelper.SetIcon(this);
         ZoomHost.Attach(this);
         _licenseService = licenseService;
+        _updateCheckService = updateCheckService;
+        _configLoader = configLoader;
         UpdateDisplay();
+        InitializeUpdateCheckPanel();
 
         // #20: Keep the Activate button's tooltip in sync with its disabled reason,
         // so the user isn't staring at a greyed-out button with no feedback.
         KeyInput.TextChanged += (_, _) => UpdateActivateButtonState();
         UpdateActivateButtonState();
+    }
+
+    private void InitializeUpdateCheckPanel()
+    {
+        if (_updateCheckService == null || _configLoader == null)
+        {
+            UpdateCheckPanel.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        UpdateCheckPanel.Visibility = Visibility.Visible;
+        _updateSettingsLoading = true;
+        try
+        {
+            var settings = _configLoader.ReadUpdateCheckSettings();
+            UpdateCheckEnabledBox.IsChecked = settings.Enabled;
+            UpdateIncludePrereleasesBox.IsChecked = settings.IncludePrereleases;
+            UpdateIncludePrereleasesBox.IsEnabled = settings.Enabled;
+        }
+        finally
+        {
+            _updateSettingsLoading = false;
+        }
+    }
+
+    private void OnUpdateSettingsChanged(object sender, RoutedEventArgs e)
+    {
+        if (_updateSettingsLoading || _configLoader == null) return;
+
+        try
+        {
+            var existing = _configLoader.ReadUpdateCheckSettings();
+            existing.Enabled = UpdateCheckEnabledBox.IsChecked == true;
+            existing.IncludePrereleases = UpdateIncludePrereleasesBox.IsChecked == true;
+            _configLoader.SaveUpdateCheckSettings(existing);
+
+            UpdateIncludePrereleasesBox.IsEnabled = existing.Enabled;
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "LicenseKeyDialog: cannot persist update-check prefs");
+        }
     }
 
     private void UpdateActivateButtonState()

--- a/src/BlockParam/UI/RelayCommand.cs
+++ b/src/BlockParam/UI/RelayCommand.cs
@@ -26,4 +26,11 @@ public class RelayCommand : ICommand
 
     public bool CanExecute(object? parameter) => _canExecute?.Invoke(parameter) ?? true;
     public void Execute(object? parameter) => _execute(parameter);
+
+    /// <summary>
+    /// Force the bound control to re-query <see cref="CanExecute"/> after
+    /// state the command depends on has changed (e.g. an async update
+    /// check resolves and a button should become enabled).
+    /// </summary>
+    public void RaiseCanExecuteChanged() => CommandManager.InvalidateRequerySuggested();
 }

--- a/src/BlockParam/UI/UpdateAvailableDialog.xaml
+++ b/src/BlockParam/UI/UpdateAvailableDialog.xaml
@@ -1,0 +1,59 @@
+<Window x:Class="BlockParam.UI.UpdateAvailableDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:BlockParam.Localization"
+        Title="{loc:Loc Update_DialogTitle}"
+        Width="520" Height="420"
+        ResizeMode="CanResizeWithGrip"
+        WindowStartupLocation="CenterOwner"
+        FontFamily="Segoe UI" FontSize="12"
+        MinWidth="400" MinHeight="320">
+
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Release title + version delta -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,8">
+            <TextBlock x:Name="ReleaseTitleText" FontSize="14" FontWeight="SemiBold"
+                       TextWrapping="Wrap"/>
+            <TextBlock x:Name="VersionDeltaText" Foreground="#666" Margin="0,2,0,0"/>
+        </StackPanel>
+
+        <!-- Published date / pre-release marker -->
+        <TextBlock Grid.Row="1" x:Name="PublishedText" Foreground="#888" FontSize="11"
+                   Margin="0,0,0,8"/>
+
+        <!-- Changelog (release body) -->
+        <Border Grid.Row="2" BorderBrush="#DDD" BorderThickness="1" Background="#FAFAFA">
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <TextBox x:Name="ChangelogText" IsReadOnly="True" BorderThickness="0"
+                         Background="Transparent" TextWrapping="Wrap" Padding="10"
+                         FontFamily="Consolas" FontSize="11"
+                         VerticalScrollBarVisibility="Disabled"/>
+            </ScrollViewer>
+        </Border>
+
+        <!-- Actions -->
+        <DockPanel Grid.Row="3" Margin="0,12,0,0">
+            <Button DockPanel.Dock="Left" x:Name="SkipButton"
+                    Content="{loc:Loc Update_SkipVersion}"
+                    Width="140" Height="28" Margin="0,0,8,0"
+                    Click="OnSkipClick"/>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button x:Name="RemindLaterButton" Content="{loc:Loc Update_RemindLater}"
+                        Width="120" Height="28" Margin="0,0,8,0"
+                        Click="OnRemindLaterClick"/>
+                <Button x:Name="OpenDownloadButton" Content="{loc:Loc Update_OpenDownload}"
+                        Width="160" Height="28"
+                        Background="#0078D7" Foreground="White" BorderThickness="0"
+                        Cursor="Hand" FontWeight="SemiBold"
+                        Click="OnOpenDownloadClick"/>
+            </StackPanel>
+        </DockPanel>
+    </Grid>
+</Window>

--- a/src/BlockParam/UI/UpdateAvailableDialog.xaml
+++ b/src/BlockParam/UI/UpdateAvailableDialog.xaml
@@ -3,11 +3,12 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:loc="clr-namespace:BlockParam.Localization"
         Title="{loc:Loc Update_DialogTitle}"
-        Width="520" Height="420"
+        Width="600" Height="420"
         ResizeMode="CanResizeWithGrip"
         WindowStartupLocation="CenterOwner"
         FontFamily="Segoe UI" FontSize="12"
-        MinWidth="400" MinHeight="320">
+        MinWidth="500" MinHeight="320"
+        SizeToContent="Manual">
 
     <Grid Margin="16">
         <Grid.RowDefinitions>
@@ -38,22 +39,17 @@
             </ScrollViewer>
         </Border>
 
-        <!-- Actions -->
-        <DockPanel Grid.Row="3" Margin="0,12,0,0">
-            <Button DockPanel.Dock="Left" x:Name="SkipButton"
-                    Content="{loc:Loc Update_SkipVersion}"
-                    Width="140" Height="28" Margin="0,0,8,0"
-                    Click="OnSkipClick"/>
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                <Button x:Name="RemindLaterButton" Content="{loc:Loc Update_RemindLater}"
-                        Width="120" Height="28" Margin="0,0,8,0"
-                        Click="OnRemindLaterClick"/>
-                <Button x:Name="OpenDownloadButton" Content="{loc:Loc Update_OpenDownload}"
-                        Width="160" Height="28"
-                        Background="#0078D7" Foreground="White" BorderThickness="0"
-                        Cursor="Hand" FontWeight="SemiBold"
-                        Click="OnOpenDownloadClick"/>
-            </StackPanel>
-        </DockPanel>
+        <!-- Actions. Buttons auto-size to label width (Padding + MinWidth)
+             so localized strings never get clipped by a fixed Width. -->
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button x:Name="RemindLaterButton" Content="{loc:Loc Update_RemindLater}"
+                    Height="28" MinWidth="100" Padding="14,4" Margin="0,0,8,0"
+                    Click="OnRemindLaterClick"/>
+            <Button x:Name="OpenDownloadButton" Content="{loc:Loc Update_OpenDownload}"
+                    Height="28" MinWidth="120" Padding="14,4"
+                    Background="#0078D7" Foreground="White" BorderThickness="0"
+                    Cursor="Hand" FontWeight="SemiBold"
+                    Click="OnOpenDownloadClick"/>
+        </StackPanel>
     </Grid>
 </Window>

--- a/src/BlockParam/UI/UpdateAvailableDialog.xaml.cs
+++ b/src/BlockParam/UI/UpdateAvailableDialog.xaml.cs
@@ -1,0 +1,79 @@
+using System.Diagnostics;
+using System.Windows;
+using BlockParam.Diagnostics;
+using BlockParam.Localization;
+using BlockParam.Updates;
+
+namespace BlockParam.UI;
+
+public partial class UpdateAvailableDialog : Window
+{
+    private readonly UpdateInfo _info;
+    private readonly IUpdateCheckService _service;
+
+    public UpdateAvailableDialog(UpdateInfo info, IUpdateCheckService service)
+    {
+        InitializeComponent();
+        WindowIconHelper.SetIcon(this);
+        ZoomHost.Attach(this);
+        _info = info;
+        _service = service;
+        Populate();
+    }
+
+    private void Populate()
+    {
+        ReleaseTitleText.Text = string.IsNullOrWhiteSpace(_info.Name) ? _info.TagName : _info.Name;
+
+        var current = typeof(UpdateAvailableDialog).Assembly.GetName().Version;
+        var currentText = current != null
+            ? $"v{current.Major}.{System.Math.Max(0, current.Minor)}.{System.Math.Max(0, current.Build)}"
+            : "v?";
+        var latest = _info.TagName;
+        if (latest.Length > 0 && latest[0] != 'v' && latest[0] != 'V') latest = "v" + latest;
+        VersionDeltaText.Text = Res.Format("Update_VersionDelta", currentText, latest);
+
+        if (_info.PublishedAt.HasValue)
+        {
+            var local = _info.PublishedAt.Value.ToLocalTime();
+            PublishedText.Text = _info.PreRelease
+                ? Res.Format("Update_PublishedAtPrerelease", local.ToString("yyyy-MM-dd"))
+                : Res.Format("Update_PublishedAt", local.ToString("yyyy-MM-dd"));
+        }
+        else
+        {
+            PublishedText.Visibility = Visibility.Collapsed;
+        }
+
+        ChangelogText.Text = string.IsNullOrWhiteSpace(_info.Body)
+            ? Res.Get("Update_NoChangelog")
+            : _info.Body.Trim();
+
+        // Disable Open if we somehow ended up without a URL — defensive
+        // against a malformed cache entry.
+        OpenDownloadButton.IsEnabled = !string.IsNullOrWhiteSpace(_info.HtmlUrl);
+    }
+
+    private void OnOpenDownloadClick(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(_info.HtmlUrl))
+                Process.Start(new ProcessStartInfo(_info.HtmlUrl) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "UpdateAvailableDialog: cannot open {Url}", _info.HtmlUrl);
+        }
+        Close();
+    }
+
+    private void OnRemindLaterClick(object sender, RoutedEventArgs e) => Close();
+
+    private void OnSkipClick(object sender, RoutedEventArgs e)
+    {
+        try { _service.SkipVersion(_info.TagName); }
+        catch (Exception ex) { Log.Warning(ex, "UpdateAvailableDialog: SkipVersion failed"); }
+        Close();
+    }
+}

--- a/src/BlockParam/UI/UpdateAvailableDialog.xaml.cs
+++ b/src/BlockParam/UI/UpdateAvailableDialog.xaml.cs
@@ -9,15 +9,13 @@ namespace BlockParam.UI;
 public partial class UpdateAvailableDialog : Window
 {
     private readonly UpdateInfo _info;
-    private readonly IUpdateCheckService _service;
 
-    public UpdateAvailableDialog(UpdateInfo info, IUpdateCheckService service)
+    public UpdateAvailableDialog(UpdateInfo info)
     {
         InitializeComponent();
         WindowIconHelper.SetIcon(this);
         ZoomHost.Attach(this);
         _info = info;
-        _service = service;
         Populate();
     }
 
@@ -69,11 +67,4 @@ public partial class UpdateAvailableDialog : Window
     }
 
     private void OnRemindLaterClick(object sender, RoutedEventArgs e) => Close();
-
-    private void OnSkipClick(object sender, RoutedEventArgs e)
-    {
-        try { _service.SkipVersion(_info.TagName); }
-        catch (Exception ex) { Log.Warning(ex, "UpdateAvailableDialog: SkipVersion failed"); }
-        Close();
-    }
 }

--- a/src/BlockParam/Updates/GitHubReleaseFetcher.cs
+++ b/src/BlockParam/Updates/GitHubReleaseFetcher.cs
@@ -1,0 +1,116 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using BlockParam.Diagnostics;
+using Newtonsoft.Json.Linq;
+
+namespace BlockParam.Updates;
+
+/// <summary>
+/// Anonymous GitHub Releases fetcher. Hits the public API at most once
+/// per check, swallows every error to a returned <c>null</c>, and uses
+/// a 3-second timeout per the issue spec — air-gapped TIA workstations
+/// must never have their dialog open delayed by a hung connection.
+/// </summary>
+public sealed class GitHubReleaseFetcher : IReleaseFetcher
+{
+    private const string DefaultEndpoint =
+        "https://api.github.com/repos/Sawascwoolf/BlockParam/releases/latest";
+
+    private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(3);
+
+    // One static client; matches the OnlineLicenseService pattern. Setting
+    // ServicePointManager here is safe — if licensing already opted into
+    // TLS 1.2/1.3 the assignment is a no-op.
+    private static readonly HttpClient Http = CreateHttpClient();
+
+    private readonly string _endpoint;
+
+    public GitHubReleaseFetcher(string? endpoint = null)
+    {
+        _endpoint = string.IsNullOrWhiteSpace(endpoint) ? DefaultEndpoint : endpoint!;
+    }
+
+    public async Task<UpdateInfo?> FetchLatestAsync(CancellationToken ct)
+    {
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, _endpoint);
+            // GitHub rejects API requests without a User-Agent.
+            request.Headers.Add("User-Agent", $"BlockParam/{GetAssemblyVersion()}");
+            request.Headers.Add("Accept", "application/vnd.github+json");
+
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            linkedCts.CancelAfter(RequestTimeout);
+
+            using var response = await Http.SendAsync(request, linkedCts.Token).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                Log.Information("UpdateCheck: GitHub returned {Status}", (int)response.StatusCode);
+                return null;
+            }
+
+            var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return ParseRelease(body);
+        }
+        catch (Exception ex)
+        {
+            Log.Information("UpdateCheck: fetch failed silently ({Type}: {Message})",
+                ex.GetType().Name, ex.Message);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Tolerant parse — only the four fields we need. A schema change on
+    /// GitHub's side won't crash, it'll just yield an UpdateInfo with the
+    /// missing fields blank.
+    /// </summary>
+    internal static UpdateInfo? ParseRelease(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+        try
+        {
+            var token = JToken.Parse(json);
+            if (token.Type != JTokenType.Object) return null;
+
+            var obj = (JObject)token;
+            var info = new UpdateInfo
+            {
+                TagName = (string?)obj["tag_name"] ?? "",
+                Name = (string?)obj["name"] ?? "",
+                HtmlUrl = (string?)obj["html_url"] ?? "",
+                Body = (string?)obj["body"] ?? "",
+                PreRelease = (bool?)obj["prerelease"] ?? false,
+                PublishedAt = (DateTime?)obj["published_at"],
+            };
+            return string.IsNullOrEmpty(info.TagName) ? null : info;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string GetAssemblyVersion() =>
+        typeof(GitHubReleaseFetcher).Assembly.GetName().Version?.ToString() ?? "0.0.0";
+
+    private static HttpClient CreateHttpClient()
+    {
+        System.Net.ServicePointManager.SecurityProtocol =
+            System.Net.SecurityProtocolType.Tls12 |
+            System.Net.SecurityProtocolType.Tls13;
+
+        var handler = new HttpClientHandler
+        {
+            UseProxy = true,
+            UseDefaultCredentials = true
+        };
+        return new HttpClient(handler)
+        {
+            // Belt-and-suspenders: per-request CancelAfter is the primary
+            // bound; this is a hard cap if the linked token stops working.
+            Timeout = TimeSpan.FromSeconds(5)
+        };
+    }
+}

--- a/src/BlockParam/Updates/IReleaseFetcher.cs
+++ b/src/BlockParam/Updates/IReleaseFetcher.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BlockParam.Updates;
+
+/// <summary>
+/// Single seam separating the update-check policy (cache TTL, version
+/// compare, skip-version) from the actual HTTP call. Tests inject a
+/// fake fetcher so the service can be exercised without a network or a
+/// flaky <see cref="System.Net.Http.HttpClient"/>.
+/// </summary>
+public interface IReleaseFetcher
+{
+    /// <summary>
+    /// Fetch the latest published release. Returns null on any failure —
+    /// timeout, non-200 status, parse error, network down. Never throws.
+    /// </summary>
+    Task<UpdateInfo?> FetchLatestAsync(CancellationToken ct);
+}

--- a/src/BlockParam/Updates/IUpdateCheckService.cs
+++ b/src/BlockParam/Updates/IUpdateCheckService.cs
@@ -30,10 +30,4 @@ public interface IUpdateCheckService
     /// or the GitHub call failed and there is no usable cache.
     /// </returns>
     Task<UpdateInfo?> CheckAsync(CancellationToken ct = default);
-
-    /// <summary>
-    /// Persists <c>skippedVersion</c> in the user's config so the dialog
-    /// stops showing the badge until something newer ships.
-    /// </summary>
-    void SkipVersion(string tagName);
 }

--- a/src/BlockParam/Updates/IUpdateCheckService.cs
+++ b/src/BlockParam/Updates/IUpdateCheckService.cs
@@ -1,0 +1,39 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BlockParam.Updates;
+
+/// <summary>
+/// Lightweight, fire-and-forget update check against GitHub Releases.
+/// All methods are safe to call from a background thread and never throw.
+/// </summary>
+public interface IUpdateCheckService
+{
+    /// <summary>
+    /// Returns the latest cached release if one is on disk, regardless of
+    /// staleness — used by the dialog at open time so the badge can render
+    /// instantly without waiting on the network.
+    /// </summary>
+    UpdateInfo? GetCached();
+
+    /// <summary>
+    /// Checks for an update.
+    ///
+    /// Cache-first: when the cache file is &lt; cache TTL old, returns the
+    /// cached result without touching the network. Otherwise issues one
+    /// anonymous GET to GitHub (3 s timeout). Network failures are
+    /// swallowed and resolve to the previous cache (if any) — never an
+    /// exception.
+    /// </summary>
+    /// <returns>
+    /// The latest release info, or null when update checks are disabled
+    /// or the GitHub call failed and there is no usable cache.
+    /// </returns>
+    Task<UpdateInfo?> CheckAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Persists <c>skippedVersion</c> in the user's config so the dialog
+    /// stops showing the badge until something newer ships.
+    /// </summary>
+    void SkipVersion(string tagName);
+}

--- a/src/BlockParam/Updates/UpdateCheckService.cs
+++ b/src/BlockParam/Updates/UpdateCheckService.cs
@@ -1,0 +1,169 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using BlockParam.Diagnostics;
+using Newtonsoft.Json;
+
+namespace BlockParam.Updates;
+
+/// <summary>
+/// Cache-fronted update check.
+///
+/// Cache layout (<c>%APPDATA%\BlockParam\update-check.json</c>):
+/// <code>
+/// { "checkedAt": "2026-05-02T08:00:00Z", "release": { ... UpdateInfo ... } }
+/// </code>
+/// A null/missing release is also cached — so a successful "no newer
+/// version" response doesn't hammer the API on every dialog open.
+///
+/// Network failures never bubble out: <see cref="CheckAsync"/> returns
+/// the previous cache (if any), or null. By contract no consumer should
+/// ever have to <c>try/catch</c> around it.
+/// </summary>
+public sealed class UpdateCheckService : IUpdateCheckService
+{
+    private static readonly TimeSpan DefaultCacheTtl = TimeSpan.FromHours(24);
+
+    private readonly IReleaseFetcher _fetcher;
+    private readonly Func<DateTime> _utcNow;
+    private readonly Func<UpdateCheckSettings> _readSettings;
+    private readonly Action<UpdateCheckSettings> _writeSettings;
+    private readonly VersionTag _currentVersion;
+    private readonly string _cachePath;
+    private readonly TimeSpan _cacheTtl;
+
+    public UpdateCheckService(
+        IReleaseFetcher fetcher,
+        VersionTag currentVersion,
+        string cachePath,
+        Func<UpdateCheckSettings> readSettings,
+        Action<UpdateCheckSettings> writeSettings,
+        Func<DateTime>? utcNow = null,
+        TimeSpan? cacheTtl = null)
+    {
+        _fetcher = fetcher;
+        _currentVersion = currentVersion;
+        _cachePath = cachePath;
+        _readSettings = readSettings;
+        _writeSettings = writeSettings;
+        _utcNow = utcNow ?? (() => DateTime.UtcNow);
+        _cacheTtl = cacheTtl ?? DefaultCacheTtl;
+    }
+
+    public UpdateInfo? GetCached()
+    {
+        var cache = LoadCache();
+        return AsActionable(cache?.Release);
+    }
+
+    public async Task<UpdateInfo?> CheckAsync(CancellationToken ct = default)
+    {
+        var settings = SafeReadSettings();
+        if (!settings.Enabled)
+            return null;
+
+        var cache = LoadCache();
+        if (cache != null && _utcNow() - cache.CheckedAt < _cacheTtl)
+            return AsActionable(cache.Release, settings);
+
+        UpdateInfo? release;
+        try
+        {
+            release = await _fetcher.FetchLatestAsync(ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // The fetcher contract is "never throw," but defend against a
+            // misbehaving custom IReleaseFetcher (or test double) so the
+            // UI thread can't be poisoned by an update check.
+            Log.Warning(ex, "UpdateCheck: fetcher threw — falling back to previous cache");
+            release = cache?.Release;
+        }
+
+        // Fetch failed entirely AND we have nothing on disk: don't write
+        // an empty cache, callers should be able to retry sooner.
+        if (release == null && cache == null)
+            return null;
+
+        SaveCache(new CacheEnvelope { CheckedAt = _utcNow(), Release = release ?? cache?.Release });
+        return AsActionable(release ?? cache?.Release, settings);
+    }
+
+    public void SkipVersion(string tagName)
+    {
+        var settings = SafeReadSettings();
+        settings.SkippedVersion = tagName;
+        try { _writeSettings(settings); }
+        catch (Exception ex) { Log.Warning(ex, "UpdateCheck: cannot persist SkippedVersion"); }
+    }
+
+    private UpdateInfo? AsActionable(UpdateInfo? release) =>
+        AsActionable(release, SafeReadSettings());
+
+    private UpdateInfo? AsActionable(UpdateInfo? release, UpdateCheckSettings settings)
+    {
+        if (release == null) return null;
+        if (!settings.Enabled) return null;
+        if (release.PreRelease && !settings.IncludePrereleases) return null;
+        if (!VersionTag.TryParse(release.TagName, out var releaseVersion)) return null;
+        if (releaseVersion.CompareTo(_currentVersion) <= 0) return null;
+
+        // "Skip this version" applies until something newer ships.
+        if (!string.IsNullOrEmpty(settings.SkippedVersion) &&
+            VersionTag.TryParse(settings.SkippedVersion, out var skipped) &&
+            releaseVersion.CompareTo(skipped) <= 0)
+            return null;
+
+        return release;
+    }
+
+    private UpdateCheckSettings SafeReadSettings()
+    {
+        try { return _readSettings() ?? new UpdateCheckSettings(); }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "UpdateCheck: cannot read settings, defaulting to enabled");
+            return new UpdateCheckSettings();
+        }
+    }
+
+    private CacheEnvelope? LoadCache()
+    {
+        try
+        {
+            if (!File.Exists(_cachePath)) return null;
+            return JsonConvert.DeserializeObject<CacheEnvelope>(File.ReadAllText(_cachePath));
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "UpdateCheck: cannot read cache {Path}", _cachePath);
+            return null;
+        }
+    }
+
+    private void SaveCache(CacheEnvelope envelope)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_cachePath);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+            File.WriteAllText(_cachePath, JsonConvert.SerializeObject(envelope, Formatting.Indented));
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "UpdateCheck: cannot write cache {Path}", _cachePath);
+        }
+    }
+
+    // Public so Newtonsoft.Json can deserialize under TIA's CAS sandbox
+    // (matches the LocalUsageTracker.UsageData rationale).
+    public sealed class CacheEnvelope
+    {
+        [JsonProperty("checkedAt")]
+        public DateTime CheckedAt { get; set; }
+
+        [JsonProperty("release")]
+        public UpdateInfo? Release { get; set; }
+    }
+}

--- a/src/BlockParam/Updates/UpdateCheckService.cs
+++ b/src/BlockParam/Updates/UpdateCheckService.cs
@@ -27,7 +27,6 @@ public sealed class UpdateCheckService : IUpdateCheckService
     private readonly IReleaseFetcher _fetcher;
     private readonly Func<DateTime> _utcNow;
     private readonly Func<UpdateCheckSettings> _readSettings;
-    private readonly Action<UpdateCheckSettings> _writeSettings;
     private readonly VersionTag _currentVersion;
     private readonly string _cachePath;
     private readonly TimeSpan _cacheTtl;
@@ -37,7 +36,6 @@ public sealed class UpdateCheckService : IUpdateCheckService
         VersionTag currentVersion,
         string cachePath,
         Func<UpdateCheckSettings> readSettings,
-        Action<UpdateCheckSettings> writeSettings,
         Func<DateTime>? utcNow = null,
         TimeSpan? cacheTtl = null)
     {
@@ -45,7 +43,6 @@ public sealed class UpdateCheckService : IUpdateCheckService
         _currentVersion = currentVersion;
         _cachePath = cachePath;
         _readSettings = readSettings;
-        _writeSettings = writeSettings;
         _utcNow = utcNow ?? (() => DateTime.UtcNow);
         _cacheTtl = cacheTtl ?? DefaultCacheTtl;
     }
@@ -89,14 +86,6 @@ public sealed class UpdateCheckService : IUpdateCheckService
         return AsActionable(release ?? cache?.Release, settings);
     }
 
-    public void SkipVersion(string tagName)
-    {
-        var settings = SafeReadSettings();
-        settings.SkippedVersion = tagName;
-        try { _writeSettings(settings); }
-        catch (Exception ex) { Log.Warning(ex, "UpdateCheck: cannot persist SkippedVersion"); }
-    }
-
     private UpdateInfo? AsActionable(UpdateInfo? release) =>
         AsActionable(release, SafeReadSettings());
 
@@ -107,12 +96,6 @@ public sealed class UpdateCheckService : IUpdateCheckService
         if (release.PreRelease && !settings.IncludePrereleases) return null;
         if (!VersionTag.TryParse(release.TagName, out var releaseVersion)) return null;
         if (releaseVersion.CompareTo(_currentVersion) <= 0) return null;
-
-        // "Skip this version" applies until something newer ships.
-        if (!string.IsNullOrEmpty(settings.SkippedVersion) &&
-            VersionTag.TryParse(settings.SkippedVersion, out var skipped) &&
-            releaseVersion.CompareTo(skipped) <= 0)
-            return null;
 
         return release;
     }

--- a/src/BlockParam/Updates/UpdateCheckSettings.cs
+++ b/src/BlockParam/Updates/UpdateCheckSettings.cs
@@ -1,0 +1,35 @@
+using Newtonsoft.Json;
+
+namespace BlockParam.Updates;
+
+/// <summary>
+/// Persisted in <c>%APPDATA%\BlockParam\config.json</c> under the
+/// <c>updateCheck</c> key. An IT-deployed override at
+/// <c>%PROGRAMDATA%\BlockParam\config.json</c> wins when present
+/// (matches the managed-license pattern from #20).
+/// </summary>
+public sealed class UpdateCheckSettings
+{
+    /// <summary>
+    /// Master opt-out. When false the service never hits the network and
+    /// the dialog never shows the "update available" badge. Air-gapped
+    /// engineering networks set this via GPO.
+    /// </summary>
+    [JsonProperty("enabled")]
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Show pre-release tags as updates too. Off by default — most users
+    /// shouldn't be nudged toward an rc build.
+    /// </summary>
+    [JsonProperty("includePrereleases")]
+    public bool IncludePrereleases { get; set; }
+
+    /// <summary>
+    /// Tag the user clicked "Skip this version" on (e.g. <c>v0.4.0</c>).
+    /// Suppress the badge while a release with this tag is the latest;
+    /// re-show on any newer version.
+    /// </summary>
+    [JsonProperty("skippedVersion")]
+    public string? SkippedVersion { get; set; }
+}

--- a/src/BlockParam/Updates/UpdateCheckSettings.cs
+++ b/src/BlockParam/Updates/UpdateCheckSettings.cs
@@ -24,12 +24,4 @@ public sealed class UpdateCheckSettings
     /// </summary>
     [JsonProperty("includePrereleases")]
     public bool IncludePrereleases { get; set; }
-
-    /// <summary>
-    /// Tag the user clicked "Skip this version" on (e.g. <c>v0.4.0</c>).
-    /// Suppress the badge while a release with this tag is the latest;
-    /// re-show on any newer version.
-    /// </summary>
-    [JsonProperty("skippedVersion")]
-    public string? SkippedVersion { get; set; }
 }

--- a/src/BlockParam/Updates/UpdateInfo.cs
+++ b/src/BlockParam/Updates/UpdateInfo.cs
@@ -1,0 +1,30 @@
+using Newtonsoft.Json;
+
+namespace BlockParam.Updates;
+
+/// <summary>
+/// One parsed GitHub Release entry (the subset BlockParam cares about).
+/// Persisted as-is into the on-disk cache so a stale-cache load yields the
+/// same object the live fetch would have.
+/// </summary>
+public sealed class UpdateInfo
+{
+    [JsonProperty("tagName")]
+    public string TagName { get; set; } = "";
+
+    [JsonProperty("name")]
+    public string Name { get; set; } = "";
+
+    [JsonProperty("htmlUrl")]
+    public string HtmlUrl { get; set; } = "";
+
+    /// <summary>Raw markdown release notes from the GitHub API.</summary>
+    [JsonProperty("body")]
+    public string Body { get; set; } = "";
+
+    [JsonProperty("prerelease")]
+    public bool PreRelease { get; set; }
+
+    [JsonProperty("publishedAt")]
+    public DateTime? PublishedAt { get; set; }
+}

--- a/src/BlockParam/Updates/VersionTag.cs
+++ b/src/BlockParam/Updates/VersionTag.cs
@@ -1,0 +1,140 @@
+using System.Globalization;
+
+namespace BlockParam.Updates;
+
+/// <summary>
+/// Parsed semver-ish release tag (e.g. <c>v0.4.0</c>, <c>0.4.0-rc1</c>).
+/// Compares using the SemVer 2.0 precedence rule: any pre-release sorts
+/// BEFORE the matching plain version, and pre-release ids compare
+/// numerically when both sides parse as integers, lexicographically
+/// otherwise. The leading <c>v</c> is optional and stripped on parse.
+/// </summary>
+public sealed class VersionTag : IComparable<VersionTag>, IEquatable<VersionTag>
+{
+    public int Major { get; }
+    public int Minor { get; }
+    public int Patch { get; }
+    /// <summary>Empty for stable releases; e.g. "rc1", "beta.2".</summary>
+    public string PreRelease { get; }
+    /// <summary>Original input — preserved so callers can echo it back ("v0.4.0").</summary>
+    public string Raw { get; }
+
+    public bool IsPreRelease => PreRelease.Length > 0;
+
+    private VersionTag(int major, int minor, int patch, string preRelease, string raw)
+    {
+        Major = major;
+        Minor = minor;
+        Patch = patch;
+        PreRelease = preRelease;
+        Raw = raw;
+    }
+
+    public static bool TryParse(string? input, out VersionTag tag)
+    {
+        tag = default!;
+        if (string.IsNullOrWhiteSpace(input)) return false;
+
+        var s = input!.Trim();
+        var raw = s;
+        if (s.Length > 0 && (s[0] == 'v' || s[0] == 'V')) s = s.Substring(1);
+
+        var preIdx = s.IndexOf('-');
+        var pre = "";
+        if (preIdx >= 0)
+        {
+            pre = s.Substring(preIdx + 1);
+            s = s.Substring(0, preIdx);
+        }
+
+        // Strip build metadata (+...) — irrelevant for ordering per SemVer.
+        var buildIdx = pre.IndexOf('+');
+        if (buildIdx >= 0) pre = pre.Substring(0, buildIdx);
+
+        var plusIdx = s.IndexOf('+');
+        if (plusIdx >= 0) s = s.Substring(0, plusIdx);
+
+        var parts = s.Split('.');
+        if (parts.Length is < 1 or > 3) return false;
+
+        if (!int.TryParse(parts[0], NumberStyles.None, CultureInfo.InvariantCulture, out int major))
+            return false;
+        int minor = 0, patch = 0;
+        if (parts.Length >= 2 &&
+            !int.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out minor))
+            return false;
+        if (parts.Length >= 3 &&
+            !int.TryParse(parts[2], NumberStyles.None, CultureInfo.InvariantCulture, out patch))
+            return false;
+
+        tag = new VersionTag(major, minor, patch, pre, raw);
+        return true;
+    }
+
+    public static VersionTag FromSystemVersion(System.Version version, bool preserveRaw = false)
+    {
+        return new VersionTag(
+            version.Major,
+            Math.Max(0, version.Minor),
+            Math.Max(0, version.Build),
+            preRelease: "",
+            raw: preserveRaw
+                ? version.ToString()
+                : $"{version.Major}.{Math.Max(0, version.Minor)}.{Math.Max(0, version.Build)}");
+    }
+
+    public int CompareTo(VersionTag? other)
+    {
+        if (other is null) return 1;
+        int c = Major.CompareTo(other.Major);
+        if (c != 0) return c;
+        c = Minor.CompareTo(other.Minor);
+        if (c != 0) return c;
+        c = Patch.CompareTo(other.Patch);
+        if (c != 0) return c;
+
+        // SemVer: stable > pre-release.
+        if (PreRelease.Length == 0 && other.PreRelease.Length == 0) return 0;
+        if (PreRelease.Length == 0) return 1;
+        if (other.PreRelease.Length == 0) return -1;
+
+        return ComparePreRelease(PreRelease, other.PreRelease);
+    }
+
+    private static int ComparePreRelease(string a, string b)
+    {
+        var ap = a.Split('.');
+        var bp = b.Split('.');
+        int len = Math.Min(ap.Length, bp.Length);
+        for (int i = 0; i < len; i++)
+        {
+            bool aNum = int.TryParse(ap[i], NumberStyles.None, CultureInfo.InvariantCulture, out int an);
+            bool bNum = int.TryParse(bp[i], NumberStyles.None, CultureInfo.InvariantCulture, out int bn);
+            if (aNum && bNum)
+            {
+                int c = an.CompareTo(bn);
+                if (c != 0) return c;
+            }
+            else if (aNum) return -1;   // numeric < alphanumeric
+            else if (bNum) return 1;
+            else
+            {
+                int c = string.CompareOrdinal(ap[i], bp[i]);
+                if (c != 0) return c;
+            }
+        }
+        return ap.Length.CompareTo(bp.Length);
+    }
+
+    public bool Equals(VersionTag? other) => other is not null && CompareTo(other) == 0;
+
+    public override bool Equals(object? obj) => obj is VersionTag other && Equals(other);
+
+    public override int GetHashCode() =>
+        HashCode.Combine(Major, Minor, Patch, PreRelease);
+
+    public override string ToString() =>
+        IsPreRelease
+            ? $"{Major}.{Minor}.{Patch}-{PreRelease}"
+            : $"{Major}.{Minor}.{Patch}";
+}

--- a/src/BlockParam/addin-publisher-v20.xml
+++ b/src/BlockParam/addin-publisher-v20.xml
@@ -40,10 +40,10 @@
         <Comment>Resolve SpecialFolder.ApplicationData and MachineName for per-user storage paths and machine-bound license obfuscation.</Comment>
       </System.Security.Permissions.EnvironmentPermission>
       <System.Net.WebPermission>
-        <Comment>HttpClient calls to the BlockParam license server for online license activation and validation.</Comment>
+        <Comment>HttpClient calls to the BlockParam license server for online license activation and validation, and an anonymous once-per-day GET to api.github.com/repos/Sawascwoolf/BlockParam/releases/latest for the in-app "update available" notice (#61).</Comment>
       </System.Net.WebPermission>
       <Siemens.Engineering.AddIn.Permissions.ProcessStartPermission>
-        <Comment>Launch default browser via Process.Start(UseShellExecute=true) to open shop checkout and customer-portal URLs from the license dialog.</Comment>
+        <Comment>Launch default browser via Process.Start(UseShellExecute=true) to open shop checkout and customer-portal URLs from the license dialog, and the GitHub release page from the "update available" dialog (#61).</Comment>
       </Siemens.Engineering.AddIn.Permissions.ProcessStartPermission>
       <System.Security.Permissions.SecurityPermission.UnmanagedCode>
         <Comment>Required transitively by WPF rendering, HttpClient socket I/O, and Newtonsoft.Json reflection-emit serialization.</Comment>

--- a/src/BlockParam/addin-publisher-v21.xml
+++ b/src/BlockParam/addin-publisher-v21.xml
@@ -40,10 +40,10 @@
         <Comment>Resolve SpecialFolder.ApplicationData and MachineName for per-user storage paths and machine-bound license obfuscation.</Comment>
       </System.Security.Permissions.EnvironmentPermission>
       <System.Net.WebPermission>
-        <Comment>HttpClient calls to the BlockParam license server for online license activation and validation.</Comment>
+        <Comment>HttpClient calls to the BlockParam license server for online license activation and validation, and an anonymous once-per-day GET to api.github.com/repos/Sawascwoolf/BlockParam/releases/latest for the in-app "update available" notice (#61).</Comment>
       </System.Net.WebPermission>
       <Siemens.Engineering.AddIn.Permissions.ProcessStartPermission>
-        <Comment>Launch default browser via Process.Start(UseShellExecute=true) to open shop checkout and customer-portal URLs from the license dialog.</Comment>
+        <Comment>Launch default browser via Process.Start(UseShellExecute=true) to open shop checkout and customer-portal URLs from the license dialog, and the GitHub release page from the "update available" dialog (#61).</Comment>
       </Siemens.Engineering.AddIn.Permissions.ProcessStartPermission>
       <System.Security.Permissions.SecurityPermission.UnmanagedCode>
         <Comment>Required transitively by WPF rendering, HttpClient socket I/O, and Newtonsoft.Json reflection-emit serialization.</Comment>


### PR DESCRIPTION
## Summary

Adds a compact, opt-out update notice driven by GitHub Releases. The Bulk Change dialog shows a footer badge when a newer version ships; clicking it opens a details popup with the changelog and an "Open download page" button.

- **Daily check, cache-fronted** — `UpdateCheckService` hits `api.github.com/repos/Sawascwoolf/BlockParam/releases/latest` at most once every 24 h. Network failures are swallowed and resolve to the previous cache.
- **Opt-out** via `updateCheck.enabled` in `%APPDATA%\BlockParam\config.json`. IT-deployed override at `%PROGRAMDATA%\BlockParam\config.json` wins for air-gapped engineering networks.
- **Pre-release tags hidden** by default; togglable from the License/About dialog.
- **SemVer-aware** `VersionTag` handles `-rc` / `-beta` suffixes per the issue spec.

### Polish in this PR (post-original commit)

- **Drop "Skip this version"** — the footer badge is unobtrusive enough that a per-version mute escape hatch isn't worth the API surface (`IUpdateCheckService.SkipVersion`, `UpdateCheckSettings.SkippedVersion`, IT-managed override path, en/de resource keys, related tests all removed).
- **Auto-size dialog buttons** so localized strings (e.g. German "Download-Seite öffnen") no longer get clipped by fixed widths.
- **Wire DevLauncher** with an `UpdateCheckService` so the badge and dialog can be exercised without TIA Portal — drop a fake `update-check.json` into `%APPDATA%\BlockParam\` and the badge appears instantly via the cached read.
- Fixed a pre-existing infinite-recursion bug in `UpdateCheckSettingsConfigTests.Build()` that was crashing the test host with a `StackOverflowException` once the suite started running again.

Closes #61

## Test plan

- [x] `dotnet test src/BlockParam.Tests` — all 522 tests green
- [x] DevLauncher: badge renders, click opens dialog with two right-aligned buttons (Remind me later / Open download page), no Skip button
- [x] German locale: button labels no longer clipped
- [ ] Verify in TIA Portal V20: install a build older than the latest GitHub release, open a DB → Bulk Change… → badge appears bottom-right
- [ ] Verify the IT-managed override (`%PROGRAMDATA%\BlockParam\config.json` with `updateCheck.enabled: false`) suppresses the badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)