### PR TITLE
Fix bulk Set button count to match would-actually-change members

### DIFF
--- a/src/BlockParam.Tests/BulkChangeViewModelTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelTests.cs
@@ -148,4 +148,66 @@ public class BulkChangeViewModelTests : IDisposable
         vm.ApplyCommand.CanExecute(null).Should().BeTrue(
             "a pre-existing violation on Speed must not block applying a valid pending edit on Enable");
     }
+
+    /// <summary>
+    /// #65: SetButtonText must reflect the count of members that will actually
+    /// be staged (effective value differs from NewValue), not the raw scope
+    /// size. Previously the button advertised "Set 6 in 'X'" even when 5 of
+    /// those 6 already held the target value — only 1 ended up pending after
+    /// click, confusing the user and skewing per-change quota math.
+    /// </summary>
+    [Fact]
+    public void SetButtonText_counts_only_members_that_will_actually_change()
+    {
+        var vm = CreateViewModelWithRule("udt-instances-db.xml", @"{ ""rules"": [] }");
+
+        FlatTreeManager.ExpandAll(vm.RootMembers);
+        vm.RefreshFlatList();
+
+        // Fixture has 4 ModuleId leaves, all already at "42".
+        var moduleId = vm.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
+        vm.SelectedFlatMember = moduleId;
+
+        var dbScope = vm.AvailableScopes.First(s => s.MatchCount == 4);
+        vm.SelectedScope = dbScope;
+
+        vm.NewValue = "42"; // matches every selected member — 0 would change
+        vm.SetButtonText.Should().Be("Set 0 in 'UdtInstancesDB'",
+            "all 4 already hold '42' so the button must advertise 0, not 4");
+        vm.SetPendingCommand.CanExecute(null).Should().BeFalse(
+            "enable state and label come from the same predicate");
+
+        vm.NewValue = "99"; // different — all 4 would change
+        vm.SetButtonText.Should().Be("Set 4 in 'UdtInstancesDB'");
+        vm.SetPendingCommand.CanExecute(null).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// #65: Manual-select label (Ctrl+Click multi-select) is also bound by the
+    /// same "would actually change" predicate. Selecting 4 members where 3
+    /// already match the typed value must show "Set 1 selected", not 4.
+    /// </summary>
+    [Fact]
+    public void SetButtonText_manual_mode_excludes_already_matching_members()
+    {
+        var vm = CreateViewModelWithRule("udt-instances-db.xml", @"{ ""rules"": [] }");
+
+        FlatTreeManager.ExpandAll(vm.RootMembers);
+        vm.RefreshFlatList();
+
+        // Pick 3 ModuleId leaves (all "42") + 1 MessageId leaf (e.g. "101").
+        var moduleIds = vm.FlatMembers.Where(m => m.Name == "ModuleId" && m.IsLeaf).Take(3).ToList();
+        var messageId = vm.FlatMembers.First(m => m.Name == "MessageId" && m.IsLeaf);
+        var picks = moduleIds.Concat(new[] { messageId }).ToList();
+
+        vm.UpdateManualSelection(picks, Array.Empty<MemberNodeViewModel>(), false);
+        vm.IsManualMode.Should().BeTrue();
+
+        // Type "42": three ModuleIds already match, the MessageId ("101") doesn't.
+        // Only 1 member would actually change.
+        vm.NewValue = "42";
+        vm.SetButtonText.Should().Be(BlockParam.Localization.Res.Format("Dialog_SetManualCount", 1),
+            "3 of 4 selected members already hold '42' so only 1 would actually change");
+        vm.SetPendingCommand.CanExecute(null).Should().BeTrue();
+    }
 }

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -142,6 +142,10 @@ Dies kann nicht rückgängig gemacht werden.</value></data>
   <data name="Dialog_Constants" xml:space="preserve"><value>Konstanten</value></data>
   <data name="Dialog_RefreshConstants" xml:space="preserve"><value>Konstanten aktualisieren</value></data>
   <data name="Dialog_SetTooltip" xml:space="preserve"><value>Bulk-Werte als ausstehend markieren (gelb)</value></data>
+  <data name="Dialog_SetTooltip_ScopeIdle" xml:space="preserve"><value>{0} Element(e) in '{1}'</value></data>
+  <data name="Dialog_SetTooltip_ManualIdle" xml:space="preserve"><value>{0} Element(e) ausgewählt</value></data>
+  <data name="Dialog_SetTooltip_ScopeBreakdown" xml:space="preserve"><value>{0} von {1} in '{2}' werden gesetzt · {3} bereits auf diesem Wert</value></data>
+  <data name="Dialog_SetTooltip_ManualBreakdown" xml:space="preserve"><value>{0} von {1} ausgewählten werden gesetzt · {2} bereits auf diesem Wert</value></data>
   <data name="Dialog_LimitReachedOverlay_Title" xml:space="preserve"><value>Tägliches Gratis-Limit erreicht</value></data>
   <data name="Dialog_LimitReachedOverlay_Text" xml:space="preserve"><value>Upgrade auf Pro für unbegrenzte Massenänderungen, oder bis morgen warten.</value></data>
   <!-- Manuelle Mehrfachauswahl -->

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -350,6 +350,22 @@ This cannot be undone.</value>
   <data name="Dialog_SetTooltip" xml:space="preserve">
     <value>Stage bulk values as pending (yellow)</value>
   </data>
+  <data name="Dialog_SetTooltip_ScopeIdle" xml:space="preserve">
+    <value>{0} member(s) in '{1}'</value>
+    <comment>{0} = total scope size, {1} = ancestor name. Shown when no value is typed.</comment>
+  </data>
+  <data name="Dialog_SetTooltip_ManualIdle" xml:space="preserve">
+    <value>{0} member(s) selected</value>
+    <comment>{0} = total manual selection. Shown when no value is typed.</comment>
+  </data>
+  <data name="Dialog_SetTooltip_ScopeBreakdown" xml:space="preserve">
+    <value>{0} of {1} in '{2}' will be staged · {3} already at this value</value>
+    <comment>{0} = will-stage count, {1} = total scope, {2} = ancestor name, {3} = already-match count</comment>
+  </data>
+  <data name="Dialog_SetTooltip_ManualBreakdown" xml:space="preserve">
+    <value>{0} of {1} selected will be staged · {2} already at this value</value>
+    <comment>{0} = will-stage count, {1} = total selected, {2} = already-match count</comment>
+  </data>
   <data name="Dialog_LimitReachedOverlay_Title" xml:space="preserve">
     <value>Daily free limit reached</value>
   </data>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -739,7 +739,7 @@
                                                 Height="28" Margin="12,10,12,6"
                                                 Background="#1f6feb" Foreground="White"
                                                 BorderThickness="0" FontWeight="SemiBold"
-                                                ToolTip="{loc:Loc Dialog_SetTooltip}"
+                                                ToolTip="{Binding SetButtonTooltip}"
                                                 Visibility="{Binding CanEdit, Converter={StaticResource BoolToVis}}"/>
 
                                         <!-- Overlap warning: bulk will overwrite existing pending edits -->

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -372,6 +372,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                         ValidateValue();
                         UpdateFilteredSuggestions();
                         UpdateHighlighting();
+                        OnPropertyChanged(nameof(SetButtonText));
                     }));
                 }, null, 150, Timeout.Infinite);
             }
@@ -514,9 +515,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         get
         {
             if (IsManualMode)
-                return Res.Format("Dialog_SetManualCount", _manualSelectedPaths.Count);
+                return Res.Format("Dialog_SetManualCount", CountWouldChangeMembers());
             return _selectedScope != null
-                ? $"Set {_selectedScope.MatchCount} in '{_selectedScope.AncestorName}'"
+                ? $"Set {CountWouldChangeMembers()} in '{_selectedScope.AncestorName}'"
                 : "Set";
         }
     }
@@ -1739,39 +1740,50 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         if (IsManualMode)
         {
-            // Blocked when selection mixes datatypes.
             if (!IsSelectionTypeHomogeneous) return false;
-
-            // At least one selected member must actually change.
-            return _manualSelectedPaths.Any(p =>
-            {
-                var node = FindNodeByPath(p);
-                if (node == null || !node.IsLeaf) return false;
-                var effective = node.IsPendingInlineEdit
-                    ? (node.EditableStartValue ?? node.StartValue ?? "")
-                    : (node.StartValue ?? "");
-                return !string.Equals(effective, _newValue, StringComparison.OrdinalIgnoreCase);
-            });
+            return CountWouldChangeMembers() > 0;
         }
 
         if (!HasSelection || !HasScope) return false;
 
-        // Disabled when all affected members already have the target value
-        if (_selectedScope != null)
+        return CountWouldChangeMembers() > 0;
+    }
+
+    /// <summary>
+    /// Count of members that will actually be staged when Set Pending runs —
+    /// i.e. those whose effective start value differs from <c>NewValue</c>.
+    /// Shared by <see cref="CanExecuteSetPending"/> and <see cref="SetButtonText"/>
+    /// so the button's enable state and advertised count cannot drift apart (#65).
+    /// </summary>
+    private int CountWouldChangeMembers()
+    {
+        if (IsManualMode)
         {
-            var wouldChange = _selectedScope.MatchingMembers.Any(m =>
+            return _manualSelectedPaths.Count(p =>
             {
-                var node = FindNodeByPath(m.Path);
-                if (node == null) return true;
-                var effective = node.IsPendingInlineEdit
-                    ? (node.EditableStartValue ?? node.StartValue ?? "")
-                    : (node.StartValue ?? "");
-                return !string.Equals(effective, _newValue, StringComparison.OrdinalIgnoreCase);
+                var node = FindNodeByPath(p);
+                if (node == null || !node.IsLeaf) return false;
+                return WouldChange(node);
             });
-            if (!wouldChange) return false;
         }
 
-        return true;
+        if (_selectedScope == null) return 0;
+
+        return _selectedScope.MatchingMembers.Count(m =>
+        {
+            var node = FindNodeByPath(m.Path);
+            // Unresolved paths can't be staged by SetPendingOnNodes, so don't
+            // count them — that's exactly the inflation the old label had.
+            return node != null && WouldChange(node);
+        });
+    }
+
+    private bool WouldChange(MemberNodeViewModel node)
+    {
+        var effective = node.IsPendingInlineEdit
+            ? (node.EditableStartValue ?? node.StartValue ?? "")
+            : (node.StartValue ?? "");
+        return !string.Equals(effective, _newValue ?? "", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -348,6 +348,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                 OnPropertyChanged(nameof(HasScope));
                 OnPropertyChanged(nameof(CanEdit));
                 OnPropertyChanged(nameof(SetButtonText));
+                OnPropertyChanged(nameof(SetButtonTooltip));
             }
         }
     }
@@ -373,6 +374,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                         UpdateFilteredSuggestions();
                         UpdateHighlighting();
                         OnPropertyChanged(nameof(SetButtonText));
+                        OnPropertyChanged(nameof(SetButtonTooltip));
                     }));
                 }, null, 150, Timeout.Infinite);
             }
@@ -519,6 +521,40 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             return _selectedScope != null
                 ? $"Set {CountWouldChangeMembers()} in '{_selectedScope.AncestorName}'"
                 : "Set";
+        }
+    }
+
+    /// <summary>
+    /// Two-line tooltip for the Set button: action description + count breakdown.
+    /// Surfaces the total scope size so users still see "40 valves selected" even
+    /// when the button label drops to "Set 35" because 5 already match (#65).
+    /// </summary>
+    public string SetButtonTooltip
+    {
+        get
+        {
+            var action = Res.Get("Dialog_SetTooltip");
+            if (!CanEdit) return action;
+
+            int total = TotalCandidateMembers();
+            int willChange = CountWouldChangeMembers();
+            int alreadyMatch = total - willChange;
+
+            string breakdown;
+            if (string.IsNullOrEmpty(_newValue))
+            {
+                breakdown = IsManualMode
+                    ? Res.Format("Dialog_SetTooltip_ManualIdle", total)
+                    : Res.Format("Dialog_SetTooltip_ScopeIdle", total, _selectedScope?.AncestorName ?? "");
+            }
+            else
+            {
+                breakdown = IsManualMode
+                    ? Res.Format("Dialog_SetTooltip_ManualBreakdown", willChange, total, alreadyMatch)
+                    : Res.Format("Dialog_SetTooltip_ScopeBreakdown",
+                        willChange, total, _selectedScope?.AncestorName ?? "", alreadyMatch);
+            }
+            return action + "\n" + breakdown;
         }
     }
 
@@ -1787,6 +1823,24 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     }
 
     /// <summary>
+    /// Total members in the active scope or manual selection — the denominator
+    /// for the tooltip's "X of Y will be staged" breakdown. Counts only paths
+    /// that resolve to a leaf so it matches what SetPendingOnNodes can act on.
+    /// </summary>
+    private int TotalCandidateMembers()
+    {
+        if (IsManualMode)
+        {
+            return _manualSelectedPaths.Count(p =>
+            {
+                var node = FindNodeByPath(p);
+                return node != null && node.IsLeaf;
+            });
+        }
+        return _selectedScope?.MatchCount ?? 0;
+    }
+
+    /// <summary>
     /// Stages bulk scope or manual-selection values as pending on each affected node.
     /// Does NOT modify XML — values turn yellow until Apply is clicked.
     /// </summary>
@@ -2482,6 +2536,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         OnPropertyChanged(nameof(HasScope));
         OnPropertyChanged(nameof(CanEdit));
         OnPropertyChanged(nameof(SetButtonText));
+        OnPropertyChanged(nameof(SetButtonTooltip));
         OnPropertyChanged(nameof(SelectedMemberDisplay));
 
         // Entering manual mode: the scope-based highlighting from the single
@@ -2575,6 +2630,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         OnPropertyChanged(nameof(HasScope));
         OnPropertyChanged(nameof(CanEdit));
         OnPropertyChanged(nameof(SetButtonText));
+        OnPropertyChanged(nameof(SetButtonTooltip));
         OnPropertyChanged(nameof(SelectedMemberDisplay));
 
         ValidateValue();


### PR DESCRIPTION
## Summary
- Bulk Set button label now uses the same "would actually change" predicate as `CanExecuteSetPending`, so the count matches the staged-pending count after click.
- Set tooltip surfaces the full breakdown (in-scope vs. would-change vs. already-matching) so the user can see *why* the number is what it is.
- Resolves the #62 cap-math confusion: each staged edit now corresponds to exactly one quota unit promised on the button.

## Test plan
- [x] Unit: `SetButtonText_counts_only_members_that_will_actually_change` (scope mode)
- [x] Unit: `SetButtonText_manual_mode_excludes_already_matching_members` (Ctrl+Click multi-select)
- [x] Full suite: 524/524 passing after merge with main
- [ ] Manual: open a DB with several already-matching members, type matching value, confirm Set reads "Set 0 …" and is disabled

Closes #65