### PR TITLE
Rule editor UX: file/rule split, inspector chrome, multi-rule round-trip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ Thumbs.db
 ## Claude Code worktrees (agent scratch dirs, separate git worktrees)
 .claude/worktrees/
 
+## Repo-local scratch dir for ad-hoc debug artifacts (copied logs, dumps, etc.).
+.tmp/
+
 ## Claude Code per-developer settings (contain local paths, personal allowlists)
 .claude/settings.json
 .claude/settings.local.json

--- a/assets/fixtures/rules/motor.json
+++ b/assets/fixtures/rules/motor.json
@@ -1,0 +1,33 @@
+{
+  "version": "1.0",
+  "rules": [
+    {
+      "pathPattern": ".*\\.startTime$",
+      "datatype": "Time",
+      "constraints": { "min": "T#100ms", "max": "T#10s" },
+      "commentTemplate": "Ramp-up time for motor {parent}"
+    },
+    {
+      "pathPattern": ".*\\.maxSpeed$",
+      "datatype": "Real",
+      "constraints": { "min": 0, "max": 1500 }
+    },
+    {
+      "pathPattern": ".*\\.direction$",
+      "datatype": "Int",
+      "constraints": { "allowedValues": [0, 1, 2] },
+      "commentTemplate": "0 = stop, 1 = forward, 2 = reverse"
+    },
+    {
+      "pathPattern": ".*\\.tagName$",
+      "tagTableReference": { "tableName": "MOTOR_TAGS" },
+      "constraints": { "requireTagTableValue": true }
+    },
+    {
+      "pathPattern": ".*\\.thermalCutoff$",
+      "datatype": "Real",
+      "constraints": { "min": 40, "max": 130 },
+      "excludeFromSetpoints": true
+    }
+  ]
+}

--- a/src/BlockParam.Tests/ConfigEditorViewModelTests.cs
+++ b/src/BlockParam.Tests/ConfigEditorViewModelTests.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Threading;
 using FluentAssertions;
 using BlockParam.Config;
 using BlockParam.UI;
@@ -273,7 +275,7 @@ public class ConfigEditorViewModelTests : IDisposable
     }
 
     [Fact]
-    public void Validation_RuleMissingPathPattern_ShowsWarning()
+    public void Validation_RuleMissingPathPattern_ShowsWarning() => WithEnglishUICulture(() =>
     {
         var loader = CreateLoader();
         var vm = new ConfigEditorViewModel(loader);
@@ -282,10 +284,10 @@ public class ConfigEditorViewModelTests : IDisposable
         vm.SaveCommand.Execute(null);
 
         vm.ValidationMessage.Should().Contain("path pattern");
-    }
+    });
 
     [Fact]
-    public void Validation_MinGreaterThanMax_ShowsWarning()
+    public void Validation_MinGreaterThanMax_ShowsWarning() => WithEnglishUICulture(() =>
     {
         var loader = CreateLoader();
         var vm = new ConfigEditorViewModel(loader);
@@ -298,7 +300,7 @@ public class ConfigEditorViewModelTests : IDisposable
         vm.SaveCommand.Execute(null);
 
         vm.ValidationMessage.Should().Contain("Min");
-    }
+    });
 
     [Fact]
     public void Load_MultipleFiles_SortedAlphabetically()
@@ -424,7 +426,7 @@ public class ConfigEditorViewModelTests : IDisposable
     }
 
     [Fact]
-    public void HeaderSummary_ReflectsRuleCount()
+    public void HeaderSummary_ReflectsRuleCount() => WithEnglishUICulture(() =>
     {
         var loader = CreateLoader();
         var vm = new ConfigEditorViewModel(loader);
@@ -434,5 +436,19 @@ public class ConfigEditorViewModelTests : IDisposable
 
         vm.NewRuleCommand.Execute(null);
         vm.SelectedFile.HeaderSummary.Should().Contain("2 rules");
+    });
+
+    private static void WithEnglishUICulture(Action action)
+    {
+        var prevUI = Thread.CurrentThread.CurrentUICulture;
+        var prev = Thread.CurrentThread.CurrentCulture;
+        Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
+        Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+        try { action(); }
+        finally
+        {
+            Thread.CurrentThread.CurrentUICulture = prevUI;
+            Thread.CurrentThread.CurrentCulture = prev;
+        }
     }
 }

--- a/src/BlockParam.Tests/ConfigEditorViewModelTests.cs
+++ b/src/BlockParam.Tests/ConfigEditorViewModelTests.cs
@@ -50,9 +50,10 @@ public class ConfigEditorViewModelTests : IDisposable
         vm.RuleFiles.Should().HaveCount(1);
         vm.RuleFiles[0].FileName.Should().Be("moduleId.json");
         vm.RuleFiles[0].FileType.Should().Be("Rule");
-        vm.RuleFiles[0].PathPattern.Should().Be(@".*\.moduleId$");
-        vm.RuleFiles[0].Min.Should().Be("0");
-        vm.RuleFiles[0].Max.Should().Be("9999");
+        vm.RuleFiles[0].Rules.Should().HaveCount(1);
+        vm.RuleFiles[0].Rules[0].PathPattern.Should().Be(@".*\.moduleId$");
+        vm.RuleFiles[0].Rules[0].Min.Should().Be("0");
+        vm.RuleFiles[0].Rules[0].Max.Should().Be("9999");
     }
 
     [Fact]
@@ -72,7 +73,7 @@ public class ConfigEditorViewModelTests : IDisposable
 
         vm.RuleFiles.Should().HaveCount(1);
         vm.RuleFiles[0].FileType.Should().Be("Rule");
-        vm.RuleFiles[0].CommentTemplate.Should().Be("{db}.{parent}");
+        vm.RuleFiles[0].Rules[0].CommentTemplate.Should().Be("{db}.{parent}");
     }
 
     [Fact]
@@ -91,7 +92,7 @@ public class ConfigEditorViewModelTests : IDisposable
 
         vm.RuleFiles.Should().HaveCount(1);
         vm.RuleFiles[0].FileType.Should().Be("Rule");
-        vm.RuleFiles[0].ExcludeFromSetpoints.Should().BeTrue();
+        vm.RuleFiles[0].Rules[0].ExcludeFromSetpoints.Should().BeTrue();
     }
 
     [Fact]
@@ -100,19 +101,17 @@ public class ConfigEditorViewModelTests : IDisposable
         var loader = CreateLoader();
         var vm = new ConfigEditorViewModel(loader);
 
-        // Create a new rule via command (no longer prompts for filename)
-        vm.NewRuleCommand.Execute(null);
+        vm.NewFileCommand.Execute(null);
         vm.SelectedFile.Should().NotBeNull();
-        vm.SelectedFile!.PathPattern = @".*\.Speed$";
-        vm.SelectedFile.Datatype = "Int";
-        vm.SelectedFile.Min = "0";
-        vm.SelectedFile.Max = "3000";
-
-        // Filename is auto-derived from path pattern
-        vm.SelectedFile.FileName.Should().Be("_any_.Speed.json");
+        vm.SelectedRule.Should().NotBeNull();
+        vm.SelectedRule!.PathPattern = @".*\.Speed$";
+        vm.SelectedRule.Datatype = "Int";
+        vm.SelectedRule.Min = "0";
+        vm.SelectedRule.Max = "3000";
 
         vm.SaveCommand.Execute(null);
 
+        // Filename is auto-derived from path pattern at save time for new files.
         File.Exists(Path.Combine(_rulesDir, "_any_.Speed.json")).Should().BeTrue();
     }
 
@@ -130,19 +129,73 @@ public class ConfigEditorViewModelTests : IDisposable
         var loader = CreateLoader();
         var vm = new ConfigEditorViewModel(loader);
 
-        // Save without changes
         vm.SaveCommand.Execute(null);
 
         var reloaded = CreateLoader();
         var vm2 = new ConfigEditorViewModel(reloaded);
         vm2.RuleFiles.Should().HaveCount(1);
-        vm2.RuleFiles[0].PathPattern.Should().Be(@".*\.moduleId$");
-        vm2.RuleFiles[0].Min.Should().Be("0");
-        vm2.RuleFiles[0].TagTableName.Should().Be("Const_Modules");
+        vm2.RuleFiles[0].Rules[0].PathPattern.Should().Be(@".*\.moduleId$");
+        vm2.RuleFiles[0].Rules[0].Min.Should().Be("0");
+        vm2.RuleFiles[0].Rules[0].TagTableName.Should().Be("Const_Modules");
+    }
+
+    /// <summary>
+    /// Issue #70: a multi-rule file must round-trip through the editor without
+    /// losing rules 2..N. Previously RuleFileViewModel.FromFile read only
+    /// config.Rules[0] and ToBulkChangeConfig emitted a single rule, so editing
+    /// any field and saving silently destroyed sibling rules.
+    /// </summary>
+    [Fact]
+    public void Save_MultiRuleFile_PreservesAllRules()
+    {
+        WriteRuleFile("udt-family.json", @"{
+            ""version"": ""1.0"",
+            ""rules"": [
+                { ""pathPattern"": "".*{udt:LibTBP_msg_UDT}\\.moduleId$"",  ""tagTableReference"": { ""tableName"": ""CcModule"" } },
+                { ""pathPattern"": "".*{udt:LibTBP_msg_UDT}\\.elementId$"", ""tagTableReference"": { ""tableName"": ""CcElement"" } },
+                { ""pathPattern"": "".*{udt:LibTBP_msg_UDT}\\.messageId$"", ""tagTableReference"": { ""tableName"": ""CcMessage"" } }
+            ]
+        }");
+
+        var loader = CreateLoader();
+        var vm = new ConfigEditorViewModel(loader);
+
+        vm.RuleFiles.Should().HaveCount(1);
+        vm.RuleFiles[0].Rules.Should().HaveCount(3, "all three rules must surface in the editor");
+
+        vm.RuleFiles[0].Rules[0].TagTableName = "CcModule_Renamed";
+        vm.SaveCommand.Execute(null);
+
+        var reloaded = CreateLoader();
+        var vm2 = new ConfigEditorViewModel(reloaded);
+        vm2.RuleFiles.Should().HaveCount(1);
+        vm2.RuleFiles[0].Rules.Should().HaveCount(3, "siblings must not be dropped on save");
+        vm2.RuleFiles[0].Rules[0].TagTableName.Should().Be("CcModule_Renamed");
+        vm2.RuleFiles[0].Rules[1].TagTableName.Should().Be("CcElement");
+        vm2.RuleFiles[0].Rules[2].TagTableName.Should().Be("CcMessage");
     }
 
     [Fact]
-    public void NewRule_CreatesEntryWithAutoName()
+    public void NewRule_AddsToSelectedFile()
+    {
+        WriteRuleFile("existing.json", @"{
+            ""version"": ""1.0"",
+            ""rules"": [{ ""pathPattern"": "".*\\.first$"" }]
+        }");
+        var loader = CreateLoader();
+        var vm = new ConfigEditorViewModel(loader);
+
+        vm.SelectedFile = vm.RuleFiles[0];
+        vm.NewRuleCommand.Execute(null);
+
+        vm.RuleFiles.Should().HaveCount(1, "the file count stays at 1");
+        vm.RuleFiles[0].Rules.Should().HaveCount(2, "a new rule was appended to the existing file");
+        vm.SelectedRule.Should().Be(vm.RuleFiles[0].Rules[1]);
+        vm.SelectedRule!.IsNew.Should().BeTrue();
+    }
+
+    [Fact]
+    public void NewRule_WithNoFileSelected_FallsBackToNewFile()
     {
         var loader = CreateLoader();
         var vm = new ConfigEditorViewModel(loader);
@@ -150,36 +203,73 @@ public class ConfigEditorViewModelTests : IDisposable
         vm.NewRuleCommand.Execute(null);
 
         vm.RuleFiles.Should().HaveCount(1);
+        vm.RuleFiles[0].Rules.Should().HaveCount(1);
+        vm.RuleFiles[0].IsNew.Should().BeTrue();
+    }
+
+    [Fact]
+    public void NewFile_CreatesEntryWithAutoName()
+    {
+        var loader = CreateLoader();
+        var vm = new ConfigEditorViewModel(loader);
+
+        vm.NewFileCommand.Execute(null);
+
+        vm.RuleFiles.Should().HaveCount(1);
         vm.RuleFiles[0].FileName.Should().Be("new-rule.json");
         vm.RuleFiles[0].FileType.Should().Be("Rule");
         vm.RuleFiles[0].IsNew.Should().BeTrue();
-        vm.SelectedFile.Should().Be(vm.RuleFiles[0]);
+        vm.RuleFiles[0].Rules.Should().HaveCount(1);
+        vm.SelectedRule.Should().Be(vm.RuleFiles[0].Rules[0]);
     }
 
     [Fact]
-    public void NewRule_PathPatternAutoSyncsFileName()
+    public void NewFile_PathPatternAutoDerivesFileNameOnSave()
     {
         var loader = CreateLoader();
         var vm = new ConfigEditorViewModel(loader);
 
-        vm.NewRuleCommand.Execute(null);
-        vm.SelectedFile!.PathPattern = @".*\.elementId$";
+        vm.NewFileCommand.Execute(null);
+        vm.SelectedRule!.PathPattern = @".*\.elementId$";
+        vm.SaveCommand.Execute(null);
 
-        vm.SelectedFile.FileName.Should().Be("_any_.elementId.json");
+        File.Exists(Path.Combine(_rulesDir, "_any_.elementId.json")).Should().BeTrue();
     }
 
     [Fact]
-    public void DeleteSelected_RemovesFileAndDeletesFromDisk()
+    public void DeleteSelected_RemovesRuleAndFileWhenLast()
     {
-        WriteRuleFile("toDelete.json", @"{ ""version"": ""1.0"", ""rules"": [{ ""pathPattern"": "".*\\.x$"" }] }");
+        WriteRuleFile("toDelete.json",
+            @"{ ""version"": ""1.0"", ""rules"": [{ ""pathPattern"": "".*\\.x$"" }] }");
         var loader = CreateLoader();
         var vm = new ConfigEditorViewModel(loader);
 
-        vm.SelectedFile = vm.RuleFiles[0];
+        vm.SelectedRule = vm.RuleFiles[0].Rules[0];
         vm.DeleteSelectedCommand.Execute(null);
 
         vm.RuleFiles.Should().BeEmpty();
         File.Exists(Path.Combine(_rulesDir, "toDelete.json")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void DeleteSelected_OnMultiRuleFile_RemovesOnlyRule()
+    {
+        WriteRuleFile("two-rules.json", @"{
+            ""version"": ""1.0"",
+            ""rules"": [
+                { ""pathPattern"": "".*\\.a$"" },
+                { ""pathPattern"": "".*\\.b$"" }
+            ]
+        }");
+        var loader = CreateLoader();
+        var vm = new ConfigEditorViewModel(loader);
+
+        vm.SelectedRule = vm.RuleFiles[0].Rules[0];
+        vm.DeleteSelectedCommand.Execute(null);
+
+        vm.RuleFiles.Should().HaveCount(1, "the file remains because the second rule still lives in it");
+        vm.RuleFiles[0].Rules.Should().HaveCount(1);
+        vm.RuleFiles[0].Rules[0].PathPattern.Should().Be(@".*\.b$");
     }
 
     [Fact]
@@ -188,8 +278,7 @@ public class ConfigEditorViewModelTests : IDisposable
         var loader = CreateLoader();
         var vm = new ConfigEditorViewModel(loader);
 
-        vm.NewRuleCommand.Execute(null);
-        // PathPattern is empty — validation should fail
+        vm.NewFileCommand.Execute(null);
         vm.SaveCommand.Execute(null);
 
         vm.ValidationMessage.Should().Contain("path pattern");
@@ -201,10 +290,10 @@ public class ConfigEditorViewModelTests : IDisposable
         var loader = CreateLoader();
         var vm = new ConfigEditorViewModel(loader);
 
-        vm.NewRuleCommand.Execute(null);
-        vm.SelectedFile!.PathPattern = @".*\.Test$";
-        vm.SelectedFile.Min = "100";
-        vm.SelectedFile.Max = "50";
+        vm.NewFileCommand.Execute(null);
+        vm.SelectedRule!.PathPattern = @".*\.Test$";
+        vm.SelectedRule.Min = "100";
+        vm.SelectedRule.Max = "50";
 
         vm.SaveCommand.Execute(null);
 
@@ -214,8 +303,10 @@ public class ConfigEditorViewModelTests : IDisposable
     [Fact]
     public void Load_MultipleFiles_SortedAlphabetically()
     {
-        WriteRuleFile("b-rule.json", @"{ ""version"": ""1.0"", ""rules"": [{ ""pathPattern"": "".*\\.b$"" }] }");
-        WriteRuleFile("a-rule.json", @"{ ""version"": ""1.0"", ""rules"": [{ ""pathPattern"": "".*\\.a$"" }] }");
+        WriteRuleFile("b-rule.json",
+            @"{ ""version"": ""1.0"", ""rules"": [{ ""pathPattern"": "".*\\.b$"" }] }");
+        WriteRuleFile("a-rule.json",
+            @"{ ""version"": ""1.0"", ""rules"": [{ ""pathPattern"": "".*\\.a$"" }] }");
 
         var loader = CreateLoader();
         var vm = new ConfigEditorViewModel(loader);
@@ -231,16 +322,16 @@ public class ConfigEditorViewModelTests : IDisposable
         var loader = CreateLoader();
         var vm = new ConfigEditorViewModel(loader);
 
-        vm.NewRuleCommand.Execute(null);
-        vm.SelectedFile!.PathPattern = @".*{udt:messageConfig_UDT}$";
-        vm.SelectedFile.CommentTemplate = "{db}.{parent}";
+        vm.NewFileCommand.Execute(null);
+        vm.SelectedRule!.PathPattern = @".*{udt:messageConfig_UDT}$";
+        vm.SelectedRule.CommentTemplate = "{db}.{parent}";
 
         vm.SaveCommand.Execute(null);
 
         var loader2 = CreateLoader();
         var vm2 = new ConfigEditorViewModel(loader2);
         vm2.RuleFiles.Should().HaveCount(1);
-        vm2.RuleFiles[0].CommentTemplate.Should().Be("{db}.{parent}");
+        vm2.RuleFiles[0].Rules[0].CommentTemplate.Should().Be("{db}.{parent}");
     }
 
     [Fact]
@@ -249,46 +340,51 @@ public class ConfigEditorViewModelTests : IDisposable
         var loader = CreateLoader();
         var vm = new ConfigEditorViewModel(loader);
 
-        vm.NewRuleCommand.Execute(null);
-        vm.SelectedFile!.PathPattern = @".*\.moduleId$";
+        vm.NewFileCommand.Execute(null);
+        vm.SelectedRule!.PathPattern = @".*\.moduleId$";
 
         vm.SaveCommand.Execute(null);
 
-        // Filename is auto-derived from pattern
-        var expectedFile = Path.Combine(_rulesDir, vm.SelectedFile.FileName);
+        var expectedFile = Path.Combine(_rulesDir, vm.SelectedFile!.FileName);
         var json = File.ReadAllText(expectedFile);
         json.Should().NotContain("commentTemplate");
     }
 
     [Fact]
-    public void DirtyTracking_NewRule_IsDirty()
+    public void DirtyTracking_NewFile_IsDirty()
     {
         var loader = CreateLoader();
         var vm = new ConfigEditorViewModel(loader);
 
-        vm.NewRuleCommand.Execute(null);
+        vm.NewFileCommand.Execute(null);
         vm.SelectedFile!.IsDirty.Should().BeTrue();
+        vm.SelectedRule!.IsDirty.Should().BeTrue();
     }
 
     [Fact]
-    public void DirtyTracking_LoadedRule_IsClean()
+    public void DirtyTracking_LoadedFile_IsClean()
     {
-        WriteRuleFile("clean.json", @"{ ""version"": ""1.0"", ""rules"": [{ ""pathPattern"": "".*\\.x$"" }] }");
+        WriteRuleFile("clean.json",
+            @"{ ""version"": ""1.0"", ""rules"": [{ ""pathPattern"": "".*\\.x$"" }] }");
         var loader = CreateLoader();
         var vm = new ConfigEditorViewModel(loader);
 
         vm.RuleFiles[0].IsDirty.Should().BeFalse();
+        vm.RuleFiles[0].Rules[0].IsDirty.Should().BeFalse();
     }
 
     [Fact]
-    public void DirtyTracking_ModifiedRule_IsDirty()
+    public void DirtyTracking_ModifiedRule_FileIsAlsoDirty()
     {
-        WriteRuleFile("clean.json", @"{ ""version"": ""1.0"", ""rules"": [{ ""pathPattern"": "".*\\.x$"" }] }");
+        WriteRuleFile("clean.json",
+            @"{ ""version"": ""1.0"", ""rules"": [{ ""pathPattern"": "".*\\.x$"" }] }");
         var loader = CreateLoader();
         var vm = new ConfigEditorViewModel(loader);
 
-        vm.RuleFiles[0].Datatype = "Int";
-        vm.RuleFiles[0].IsDirty.Should().BeTrue();
+        vm.RuleFiles[0].Rules[0].Datatype = "Int";
+
+        vm.RuleFiles[0].Rules[0].IsDirty.Should().BeTrue();
+        vm.RuleFiles[0].IsDirty.Should().BeTrue("the file aggregates dirtiness from its rules");
     }
 
     [Fact]
@@ -297,12 +393,13 @@ public class ConfigEditorViewModelTests : IDisposable
         var loader = CreateLoader();
         var vm = new ConfigEditorViewModel(loader);
 
-        vm.NewRuleCommand.Execute(null);
-        vm.SelectedFile!.PathPattern = @".*\.test$";
-        vm.SelectedFile.IsDirty.Should().BeTrue();
+        vm.NewFileCommand.Execute(null);
+        vm.SelectedRule!.PathPattern = @".*\.test$";
+        vm.SelectedRule.IsDirty.Should().BeTrue();
 
         vm.SaveCommand.Execute(null);
-        vm.SelectedFile.IsDirty.Should().BeFalse();
+        vm.SelectedRule.IsDirty.Should().BeFalse();
+        vm.SelectedFile!.IsDirty.Should().BeFalse();
     }
 
     [Fact]
@@ -326,4 +423,16 @@ public class ConfigEditorViewModelTests : IDisposable
             .Should().Be("new-rule.json");
     }
 
+    [Fact]
+    public void HeaderSummary_ReflectsRuleCount()
+    {
+        var loader = CreateLoader();
+        var vm = new ConfigEditorViewModel(loader);
+
+        vm.NewFileCommand.Execute(null);
+        vm.SelectedFile!.HeaderSummary.Should().Contain("1 rule");
+
+        vm.NewRuleCommand.Execute(null);
+        vm.SelectedFile.HeaderSummary.Should().Contain("2 rules");
+    }
 }

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -191,6 +191,17 @@ Dies kann nicht rückgängig gemacht werden.</value></data>
   <data name="ConfigEditor_Project" xml:space="preserve"><value>Projekt</value></data>
   <data name="ConfigEditor_Local" xml:space="preserve"><value>Lokal</value></data>
   <data name="ConfigEditor_Shared" xml:space="preserve"><value>Gemeinsam</value></data>
+  <data name="ConfigEditor_NewRule_Short" xml:space="preserve"><value>+ Regel</value></data>
+  <data name="ConfigEditor_NewRule_Tooltip" xml:space="preserve"><value>Fügt eine neue Regel zur aktuell ausgewählten Datei hinzu. Ist keine Datei ausgewählt, wird eine neue Datei mit einer Startregel erzeugt.</value></data>
+  <data name="ConfigEditor_NewFile_Short" xml:space="preserve"><value>+ Datei</value></data>
+  <data name="ConfigEditor_NewFile_Tooltip" xml:space="preserve"><value>Erzeugt eine neue Regeldatei mit einer Startregel.</value></data>
+  <data name="ConfigEditor_Import" xml:space="preserve"><value>Importieren...</value></data>
+  <data name="ConfigEditor_Import_Tooltip" xml:space="preserve"><value>Regeldateien importieren (noch nicht implementiert).</value></data>
+  <data name="ConfigEditor_Export" xml:space="preserve"><value>Exportieren...</value></data>
+  <data name="ConfigEditor_Export_Tooltip" xml:space="preserve"><value>Die ausgewählte Regeldatei exportieren (noch nicht implementiert).</value></data>
+  <data name="ConfigEditor_FileActions" xml:space="preserve"><value>Dateiaktionen</value></data>
+  <data name="ConfigEditor_DeleteFile" xml:space="preserve"><value>Datei löschen</value></data>
+  <data name="ConfigEditor_ExportFile" xml:space="preserve"><value>Datei exportieren...</value></data>
   <!-- Inline-Hilfe Tooltips für ConfigEditor-Felder -->
   <data name="ConfigEditor_Help_PathPattern" xml:space="preserve"><value>Regex-Muster für den Elementpfad innerhalb des DB.
 Beispiele:

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -307,4 +307,21 @@ Datenbaustein jetzt kompilieren?</value></data>
   <data name="Update_IncludePrereleases" xml:space="preserve"><value>Vorabversionen einbeziehen</value></data>
   <data name="Update_IncludePrereleasesTooltip" xml:space="preserve"><value>Release-Candidate- / Beta-Versionen (z. B. v0.4.0-rc1) als Updates anzeigen.</value></data>
   <data name="Update_ManagedHint" xml:space="preserve"><value>Die Update-Prüfung wird zentral verwaltet und kann lokal nicht geändert werden.</value></data>
+  <!-- Regel-Editor: linke Spalte und Validierung -->
+  <data name="ConfigEditor_NoPattern" xml:space="preserve"><value>(kein Muster)</value></data>
+  <data name="ConfigEditor_RuleSecondary_TagTable" xml:space="preserve"><value>Variablentabelle: {0}</value></data>
+  <data name="ConfigEditor_RuleSecondary_Allowed" xml:space="preserve"><value>Erlaubt: {0}</value></data>
+  <data name="ConfigEditor_RuleSecondary_Comment" xml:space="preserve"><value>Kommentar: {0}</value></data>
+  <data name="ConfigEditor_HeaderSummary_OneRule" xml:space="preserve"><value>1 Regel</value></data>
+  <data name="ConfigEditor_HeaderSummary_NRules" xml:space="preserve"><value>{0} Regeln</value></data>
+  <data name="ConfigEditor_RuleValidation_NeedsPathPattern" xml:space="preserve"><value>Regel in '{0}' benötigt ein Pfadmuster.</value></data>
+  <data name="ConfigEditor_RuleValidation_MinGtMax" xml:space="preserve"><value>Regel '{0}' in '{1}': Min ({2}) muss ≤ Max ({3}) sein.</value></data>
+  <data name="ConfigEditor_NewRule_Failed" xml:space="preserve"><value>Neue Regel konnte nicht erstellt werden: {0}</value></data>
+  <data name="ConfigEditor_NewFile_NoDir" xml:space="preserve"><value>Kein gültiges Speicherverzeichnis verfügbar.</value></data>
+  <data name="ConfigEditor_NewFile_Failed" xml:space="preserve"><value>Neue Datei konnte nicht erstellt werden: {0}</value></data>
+  <data name="ConfigEditor_Duplicate_Failed" xml:space="preserve"><value>Regel konnte nicht dupliziert werden: {0}</value></data>
+  <data name="ConfigEditor_DeleteFile_Failed" xml:space="preserve"><value>Datei kann nicht gelöscht werden: {0}</value></data>
+  <data name="ConfigEditor_Import_NotImplemented" xml:space="preserve"><value>Import ist noch nicht implementiert.</value></data>
+  <data name="ConfigEditor_Export_NotImplemented" xml:space="preserve"><value>Export ist noch nicht implementiert.</value></data>
+  <data name="ConfigEditor_ExportFile_NotImplemented" xml:space="preserve"><value>Export von '{0}' ist noch nicht implementiert.</value></data>
 </root>

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -502,6 +502,39 @@ This cannot be undone.</value>
   <data name="ConfigEditor_Shared" xml:space="preserve">
     <value>Shared</value>
   </data>
+  <data name="ConfigEditor_NewRule_Short" xml:space="preserve">
+    <value>+ Rule</value>
+  </data>
+  <data name="ConfigEditor_NewRule_Tooltip" xml:space="preserve">
+    <value>Add a new rule to the currently selected file. If no file is selected, creates a new file with one starter rule.</value>
+  </data>
+  <data name="ConfigEditor_NewFile_Short" xml:space="preserve">
+    <value>+ File</value>
+  </data>
+  <data name="ConfigEditor_NewFile_Tooltip" xml:space="preserve">
+    <value>Create a new rule file with one starter rule.</value>
+  </data>
+  <data name="ConfigEditor_Import" xml:space="preserve">
+    <value>Import...</value>
+  </data>
+  <data name="ConfigEditor_Import_Tooltip" xml:space="preserve">
+    <value>Import rule files (not yet implemented).</value>
+  </data>
+  <data name="ConfigEditor_Export" xml:space="preserve">
+    <value>Export...</value>
+  </data>
+  <data name="ConfigEditor_Export_Tooltip" xml:space="preserve">
+    <value>Export the selected rule file (not yet implemented).</value>
+  </data>
+  <data name="ConfigEditor_FileActions" xml:space="preserve">
+    <value>File actions</value>
+  </data>
+  <data name="ConfigEditor_DeleteFile" xml:space="preserve">
+    <value>Delete file</value>
+  </data>
+  <data name="ConfigEditor_ExportFile" xml:space="preserve">
+    <value>Export file...</value>
+  </data>
   <!-- Inline help tooltips for ConfigEditor fields -->
   <data name="ConfigEditor_Help_PathPattern" xml:space="preserve">
     <value>Regex pattern matching the member path inside the DB.

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -794,4 +794,52 @@ Compile the block now?</value>
   <data name="Update_ManagedHint" xml:space="preserve">
     <value>Update-check policy is managed by IT and cannot be changed locally.</value>
   </data>
+  <data name="ConfigEditor_NoPattern" xml:space="preserve">
+    <value>(no pattern)</value>
+  </data>
+  <data name="ConfigEditor_RuleSecondary_TagTable" xml:space="preserve">
+    <value>tagTable: {0}</value>
+  </data>
+  <data name="ConfigEditor_RuleSecondary_Allowed" xml:space="preserve">
+    <value>allowed: {0}</value>
+  </data>
+  <data name="ConfigEditor_RuleSecondary_Comment" xml:space="preserve">
+    <value>comment: {0}</value>
+  </data>
+  <data name="ConfigEditor_HeaderSummary_OneRule" xml:space="preserve">
+    <value>1 rule</value>
+  </data>
+  <data name="ConfigEditor_HeaderSummary_NRules" xml:space="preserve">
+    <value>{0} rules</value>
+  </data>
+  <data name="ConfigEditor_RuleValidation_NeedsPathPattern" xml:space="preserve">
+    <value>Rule in '{0}' must have a path pattern.</value>
+  </data>
+  <data name="ConfigEditor_RuleValidation_MinGtMax" xml:space="preserve">
+    <value>Rule '{0}' in '{1}': Min ({2}) must be ≤ Max ({3}).</value>
+  </data>
+  <data name="ConfigEditor_NewRule_Failed" xml:space="preserve">
+    <value>Could not create new rule: {0}</value>
+  </data>
+  <data name="ConfigEditor_NewFile_NoDir" xml:space="preserve">
+    <value>No valid save directory available.</value>
+  </data>
+  <data name="ConfigEditor_NewFile_Failed" xml:space="preserve">
+    <value>Could not create new file: {0}</value>
+  </data>
+  <data name="ConfigEditor_Duplicate_Failed" xml:space="preserve">
+    <value>Could not duplicate rule: {0}</value>
+  </data>
+  <data name="ConfigEditor_DeleteFile_Failed" xml:space="preserve">
+    <value>Cannot delete file: {0}</value>
+  </data>
+  <data name="ConfigEditor_Import_NotImplemented" xml:space="preserve">
+    <value>Import is not yet implemented.</value>
+  </data>
+  <data name="ConfigEditor_Export_NotImplemented" xml:space="preserve">
+    <value>Export is not yet implemented.</value>
+  </data>
+  <data name="ConfigEditor_ExportFile_NotImplemented" xml:space="preserve">
+    <value>Export of '{0}' is not yet implemented.</value>
+  </data>
 </root>

--- a/src/BlockParam/UI/ConfigEditorDialog.xaml
+++ b/src/BlockParam/UI/ConfigEditorDialog.xaml
@@ -15,9 +15,58 @@
         <local:StringNotEmptyToVisibilityConverter x:Key="StringToVis"/>
         <local:InvertBoolConverter x:Key="InvertBool"/>
         <local:RuleSourceToBoolConverter x:Key="RuleSourceConverter"/>
+        <local:RuleSourceToLabelConverter x:Key="RuleSourceLabel"/>
 
-        <!-- File icon (folder-document) -->
+        <!-- File icon (folder-document, Material-style fill) -->
         <Geometry x:Key="IconRuleFile">M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm-1 7V3.5L18.5 9H13z</Geometry>
+
+        <!-- Lucide-style stroke icons (24x24 viewBox). Used by IconButton style below. -->
+        <Geometry x:Key="IconPlus">M5 12h14M12 5v14</Geometry>
+        <Geometry x:Key="IconFilePlus">M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z M14 2v6h6 M9 15h6 M12 12v6</Geometry>
+        <Geometry x:Key="IconCopy">M10 8h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2h-12a2 2 0 0 1-2-2v-12a2 2 0 0 1 2-2z M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2</Geometry>
+        <Geometry x:Key="IconTrash">M3 6h18 M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6 M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2 M10 11v6 M14 11v6</Geometry>
+        <Geometry x:Key="IconDownload">M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4 M7 10l5 5 5-5 M12 15V3</Geometry>
+        <Geometry x:Key="IconUpload">M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4 M17 8l-5-5-5 5 M12 3v12</Geometry>
+
+        <!-- Icon-only action button. Pass the Geometry through Tag.
+             Tooltip + Command come from the call site. -->
+        <Style x:Key="IconButton" TargetType="Button">
+            <Setter Property="Width" Value="28"/>
+            <Setter Property="Height" Value="24"/>
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bd"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="#B9BEC6"
+                                BorderThickness="0"
+                                CornerRadius="3">
+                            <Path Data="{TemplateBinding Tag}"
+                                  Stroke="#3a4250" StrokeThickness="1.6"
+                                  StrokeStartLineCap="Round" StrokeEndLineCap="Round"
+                                  StrokeLineJoin="Round"
+                                  Stretch="Uniform" Width="14" Height="14"
+                                  HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="#E8F0FE"/>
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="#D6E5FA"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter Property="Opacity" Value="0.4"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
 
         <!-- Style for help icons (?) next to labels -->
         <Style x:Key="HelpIcon" TargetType="ToggleButton">
@@ -50,37 +99,6 @@
             <Setter Property="AllowsTransparency" Value="True"/>
             <Setter Property="Placement" Value="Right"/>
             <Setter Property="StaysOpen" Value="False"/>
-        </Style>
-
-        <!-- Source segmented button: looks like a tiny pill in the file header -->
-        <Style x:Key="SourceSegment" TargetType="RadioButton">
-            <Setter Property="Margin" Value="0"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="RadioButton">
-                        <Border x:Name="Pill"
-                                Background="Transparent"
-                                BorderBrush="#B9BEC6" BorderThickness="1"
-                                Padding="6,1">
-                            <TextBlock Text="{TemplateBinding Content}"
-                                       FontSize="10" Foreground="#5b6471"
-                                       VerticalAlignment="Center"/>
-                        </Border>
-                        <ControlTemplate.Triggers>
-                            <Trigger Property="IsChecked" Value="True">
-                                <Setter TargetName="Pill" Property="Background" Value="#1f6feb"/>
-                                <Setter TargetName="Pill" Property="BorderBrush" Value="#1f6feb"/>
-                                <Setter Property="Foreground" Value="White"/>
-                            </Trigger>
-                            <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="Pill" Property="Background" Value="#E8F0FE"/>
-                            </Trigger>
-                        </ControlTemplate.Triggers>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
         </Style>
 
         <!-- File section template: header + collapsible body of rules -->
@@ -133,18 +151,20 @@
                                     MouseLeftButtonDown="OnHeaderControlsMouseDown"
                                     Margin="8,0,0,0">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                    <RadioButton Style="{StaticResource SourceSegment}"
-                                                 GroupName="{Binding GroupId}"
-                                                 Content="{loc:Loc ConfigEditor_Project}"
-                                                 IsChecked="{Binding SaveDestination, Converter={StaticResource RuleSourceConverter}, ConverterParameter=TiaProject}"/>
-                                    <RadioButton Style="{StaticResource SourceSegment}"
-                                                 GroupName="{Binding GroupId}"
-                                                 Content="{loc:Loc ConfigEditor_Local}"
-                                                 IsChecked="{Binding SaveDestination, Converter={StaticResource RuleSourceConverter}, ConverterParameter=Local}"/>
-                                    <RadioButton Style="{StaticResource SourceSegment}"
-                                                 GroupName="{Binding GroupId}"
-                                                 Content="{loc:Loc ConfigEditor_Shared}"
-                                                 IsChecked="{Binding SaveDestination, Converter={StaticResource RuleSourceConverter}, ConverterParameter=Shared}"/>
+                                    <!-- Source picker: selected item doubles as the
+                                         current-location indicator, freeing horizontal
+                                         space the 3-pill segmented control was eating. -->
+                                    <ComboBox ItemsSource="{x:Static local:RuleFileViewModel.UserSelectableSources}"
+                                              SelectedItem="{Binding SaveDestination, Mode=TwoWay}"
+                                              MinWidth="78" Height="20" Padding="4,0"
+                                              FontSize="10" VerticalAlignment="Center">
+                                        <ComboBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding Converter={StaticResource RuleSourceLabel}}"
+                                                           FontSize="10"/>
+                                            </DataTemplate>
+                                        </ComboBox.ItemTemplate>
+                                    </ComboBox>
                                     <Button Content="&#x22EF;" FontSize="14" FontWeight="Bold"
                                             Width="22" Height="20" Margin="6,0,0,0"
                                             Background="Transparent" BorderThickness="0"
@@ -275,24 +295,25 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     <StackPanel Orientation="Horizontal">
-                        <Button Content="{loc:Loc ConfigEditor_NewRule_Short}" Command="{Binding NewRuleCommand}"
-                                Height="24" Padding="8,0"
+                        <Button Style="{StaticResource IconButton}" Tag="{StaticResource IconPlus}"
+                                Command="{Binding NewRuleCommand}"
                                 ToolTip="{loc:Loc ConfigEditor_NewRule_Tooltip}"/>
-                        <Button Content="{loc:Loc ConfigEditor_NewFile_Short}" Command="{Binding NewFileCommand}"
-                                Height="24" Margin="4,0,0,0" Padding="8,0"
+                        <Button Style="{StaticResource IconButton}" Tag="{StaticResource IconFilePlus}"
+                                Command="{Binding NewFileCommand}" Margin="2,0,0,0"
                                 ToolTip="{loc:Loc ConfigEditor_NewFile_Tooltip}"/>
-                        <Button Content="{loc:Loc ConfigEditor_Duplicate}" Command="{Binding DuplicateSelectedCommand}"
-                                Height="24" Margin="4,0,0,0" Padding="8,0"
+                        <Button Style="{StaticResource IconButton}" Tag="{StaticResource IconCopy}"
+                                Command="{Binding DuplicateSelectedCommand}" Margin="2,0,0,0"
                                 ToolTip="{loc:Loc ConfigEditor_Duplicate_Tooltip}"/>
-                        <Button Content="{loc:Loc ConfigEditor_Delete}" Command="{Binding DeleteSelectedCommand}"
-                                Height="24" Margin="4,0,0,0" Padding="8,0"/>
+                        <Button Style="{StaticResource IconButton}" Tag="{StaticResource IconTrash}"
+                                Command="{Binding DeleteSelectedCommand}" Margin="2,0,0,0"
+                                ToolTip="{loc:Loc ConfigEditor_Delete}"/>
                     </StackPanel>
                     <StackPanel Grid.Column="1" Orientation="Horizontal">
-                        <Button Content="{loc:Loc ConfigEditor_Import}" Command="{Binding ImportFilesCommand}"
-                                Height="24" Padding="8,0" Margin="8,0,0,0"
+                        <Button Style="{StaticResource IconButton}" Tag="{StaticResource IconDownload}"
+                                Command="{Binding ImportFilesCommand}" Margin="8,0,0,0"
                                 ToolTip="{loc:Loc ConfigEditor_Import_Tooltip}"/>
-                        <Button Content="{loc:Loc ConfigEditor_Export}" Command="{Binding ExportSelectedCommand}"
-                                Height="24" Padding="8,0" Margin="4,0,0,0"
+                        <Button Style="{StaticResource IconButton}" Tag="{StaticResource IconUpload}"
+                                Command="{Binding ExportSelectedCommand}" Margin="2,0,0,0"
                                 ToolTip="{loc:Loc ConfigEditor_Export_Tooltip}"/>
                     </StackPanel>
                 </Grid>

--- a/src/BlockParam/UI/ConfigEditorDialog.xaml
+++ b/src/BlockParam/UI/ConfigEditorDialog.xaml
@@ -85,7 +85,7 @@
 
         <!-- File section template: header + collapsible body of rules -->
         <DataTemplate x:Key="FileSectionTemplate" DataType="{x:Type local:RuleFileViewModel}">
-            <Grid Tag="{Binding}" Loaded="OnFileSectionLoaded">
+            <Grid Tag="{Binding}" Loaded="OnFileSectionLoaded" Unloaded="OnFileSectionUnloaded">
                 <StackPanel>
                     <!-- Sticky header bar -->
                     <Border x:Name="FileHeader"
@@ -134,15 +134,15 @@
                                     Margin="8,0,0,0">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                                     <RadioButton Style="{StaticResource SourceSegment}"
-                                                 GroupName="{Binding FilePath}"
+                                                 GroupName="{Binding GroupId}"
                                                  Content="{loc:Loc ConfigEditor_Project}"
                                                  IsChecked="{Binding SaveDestination, Converter={StaticResource RuleSourceConverter}, ConverterParameter=TiaProject}"/>
                                     <RadioButton Style="{StaticResource SourceSegment}"
-                                                 GroupName="{Binding FilePath}"
+                                                 GroupName="{Binding GroupId}"
                                                  Content="{loc:Loc ConfigEditor_Local}"
                                                  IsChecked="{Binding SaveDestination, Converter={StaticResource RuleSourceConverter}, ConverterParameter=Local}"/>
                                     <RadioButton Style="{StaticResource SourceSegment}"
-                                                 GroupName="{Binding FilePath}"
+                                                 GroupName="{Binding GroupId}"
                                                  Content="{loc:Loc ConfigEditor_Shared}"
                                                  IsChecked="{Binding SaveDestination, Converter={StaticResource RuleSourceConverter}, ConverterParameter=Shared}"/>
                                     <Button Content="&#x22EF;" FontSize="14" FontWeight="Bold"

--- a/src/BlockParam/UI/ConfigEditorDialog.xaml
+++ b/src/BlockParam/UI/ConfigEditorDialog.xaml
@@ -193,7 +193,6 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate DataType="{x:Type local:RuleViewModel}">
                                 <Border x:Name="RuleRow"
-                                        Background="White"
                                         BorderBrush="#E0E3E8" BorderThickness="0,0,0,1"
                                         Padding="28,4,8,4"
                                         Cursor="Hand"
@@ -201,6 +200,7 @@
                                         Tag="{Binding}">
                                     <Border.Style>
                                         <Style TargetType="Border">
+                                            <Setter Property="Background" Value="White"/>
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding IsDirty}" Value="True">
                                                     <Setter Property="Background" Value="#FFF8DC"/>

--- a/src/BlockParam/UI/ConfigEditorDialog.xaml
+++ b/src/BlockParam/UI/ConfigEditorDialog.xaml
@@ -107,7 +107,7 @@
                 <StackPanel>
                     <!-- Sticky header bar -->
                     <Border x:Name="FileHeader"
-                            Background="#EEF0F3" BorderBrush="#B9BEC6"
+                            BorderBrush="#B9BEC6"
                             BorderThickness="0,1,0,1"
                             Cursor="Hand"
                             MouseLeftButtonUp="OnFileHeaderClick"
@@ -117,6 +117,7 @@
                         </Border.RenderTransform>
                         <Border.Style>
                             <Style TargetType="Border">
+                                <Setter Property="Background" Value="#EEF0F3"/>
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsDirty}" Value="True">
                                         <Setter Property="Background" Value="#FFF8DC"/>
@@ -225,7 +226,7 @@
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding PathPattern}" Value="">
                                                             <Setter Property="Foreground" Value="#999999"/>
-                                                            <Setter Property="Text" Value="(no pattern)"/>
+                                                            <Setter Property="Text" Value="{loc:Loc ConfigEditor_NoPattern}"/>
                                                             <Setter Property="FontStyle" Value="Italic"/>
                                                         </DataTrigger>
                                                     </Style.Triggers>

--- a/src/BlockParam/UI/ConfigEditorDialog.xaml
+++ b/src/BlockParam/UI/ConfigEditorDialog.xaml
@@ -4,8 +4,8 @@
         xmlns:local="clr-namespace:BlockParam.UI"
         xmlns:loc="clr-namespace:BlockParam.Localization"
         Title="{loc:Loc ConfigEditor_Title}"
-                Width="750" Height="550"
-        MinWidth="600" MinHeight="400"
+        Width="900" Height="600"
+        MinWidth="700" MinHeight="450"
         WindowStartupLocation="CenterScreen"
         FontFamily="Segoe UI" FontSize="12">
 
@@ -16,7 +16,10 @@
         <local:InvertBoolConverter x:Key="InvertBool"/>
         <local:RuleSourceToBoolConverter x:Key="RuleSourceConverter"/>
 
-        <!-- Style for help icons (?) next to labels: click toggles popup -->
+        <!-- File icon (folder-document) -->
+        <Geometry x:Key="IconRuleFile">M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm-1 7V3.5L18.5 9H13z</Geometry>
+
+        <!-- Style for help icons (?) next to labels -->
         <Style x:Key="HelpIcon" TargetType="ToggleButton">
             <Setter Property="Content" Value="?"/>
             <Setter Property="Foreground" Value="#888888"/>
@@ -43,28 +46,188 @@
             </Setter>
         </Style>
 
-        <!-- Popup template for help icons -->
         <Style x:Key="HelpPopup" TargetType="Popup">
             <Setter Property="AllowsTransparency" Value="True"/>
             <Setter Property="Placement" Value="Right"/>
             <Setter Property="StaysOpen" Value="False"/>
         </Style>
 
-        <!-- Dirty row highlight for DataGrid -->
-        <Style x:Key="DirtyRowStyle" TargetType="DataGridRow">
-            <Style.Triggers>
-                <DataTrigger Binding="{Binding IsDirty}" Value="True">
-                    <Setter Property="Background" Value="#FFF8DC"/>
-                </DataTrigger>
-                <DataTrigger Binding="{Binding IsNew}" Value="True">
-                    <Setter Property="Background" Value="#FFFACD"/>
-                </DataTrigger>
-            </Style.Triggers>
+        <!-- Source segmented button: looks like a tiny pill in the file header -->
+        <Style x:Key="SourceSegment" TargetType="RadioButton">
+            <Setter Property="Margin" Value="0"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="RadioButton">
+                        <Border x:Name="Pill"
+                                Background="Transparent"
+                                BorderBrush="#B9BEC6" BorderThickness="1"
+                                Padding="6,1">
+                            <TextBlock Text="{TemplateBinding Content}"
+                                       FontSize="10" Foreground="#5b6471"
+                                       VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsChecked" Value="True">
+                                <Setter TargetName="Pill" Property="Background" Value="#1f6feb"/>
+                                <Setter TargetName="Pill" Property="BorderBrush" Value="#1f6feb"/>
+                                <Setter Property="Foreground" Value="White"/>
+                            </Trigger>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Pill" Property="Background" Value="#E8F0FE"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
         </Style>
+
+        <!-- File section template: header + collapsible body of rules -->
+        <DataTemplate x:Key="FileSectionTemplate" DataType="{x:Type local:RuleFileViewModel}">
+            <Grid Tag="{Binding}" Loaded="OnFileSectionLoaded">
+                <StackPanel>
+                    <!-- Sticky header bar -->
+                    <Border x:Name="FileHeader"
+                            Background="#EEF0F3" BorderBrush="#B9BEC6"
+                            BorderThickness="0,1,0,1"
+                            Cursor="Hand"
+                            MouseLeftButtonUp="OnFileHeaderClick"
+                            Panel.ZIndex="10">
+                        <Border.RenderTransform>
+                            <TranslateTransform/>
+                        </Border.RenderTransform>
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsDirty}" Value="True">
+                                        <Setter Property="Background" Value="#FFF8DC"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding IsNew}" Value="True">
+                                        <Setter Property="Background" Value="#FFFACD"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <DockPanel LastChildFill="True" Margin="0,4,4,4">
+                            <!-- Chevron -->
+                            <Grid DockPanel.Dock="Left" Width="18" Height="18" Margin="2,0,2,0">
+                                <TextBlock Text="&#x25BC;" FontSize="9" Foreground="#5b6471"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                                           Visibility="{Binding IsExpanded, Converter={StaticResource BoolToVis}}"/>
+                                <TextBlock Text="&#x25B6;" FontSize="9" Foreground="#5b6471"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                                           Visibility="{Binding IsExpanded, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"/>
+                            </Grid>
+                            <!-- File icon -->
+                            <Viewbox DockPanel.Dock="Left" Width="13" Height="13"
+                                     Margin="0,0,6,0" VerticalAlignment="Center">
+                                <Path Data="{StaticResource IconRuleFile}" Fill="#1f6feb"/>
+                            </Viewbox>
+                            <!-- Right side: source segmented + overflow.
+                                 Mouse events are stopped here so clicking these
+                                 controls does NOT bubble up to the header (which
+                                 would toggle the file's IsExpanded). -->
+                            <Border DockPanel.Dock="Right" Background="Transparent"
+                                    MouseLeftButtonUp="OnHeaderControlsMouseUp"
+                                    MouseLeftButtonDown="OnHeaderControlsMouseDown"
+                                    Margin="8,0,0,0">
+                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                    <RadioButton Style="{StaticResource SourceSegment}"
+                                                 GroupName="{Binding FilePath}"
+                                                 Content="{loc:Loc ConfigEditor_Project}"
+                                                 IsChecked="{Binding SaveDestination, Converter={StaticResource RuleSourceConverter}, ConverterParameter=TiaProject}"/>
+                                    <RadioButton Style="{StaticResource SourceSegment}"
+                                                 GroupName="{Binding FilePath}"
+                                                 Content="{loc:Loc ConfigEditor_Local}"
+                                                 IsChecked="{Binding SaveDestination, Converter={StaticResource RuleSourceConverter}, ConverterParameter=Local}"/>
+                                    <RadioButton Style="{StaticResource SourceSegment}"
+                                                 GroupName="{Binding FilePath}"
+                                                 Content="{loc:Loc ConfigEditor_Shared}"
+                                                 IsChecked="{Binding SaveDestination, Converter={StaticResource RuleSourceConverter}, ConverterParameter=Shared}"/>
+                                    <Button Content="&#x22EF;" FontSize="14" FontWeight="Bold"
+                                            Width="22" Height="20" Margin="6,0,0,0"
+                                            Background="Transparent" BorderThickness="0"
+                                            Foreground="#5b6471" Cursor="Hand"
+                                            Click="OnFileOverflowClick"
+                                            Tag="{Binding}"
+                                            ToolTip="{loc:Loc ConfigEditor_FileActions}"/>
+                                </StackPanel>
+                            </Border>
+                            <!-- Filename + summary (the elastic middle) -->
+                            <StackPanel VerticalAlignment="Center">
+                                <TextBlock Text="{Binding FileName}"
+                                           FontSize="12" FontWeight="SemiBold"
+                                           Foreground="#1e2227"
+                                           TextTrimming="CharacterEllipsis"/>
+                                <TextBlock Text="{Binding HeaderSummary}"
+                                           FontSize="10" Foreground="#5b6471"
+                                           TextTrimming="CharacterEllipsis"/>
+                            </StackPanel>
+                        </DockPanel>
+                    </Border>
+
+                    <!-- Body: list of rules in this file -->
+                    <ItemsControl ItemsSource="{Binding Rules}"
+                                  Visibility="{Binding IsExpanded, Converter={StaticResource BoolToVis}}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="{x:Type local:RuleViewModel}">
+                                <Border x:Name="RuleRow"
+                                        Background="White"
+                                        BorderBrush="#E0E3E8" BorderThickness="0,0,0,1"
+                                        Padding="28,4,8,4"
+                                        Cursor="Hand"
+                                        MouseLeftButtonUp="OnRuleRowClick"
+                                        Tag="{Binding}">
+                                    <Border.Style>
+                                        <Style TargetType="Border">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsDirty}" Value="True">
+                                                    <Setter Property="Background" Value="#FFF8DC"/>
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding IsNew}" Value="True">
+                                                    <Setter Property="Background" Value="#FFFACD"/>
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                                    <Setter Property="Background" Value="#D6E5FA"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Border.Style>
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding PathPattern}"
+                                                   FontFamily="Consolas" FontSize="11"
+                                                   Foreground="#1e2227"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   ToolTip="{Binding PathPattern}">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding PathPattern}" Value="">
+                                                            <Setter Property="Foreground" Value="#999999"/>
+                                                            <Setter Property="Text" Value="(no pattern)"/>
+                                                            <Setter Property="FontStyle" Value="Italic"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                        <TextBlock Text="{Binding SecondaryDisplay}"
+                                                   FontSize="10" Foreground="#5b6471"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   Visibility="{Binding SecondaryDisplay, Converter={StaticResource StringToVis}}"/>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Grid>
+        </DataTemplate>
     </Window.Resources>
 
     <DockPanel Margin="10">
-        <!-- Bottom: Buttons + Validation -->
+        <!-- Bottom: validation + buttons -->
         <StackPanel DockPanel.Dock="Bottom" Margin="0,8,0,0">
             <TextBlock Text="{Binding ValidationMessage}" Foreground="Red" Margin="0,0,0,6"
                        Visibility="{Binding ValidationMessage, Converter={StaticResource StringToVis}}"
@@ -79,17 +242,17 @@
             </StackPanel>
         </StackPanel>
 
-        <!-- Main: two-panel horizontal layout -->
+        <!-- Main: file/rule list (left) + rule detail editor (right) -->
         <Grid>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="200" MinWidth="140"/>
+                <ColumnDefinition Width="320" MinWidth="240"/>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
-            <!-- Left panel: compact rule list -->
+            <!-- Left panel: file/rule list -->
             <DockPanel Grid.Column="0">
-                <!-- Shared directory (collapsed by default, expandable) -->
+                <!-- Shared directory (collapsed expander) -->
                 <Expander DockPanel.Dock="Top" Margin="0,0,0,6"
                           Header="{loc:Loc ConfigEditor_SharedDir}" IsExpanded="False" FontSize="11">
                     <Grid Margin="0,4,0,0">
@@ -105,17 +268,34 @@
                     </Grid>
                 </Expander>
 
-                <!-- Action buttons -->
-                <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Margin="0,4,0,0">
-                    <Button Content="+" Command="{Binding NewRuleCommand}"
-                            Width="26" Height="24" FontWeight="Bold" FontSize="14"
-                            ToolTip="{loc:Loc ConfigEditor_NewRule}"/>
-                    <Button Content="{loc:Loc ConfigEditor_Duplicate}" Command="{Binding DuplicateSelectedCommand}"
-                            Height="24" Margin="6,0,0,0" Padding="8,0"
-                            ToolTip="{loc:Loc ConfigEditor_Duplicate_Tooltip}"/>
-                    <Button Content="{loc:Loc ConfigEditor_Delete}" Command="{Binding DeleteSelectedCommand}"
-                            Height="24" Margin="6,0,0,0" Padding="8,0"/>
-                </StackPanel>
+                <!-- Bottom toolbar: actions -->
+                <Grid DockPanel.Dock="Bottom" Margin="0,4,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Orientation="Horizontal">
+                        <Button Content="{loc:Loc ConfigEditor_NewRule_Short}" Command="{Binding NewRuleCommand}"
+                                Height="24" Padding="8,0"
+                                ToolTip="{loc:Loc ConfigEditor_NewRule_Tooltip}"/>
+                        <Button Content="{loc:Loc ConfigEditor_NewFile_Short}" Command="{Binding NewFileCommand}"
+                                Height="24" Margin="4,0,0,0" Padding="8,0"
+                                ToolTip="{loc:Loc ConfigEditor_NewFile_Tooltip}"/>
+                        <Button Content="{loc:Loc ConfigEditor_Duplicate}" Command="{Binding DuplicateSelectedCommand}"
+                                Height="24" Margin="4,0,0,0" Padding="8,0"
+                                ToolTip="{loc:Loc ConfigEditor_Duplicate_Tooltip}"/>
+                        <Button Content="{loc:Loc ConfigEditor_Delete}" Command="{Binding DeleteSelectedCommand}"
+                                Height="24" Margin="4,0,0,0" Padding="8,0"/>
+                    </StackPanel>
+                    <StackPanel Grid.Column="1" Orientation="Horizontal">
+                        <Button Content="{loc:Loc ConfigEditor_Import}" Command="{Binding ImportFilesCommand}"
+                                Height="24" Padding="8,0" Margin="8,0,0,0"
+                                ToolTip="{loc:Loc ConfigEditor_Import_Tooltip}"/>
+                        <Button Content="{loc:Loc ConfigEditor_Export}" Command="{Binding ExportSelectedCommand}"
+                                Height="24" Padding="8,0" Margin="4,0,0,0"
+                                ToolTip="{loc:Loc ConfigEditor_Export_Tooltip}"/>
+                    </StackPanel>
+                </Grid>
 
                 <!-- Search filter -->
                 <TextBox DockPanel.Dock="Top" Margin="0,0,0,4" Padding="4,2"
@@ -141,75 +321,40 @@
                     </TextBox.Style>
                 </TextBox>
 
-                <!-- Rule list: show PathPattern as primary, source as secondary -->
-                <ListBox ItemsSource="{Binding FilteredRuleFiles}"
-                         SelectedItem="{Binding SelectedFile}"
-                         HorizontalContentAlignment="Stretch"
-                         BorderBrush="#CCCCCC" BorderThickness="1"
-                         ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-                    <ListBox.ItemContainerStyle>
-                        <Style TargetType="ListBoxItem">
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding IsDirty}" Value="True">
-                                    <Setter Property="Background" Value="#FFF8DC"/>
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding IsNew}" Value="True">
-                                    <Setter Property="Background" Value="#FFFACD"/>
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </ListBox.ItemContainerStyle>
-                    <ListBox.ItemTemplate>
-                        <DataTemplate>
-                            <StackPanel Margin="2,3">
-                                <TextBlock Text="{Binding PathPattern}" FontFamily="Consolas" FontSize="11"
-                                           TextTrimming="CharacterEllipsis"
-                                           ToolTip="{Binding PathPattern}">
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="Foreground" Value="#333333"/>
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding PathPattern}" Value="">
-                                                    <Setter Property="Foreground" Value="#999999"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBlock Text="{Binding SourceDisplay}" FontSize="10" Foreground="#888888"/>
-                                    <TextBlock Text=" · " FontSize="10" Foreground="#CCCCCC"
-                                               Visibility="{Binding StatusDisplay, Converter={StaticResource StringToVis}}"/>
-                                    <TextBlock Text="{Binding StatusDisplay}" FontSize="10" Foreground="#CC8800"
-                                               Visibility="{Binding StatusDisplay, Converter={StaticResource StringToVis}}"/>
-                                </StackPanel>
-                            </StackPanel>
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
-                </ListBox>
+                <!-- File/rule list with rolling-sticky headers -->
+                <Border BorderBrush="#B9BEC6" BorderThickness="1">
+                    <ScrollViewer x:Name="FileListScroll"
+                                  VerticalScrollBarVisibility="Auto"
+                                  HorizontalScrollBarVisibility="Disabled"
+                                  ScrollChanged="OnFileListScrollChanged">
+                        <ItemsControl x:Name="FileListItemsControl"
+                                      ItemsSource="{Binding FilteredRuleFiles}"
+                                      ItemTemplate="{StaticResource FileSectionTemplate}"/>
+                    </ScrollViewer>
+                </Border>
             </DockPanel>
 
             <!-- Splitter -->
             <GridSplitter Grid.Column="1" Width="4" HorizontalAlignment="Center"
                           VerticalAlignment="Stretch" Background="Transparent"/>
 
-            <!-- Right panel: Rule detail editor -->
+            <!-- Right panel: Rule detail editor (binds to SelectedRule) -->
             <ScrollViewer Grid.Column="2" VerticalScrollBarVisibility="Auto" Margin="8,0,0,0">
                 <Border BorderBrush="#CCCCCC" BorderThickness="1" Padding="12" CornerRadius="3"
-                        Visibility="{Binding SelectedFile, Converter={StaticResource NullToVis}}">
+                        Visibility="{Binding SelectedRule, Converter={StaticResource NullToVis}}">
                     <Border.Style>
                         <Style TargetType="Border">
                             <Setter Property="Background" Value="#FAFAFA"/>
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding SelectedFile.IsDirty}" Value="True">
+                                <DataTrigger Binding="{Binding SelectedRule.IsDirty}" Value="True">
                                     <Setter Property="Background" Value="#FFFFF0"/>
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>
                     </Border.Style>
-                    <StackPanel DataContext="{Binding SelectedFile}">
+                    <StackPanel DataContext="{Binding SelectedRule}">
 
-                        <!-- Path Pattern: PROMINENT, top position -->
+                        <!-- Path Pattern: prominent, top -->
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
                             <TextBlock Text="{loc:Loc ConfigEditor_PathPattern}"
                                        FontWeight="SemiBold" FontSize="13" VerticalAlignment="Center"/>
@@ -225,14 +370,6 @@
                                  Margin="0,0,0,12" Padding="6,4"
                                  FontFamily="Consolas" FontSize="14"
                                  BorderBrush="#999999" BorderThickness="1.5"/>
-
-                        <!-- File Name (read-only display) -->
-                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
-                            <TextBlock Text="{loc:Loc ConfigEditor_FileName}" Foreground="#888888" FontSize="11"
-                                       VerticalAlignment="Center"/>
-                            <TextBlock Text="{Binding FileName}" FontSize="11" Foreground="#666666"
-                                       Margin="6,0,0,0" VerticalAlignment="Center"/>
-                        </StackPanel>
 
                         <!-- Rule Detail Grid -->
                         <Grid>
@@ -250,7 +387,7 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
 
-                            <!-- Row 0: Datatype (dropdown) -->
+                            <!-- Datatype -->
                             <StackPanel Orientation="Horizontal" Grid.Row="0" VerticalAlignment="Center" Margin="0,0,8,6">
                                 <TextBlock Text="{loc:Loc ConfigEditor_Datatype}" VerticalAlignment="Center"/>
                                 <ToggleButton x:Name="HelpDatatype" Style="{StaticResource HelpIcon}"/>
@@ -266,7 +403,7 @@
                                       Text="{Binding Datatype, UpdateSourceTrigger=PropertyChanged}"
                                       ItemsSource="{x:Static local:RuleFileViewModel.TiaDataTypes}"/>
 
-                            <!-- Row 1: Tag Table (dropdown) -->
+                            <!-- Tag Table -->
                             <StackPanel Orientation="Horizontal" Grid.Row="1" VerticalAlignment="Center" Margin="0,0,8,6">
                                 <TextBlock Text="{loc:Loc ConfigEditor_TagTable}" VerticalAlignment="Center"/>
                                 <ToggleButton x:Name="HelpTagTable" Style="{StaticResource HelpIcon}"/>
@@ -282,7 +419,7 @@
                                       Text="{Binding TagTableName, UpdateSourceTrigger=PropertyChanged}"
                                       ItemsSource="{Binding DataContext.TagTableNames, RelativeSource={RelativeSource AncestorType=Window}}"/>
 
-                            <!-- Row 2: Require Value -->
+                            <!-- Require Value -->
                             <StackPanel Orientation="Horizontal" Grid.Row="2" VerticalAlignment="Center" Margin="0,0,8,6">
                                 <TextBlock Text="{loc:Loc ConfigEditor_RequireValue}" VerticalAlignment="Center"/>
                                 <ToggleButton x:Name="HelpRequireValue" Style="{StaticResource HelpIcon}"/>
@@ -297,7 +434,7 @@
                                       Grid.Row="2" Grid.Column="1" Margin="0,0,0,6"
                                       VerticalAlignment="Center"/>
 
-                            <!-- Row 3: Min / Max -->
+                            <!-- Min / Max -->
                             <StackPanel Orientation="Horizontal" Grid.Row="3" VerticalAlignment="Center" Margin="0,0,8,6"
                                         IsEnabled="{Binding IsMinMaxSupported}">
                                 <TextBlock Text="{loc:Loc ConfigEditor_MinMax}" VerticalAlignment="Center"/>
@@ -357,7 +494,7 @@
                                            Visibility="{Binding MaxError, Converter={StaticResource StringToVis}}"/>
                             </StackPanel>
 
-                            <!-- Row 4: Allowed Values -->
+                            <!-- Allowed Values -->
                             <StackPanel Orientation="Horizontal" Grid.Row="4" VerticalAlignment="Center" Margin="0,0,8,6">
                                 <TextBlock Text="{loc:Loc ConfigEditor_AllowedValues}" VerticalAlignment="Center"/>
                                 <ToggleButton x:Name="HelpAllowedValues" Style="{StaticResource HelpIcon}"/>
@@ -371,7 +508,7 @@
                             <TextBox Text="{Binding AllowedValues, UpdateSourceTrigger=PropertyChanged}"
                                      Grid.Row="4" Grid.Column="1" Margin="0,0,0,6" Padding="4,2"/>
 
-                            <!-- Row 5: Comment Template -->
+                            <!-- Comment Template -->
                             <StackPanel Orientation="Horizontal" Grid.Row="5" VerticalAlignment="Center" Margin="0,0,8,6">
                                 <TextBlock Text="{loc:Loc ConfigEditor_CommentTemplate}" VerticalAlignment="Center"/>
                                 <ToggleButton x:Name="HelpCommentTemplate" Style="{StaticResource HelpIcon}"/>
@@ -386,7 +523,7 @@
                                      Grid.Row="5" Grid.Column="1" Margin="0,0,0,6" Padding="4,2"
                                      FontFamily="Consolas"/>
 
-                            <!-- Row 6: Exclude from Setpoints -->
+                            <!-- Exclude -->
                             <StackPanel Orientation="Horizontal" Grid.Row="6" VerticalAlignment="Center" Margin="0,0,8,6">
                                 <TextBlock Text="{loc:Loc ConfigEditor_Exclude}" VerticalAlignment="Center"/>
                                 <ToggleButton x:Name="HelpExclude" Style="{StaticResource HelpIcon}"/>
@@ -403,29 +540,15 @@
                                       VerticalAlignment="Center"/>
                         </Grid>
 
-                        <!-- Save Destination -->
-                        <StackPanel Orientation="Horizontal" Margin="0,12,0,0">
-                            <TextBlock Text="{loc:Loc ConfigEditor_SaveTo}" VerticalAlignment="Center" Margin="0,0,12,0"/>
-                            <RadioButton Content="{loc:Loc ConfigEditor_Project}" Margin="0,0,12,0"
-                                         IsChecked="{Binding SaveDestination, Converter={StaticResource RuleSourceConverter}, ConverterParameter=TiaProject}"
-                                         VerticalAlignment="Center"/>
-                            <RadioButton Content="{loc:Loc ConfigEditor_Local}" Margin="0,0,12,0"
-                                         IsChecked="{Binding SaveDestination, Converter={StaticResource RuleSourceConverter}, ConverterParameter=Local}"
-                                         VerticalAlignment="Center"/>
-                            <RadioButton Content="{loc:Loc ConfigEditor_Shared}"
-                                         IsChecked="{Binding SaveDestination, Converter={StaticResource RuleSourceConverter}, ConverterParameter=Shared}"
-                                         VerticalAlignment="Center"/>
-                        </StackPanel>
-
-                        <!-- Override info + Reset button -->
+                        <!-- Override info banner (file-level, surfaced through SelectedRule.ParentFile) -->
                         <Border Margin="0,12,0,0" Padding="8,6" CornerRadius="3"
                                 Background="#FFF3E0" BorderBrush="#FFB74D" BorderThickness="1"
-                                Visibility="{Binding HasOverrides, Converter={StaticResource BoolToVis}}">
+                                Visibility="{Binding ParentFile.HasOverrides, Converter={StaticResource BoolToVis}}">
                             <StackPanel>
                                 <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
                                     <TextBlock FontSize="11" Foreground="#E65100" VerticalAlignment="Center">
                                         <Run Text="{loc:Loc ConfigEditor_OverrideInfo}"/>
-                                        <Run Text="{Binding StatusDisplay, Mode=OneWay}" FontWeight="SemiBold"/>
+                                        <Run Text="{Binding ParentFile.StatusDisplay, Mode=OneWay}" FontWeight="SemiBold"/>
                                     </TextBlock>
                                     <ToggleButton x:Name="HelpOverride" Style="{StaticResource HelpIcon}"/>
                                     <Popup IsOpen="{Binding IsChecked, ElementName=HelpOverride}" Style="{StaticResource HelpPopup}"

--- a/src/BlockParam/UI/ConfigEditorDialog.xaml.cs
+++ b/src/BlockParam/UI/ConfigEditorDialog.xaml.cs
@@ -105,19 +105,10 @@ public partial class ConfigEditorDialog : Window
         if (sender is not Border header) return;
         if (header.DataContext is not RuleFileViewModel file) return;
 
-        // Toggle expand/collapse and select the file (without changing rule selection
-        // unless none was set yet).
         file.IsExpanded = !file.IsExpanded;
 
         if (DataContext is ConfigEditorViewModel vm)
-        {
             vm.SelectedFile = file;
-            // If no rule is selected or the selected rule belongs to another file,
-            // adopt the first rule of this file so the detail panel has something
-            // to show. Otherwise leave the existing rule selection alone.
-            if (vm.SelectedRule == null || vm.SelectedRule.ParentFile != file)
-                vm.SelectedRule = file.Rules.FirstOrDefault();
-        }
 
         Dispatcher.BeginInvoke(new Action(UpdateRollingSticky),
             System.Windows.Threading.DispatcherPriority.Loaded);

--- a/src/BlockParam/UI/ConfigEditorDialog.xaml.cs
+++ b/src/BlockParam/UI/ConfigEditorDialog.xaml.cs
@@ -1,8 +1,8 @@
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Media;
+using FolderBrowserDialog = System.Windows.Forms.FolderBrowserDialog;
 
 namespace BlockParam.UI;
 

--- a/src/BlockParam/UI/ConfigEditorDialog.xaml.cs
+++ b/src/BlockParam/UI/ConfigEditorDialog.xaml.cs
@@ -81,6 +81,17 @@ public partial class ConfigEditorDialog : Window
             System.Windows.Threading.DispatcherPriority.Loaded);
     }
 
+    /// <summary>
+    /// Removes the section from the tracking list when its container leaves
+    /// the visual tree (filter refresh, save reload, dialog close). Without
+    /// this, _fileSections grows unboundedly across edit cycles.
+    /// </summary>
+    private void OnFileSectionUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Grid root) return;
+        _fileSections.RemoveAll(fs => ReferenceEquals(fs.Root, root));
+    }
+
     private void OnFileHeaderClick(object sender, MouseButtonEventArgs e)
     {
         if (e.Handled) return;
@@ -187,16 +198,17 @@ public partial class ConfigEditorDialog : Window
     {
         if (FileListScroll == null || _fileSections.Count == 0) return;
 
-        // Reset all transforms first.
+        // Reset transforms and Z-index on all sections. We re-apply only on
+        // the active sticky below.
         foreach (var fs in _fileSections)
         {
             if (fs.Header.RenderTransform is TranslateTransform existing)
                 existing.Y = 0;
+            SetContainerZIndex(fs.Root, 0);
         }
 
         var viewportTop = 0.0; // relative to the ScrollViewer's content area
         FileSectionVisuals? activeSticky = null;
-        FileSectionVisuals? nextSection = null;
 
         foreach (var fs in _fileSections)
         {
@@ -213,31 +225,46 @@ public partial class ConfigEditorDialog : Window
             {
                 activeSticky = fs;
             }
-            else if (rootTopInScroll > viewportTop && nextSection == null)
-            {
-                nextSection = fs;
-            }
         }
 
         if (activeSticky != null)
         {
             var rootTop = TopWithinScrollViewer(activeSticky.Root);
-            // Pin: translate header down to viewport top.
+            var rootBottom = rootTop + activeSticky.Root.ActualHeight;
+            var headerH = activeSticky.Header.ActualHeight;
+
+            // Pin: translate the header down to the viewport top.
             var translate = -rootTop;
 
-            // Push it back out as the next section approaches, so the swap is smooth.
-            if (nextSection != null)
-            {
-                var nextTop = TopWithinScrollViewer(nextSection.Root);
-                var headerH = activeSticky.Header.ActualHeight;
-                var distance = nextTop - viewportTop;
-                if (distance < headerH)
-                    translate -= (headerH - distance);
-            }
+            // Trailing-edge ride-out: as the section's body bottom approaches
+            // the viewport top, push the header upward so it exits smoothly
+            // instead of un-pinning abruptly on the next scroll tick. This
+            // single metric also handles the incoming-next-section case for
+            // adjacent sections (no gap), since rootBottom == nextTop there.
+            var distToBottom = rootBottom - viewportTop;
+            if (distToBottom < headerH)
+                translate -= (headerH - distToBottom);
 
             if (activeSticky.Header.RenderTransform is TranslateTransform t)
                 t.Y = translate;
+
+            // The pinned header lives inside the active section's container.
+            // Without bumping the container's Z-index above its siblings,
+            // later items in the ItemsControl (drawn in document order) would
+            // paint OVER the translated header, clipping it. Setting Panel.ZIndex
+            // on the ContentPresenter lifts the whole section to the front.
+            SetContainerZIndex(activeSticky.Root, 100);
         }
+    }
+
+    /// <summary>
+    /// Sets <see cref="Panel.ZIndex"/> on the ItemsControl's container for
+    /// <paramref name="root"/> (a ContentPresenter wrapping the data template).
+    /// </summary>
+    private static void SetContainerZIndex(FrameworkElement root, int z)
+    {
+        if (VisualTreeHelper.GetParent(root) is FrameworkElement container)
+            Panel.SetZIndex(container, z);
     }
 
     /// <summary>

--- a/src/BlockParam/UI/ConfigEditorDialog.xaml.cs
+++ b/src/BlockParam/UI/ConfigEditorDialog.xaml.cs
@@ -1,10 +1,19 @@
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Forms;
+using System.Windows.Input;
+using System.Windows.Media;
 
 namespace BlockParam.UI;
 
 public partial class ConfigEditorDialog : Window
 {
+    /// <summary>
+    /// Tracks each visible file section's chrome — used by the rolling-sticky
+    /// scroll handler to translate the header straddling the viewport top.
+    /// </summary>
+    private readonly List<FileSectionVisuals> _fileSections = new();
+
     public ConfigEditorDialog()
     {
         InitializeComponent();
@@ -17,8 +26,6 @@ public partial class ConfigEditorDialog : Window
         DataContext = viewModel;
         viewModel.RequestClose += () => Close();
 
-        // Briefly set Topmost to appear above TIA Portal, then release
-        // so other windows (non-TIA) can go in front.
         Loaded += (_, _) =>
         {
             Topmost = true;
@@ -51,4 +58,220 @@ public partial class ConfigEditorDialog : Window
             vm.SharedRulesDirectory = dialog.SelectedPath;
         }
     }
+
+    /// <summary>
+    /// Each file section registers itself here when its container Grid loads.
+    /// Once registered we can find the header Border + the section's overall
+    /// bounds for the rolling-sticky calculation.
+    /// </summary>
+    private void OnFileSectionLoaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Grid root) return;
+        if (root.Tag is not RuleFileViewModel file) return;
+
+        var header = FindDescendantByName(root, "FileHeader") as Border;
+        if (header == null) return;
+
+        // Replace any existing entry for this file (template recycling).
+        _fileSections.RemoveAll(fs => ReferenceEquals(fs.Root, root));
+        _fileSections.Add(new FileSectionVisuals(file, root, header));
+
+        // Trigger one sticky pass so the just-added section participates immediately.
+        Dispatcher.BeginInvoke(new Action(UpdateRollingSticky),
+            System.Windows.Threading.DispatcherPriority.Loaded);
+    }
+
+    private void OnFileHeaderClick(object sender, MouseButtonEventArgs e)
+    {
+        if (e.Handled) return;
+        if (sender is not Border header) return;
+        if (header.DataContext is not RuleFileViewModel file) return;
+
+        // Toggle expand/collapse and select the file (without changing rule selection
+        // unless none was set yet).
+        file.IsExpanded = !file.IsExpanded;
+
+        if (DataContext is ConfigEditorViewModel vm)
+        {
+            vm.SelectedFile = file;
+            // If no rule is selected or the selected rule belongs to another file,
+            // adopt the first rule of this file so the detail panel has something
+            // to show. Otherwise leave the existing rule selection alone.
+            if (vm.SelectedRule == null || vm.SelectedRule.ParentFile != file)
+                vm.SelectedRule = file.Rules.FirstOrDefault();
+        }
+
+        Dispatcher.BeginInvoke(new Action(UpdateRollingSticky),
+            System.Windows.Threading.DispatcherPriority.Loaded);
+        e.Handled = true;
+    }
+
+    private void OnRuleRowClick(object sender, MouseButtonEventArgs e)
+    {
+        if (e.Handled) return;
+        if (sender is not Border row) return;
+        if (row.Tag is not RuleViewModel rule) return;
+
+        if (DataContext is ConfigEditorViewModel vm)
+            vm.SelectedRule = rule;
+
+        e.Handled = true;
+    }
+
+    /// <summary>
+    /// The right-side controls in the file header (source pills, overflow)
+    /// must not bubble their clicks up to the header — that would toggle
+    /// expansion every time the user changed the source.
+    /// </summary>
+    private void OnHeaderControlsMouseUp(object sender, MouseButtonEventArgs e)
+    {
+        e.Handled = true;
+    }
+
+    private void OnHeaderControlsMouseDown(object sender, MouseButtonEventArgs e)
+    {
+        e.Handled = true;
+    }
+
+    private void OnFileOverflowClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is not System.Windows.Controls.Button button) return;
+        if (button.Tag is not RuleFileViewModel file) return;
+        if (DataContext is not ConfigEditorViewModel vm) return;
+
+        var menu = new ContextMenu { PlacementTarget = button };
+
+        var deleteItem = new MenuItem
+        {
+            Header = BlockParam.Localization.Res.Get("ConfigEditor_DeleteFile")
+        };
+        deleteItem.Click += (_, _) => vm.DeleteFileCommand.Execute(file);
+        menu.Items.Add(deleteItem);
+
+        var exportItem = new MenuItem
+        {
+            Header = BlockParam.Localization.Res.Get("ConfigEditor_ExportFile")
+        };
+        exportItem.Click += (_, _) => vm.ExportFileCommand.Execute(file);
+        menu.Items.Add(exportItem);
+
+        if (file.HasOverrides)
+        {
+            menu.Items.Add(new Separator());
+            var resetItem = new MenuItem
+            {
+                Header = BlockParam.Localization.Res.Get("ConfigEditor_ResetToBase")
+            };
+            resetItem.Click += (_, _) =>
+            {
+                vm.SelectedFile = file;
+                vm.ResetToBaseCommand.Execute(null);
+            };
+            menu.Items.Add(resetItem);
+        }
+
+        menu.IsOpen = true;
+    }
+
+    /// <summary>
+    /// Rolling sticky: only one file header is pinned to the viewport top at
+    /// a time — whichever section is currently being scrolled through. As the
+    /// user crosses into the next section, that section's header takes over.
+    /// </summary>
+    private void OnFileListScrollChanged(object sender, ScrollChangedEventArgs e)
+    {
+        UpdateRollingSticky();
+    }
+
+    private void UpdateRollingSticky()
+    {
+        if (FileListScroll == null || _fileSections.Count == 0) return;
+
+        // Reset all transforms first.
+        foreach (var fs in _fileSections)
+        {
+            if (fs.Header.RenderTransform is TranslateTransform existing)
+                existing.Y = 0;
+        }
+
+        var viewportTop = 0.0; // relative to the ScrollViewer's content area
+        FileSectionVisuals? activeSticky = null;
+        FileSectionVisuals? nextSection = null;
+
+        foreach (var fs in _fileSections)
+        {
+            if (!IsRegistered(fs.Root)) continue;
+
+            var rootTopInScroll = TopWithinScrollViewer(fs.Root);
+            var rootHeight = fs.Root.ActualHeight;
+            var rootBottom = rootTopInScroll + rootHeight;
+
+            // Active sticky = the section straddling the viewport top.
+            // Once the body fully passes above the viewport top, the next
+            // section takes over. Single-section sticky (#70) — no stacking.
+            if (rootTopInScroll <= viewportTop && rootBottom > viewportTop)
+            {
+                activeSticky = fs;
+            }
+            else if (rootTopInScroll > viewportTop && nextSection == null)
+            {
+                nextSection = fs;
+            }
+        }
+
+        if (activeSticky != null)
+        {
+            var rootTop = TopWithinScrollViewer(activeSticky.Root);
+            // Pin: translate header down to viewport top.
+            var translate = -rootTop;
+
+            // Push it back out as the next section approaches, so the swap is smooth.
+            if (nextSection != null)
+            {
+                var nextTop = TopWithinScrollViewer(nextSection.Root);
+                var headerH = activeSticky.Header.ActualHeight;
+                var distance = nextTop - viewportTop;
+                if (distance < headerH)
+                    translate -= (headerH - distance);
+            }
+
+            if (activeSticky.Header.RenderTransform is TranslateTransform t)
+                t.Y = translate;
+        }
+    }
+
+    /// <summary>
+    /// Computes the top of <paramref name="el"/> relative to the FileListScroll
+    /// content area, accounting for the current scroll offset. (Transforming
+    /// to the ScrollViewer itself includes the scroll offset; we add it back
+    /// out by transforming relative to the ItemsControl.)
+    /// </summary>
+    private double TopWithinScrollViewer(FrameworkElement el)
+    {
+        if (FileListScroll?.Content is not FrameworkElement content)
+            return 0;
+        var p = el.TransformToVisual(content).Transform(new Point(0, 0));
+        return p.Y - FileListScroll.VerticalOffset;
+    }
+
+    private static bool IsRegistered(FrameworkElement el)
+    {
+        return PresentationSource.FromVisual(el) != null;
+    }
+
+    private static DependencyObject? FindDescendantByName(DependencyObject parent, string name)
+    {
+        for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, i);
+            if (child is FrameworkElement fe && fe.Name == name)
+                return child;
+
+            var found = FindDescendantByName(child, name);
+            if (found != null) return found;
+        }
+        return null;
+    }
+
+    private record FileSectionVisuals(RuleFileViewModel File, Grid Root, Border Header);
 }

--- a/src/BlockParam/UI/ConfigEditorDialog.xaml.cs
+++ b/src/BlockParam/UI/ConfigEditorDialog.xaml.cs
@@ -72,6 +72,13 @@ public partial class ConfigEditorDialog : Window
         var header = FindDescendantByName(root, "FileHeader") as Border;
         if (header == null) return;
 
+        // The inline <TranslateTransform/> declared in the DataTemplate gets
+        // auto-frozen by BAML (no bindings → shareable). A frozen Freezable
+        // throws InvalidOperationException on any property set, killing
+        // UpdateRollingSticky on every scroll tick. Swap in a per-instance
+        // mutable transform so the sticky math can mutate Y.
+        header.RenderTransform = new TranslateTransform();
+
         // Replace any existing entry for this file (template recycling).
         _fileSections.RemoveAll(fs => ReferenceEquals(fs.Root, root));
         _fileSections.Add(new FileSectionVisuals(file, root, header));

--- a/src/BlockParam/UI/ConfigEditorViewModel.cs
+++ b/src/BlockParam/UI/ConfigEditorViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.IO;
 using System.Windows.Data;
 using System.Windows.Input;

--- a/src/BlockParam/UI/ConfigEditorViewModel.cs
+++ b/src/BlockParam/UI/ConfigEditorViewModel.cs
@@ -1,5 +1,4 @@
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.IO;
 using System.Windows.Data;
 using System.Windows.Input;
@@ -11,7 +10,10 @@ namespace BlockParam.UI;
 
 /// <summary>
 /// ViewModel for the file-based Configuration Editor dialog.
-/// Scans Project/Local/Shared directories and shows individual rule files.
+///
+/// Two-level model: <see cref="RuleFiles"/> are physical .json files on disk,
+/// each containing 1..N <see cref="RuleViewModel"/> entries (issue #70 fix —
+/// previously rules 2..N were silently dropped on save).
 /// </summary>
 public class ConfigEditorViewModel : ViewModelBase
 {
@@ -19,10 +21,9 @@ public class ConfigEditorViewModel : ViewModelBase
     private string _sharedRulesDirectory = "";
     private string _validationMessage = "";
     private string _filterText = "";
+    private RuleViewModel? _selectedRule;
     private RuleFileViewModel? _selectedFile;
 
-    /// <param name="configLoader">Config loader (provides directory paths).</param>
-    /// <param name="tagTableNames">Optional tag table names for dropdown.</param>
     public ConfigEditorViewModel(
         ConfigLoader configLoader,
         IEnumerable<string>? tagTableNames = null)
@@ -32,14 +33,19 @@ public class ConfigEditorViewModel : ViewModelBase
         RuleFiles = new ObservableCollection<RuleFileViewModel>();
         TagTableNames = new ObservableCollection<string>();
         FilteredRuleFiles = CollectionViewSource.GetDefaultView(RuleFiles);
-        FilteredRuleFiles.Filter = FilterRule;
+        FilteredRuleFiles.Filter = FilterFile;
 
         NewRuleCommand = new RelayCommand(ExecuteNewRule);
-        DuplicateSelectedCommand = new RelayCommand(ExecuteDuplicateSelected, () => SelectedFile != null);
-        DeleteSelectedCommand = new RelayCommand(ExecuteDeleteSelected, () => SelectedFile != null);
+        NewFileCommand = new RelayCommand(ExecuteNewFile);
+        DuplicateSelectedCommand = new RelayCommand(ExecuteDuplicateSelected, () => SelectedRule != null);
+        DeleteSelectedCommand = new RelayCommand(ExecuteDeleteSelected, () => SelectedRule != null || SelectedFile != null);
+        DeleteFileCommand = new RelayCommand(p => ExecuteDeleteFile(p as RuleFileViewModel), p => p is RuleFileViewModel);
         ResetToBaseCommand = new RelayCommand(ExecuteResetToBase, () => SelectedFile?.HasOverrides == true);
         SaveCommand = new RelayCommand(ExecuteSave);
         SaveAndCloseCommand = new RelayCommand(ExecuteSaveAndClose);
+        ImportFilesCommand = new RelayCommand(ExecuteImportFiles);
+        ExportFileCommand = new RelayCommand(p => ExecuteExportFile(p as RuleFileViewModel), p => p is RuleFileViewModel);
+        ExportSelectedCommand = new RelayCommand(ExecuteExportSelected, () => SelectedFile != null);
 
         LoadAllFiles();
 
@@ -54,6 +60,30 @@ public class ConfigEditorViewModel : ViewModelBase
 
     public event Action? RequestClose;
 
+    /// <summary>The rule currently bound to the detail panel.</summary>
+    public RuleViewModel? SelectedRule
+    {
+        get => _selectedRule;
+        set
+        {
+            var previous = _selectedRule;
+            if (SetProperty(ref _selectedRule, value))
+            {
+                if (previous != null) previous.IsSelected = false;
+                if (value != null)
+                {
+                    value.IsSelected = true;
+                    if (value.ParentFile != null)
+                        SelectedFile = value.ParentFile;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// The file currently in focus. Set automatically when a rule is selected,
+    /// or explicitly when the user clicks a file header (no rule selected).
+    /// </summary>
     public RuleFileViewModel? SelectedFile
     {
         get => _selectedFile;
@@ -72,7 +102,10 @@ public class ConfigEditorViewModel : ViewModelBase
         set
         {
             if (SetProperty(ref _filterText, value))
+            {
                 FilteredRuleFiles.Refresh();
+                AutoExpandMatches();
+            }
         }
     }
 
@@ -83,33 +116,68 @@ public class ConfigEditorViewModel : ViewModelBase
     }
 
     public ICommand NewRuleCommand { get; }
+    public ICommand NewFileCommand { get; }
     public ICommand DuplicateSelectedCommand { get; }
     public ICommand DeleteSelectedCommand { get; }
+    public ICommand DeleteFileCommand { get; }
     public ICommand ResetToBaseCommand { get; }
     public ICommand SaveCommand { get; }
     public ICommand SaveAndCloseCommand { get; }
 
-    private bool FilterRule(object obj)
+    /// <summary>
+    /// UI-only stub for now (#70 follow-up). Wires the toolbar button so the
+    /// import flow can be added without touching the ViewModel surface again.
+    /// </summary>
+    public ICommand ImportFilesCommand { get; }
+
+    /// <summary>UI-only stub: export currently selected file. Logic out of scope.</summary>
+    public ICommand ExportSelectedCommand { get; }
+
+    /// <summary>UI-only stub: export a specific file (used by the file-header overflow).</summary>
+    public ICommand ExportFileCommand { get; }
+
+    /// <summary>True when the import/export flow is implemented. Always false until logic lands.</summary>
+    public bool IsImportExportImplemented => false;
+
+    private bool FilterFile(object obj)
     {
         if (string.IsNullOrWhiteSpace(_filterText)) return true;
-        if (obj is not RuleFileViewModel rule) return false;
-        return rule.PathPattern.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0;
+        if (obj is not RuleFileViewModel file) return false;
+
+        if (file.FileName.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0)
+            return true;
+
+        return file.Rules.Any(r =>
+            r.PathPattern.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
+            || r.TagTableName.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
+            || r.CommentTemplate.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0);
+    }
+
+    private void AutoExpandMatches()
+    {
+        if (string.IsNullOrWhiteSpace(_filterText)) return;
+        foreach (var file in RuleFiles)
+        {
+            var anyMatch = file.Rules.Any(r =>
+                r.PathPattern.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
+                || r.TagTableName.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
+                || r.CommentTemplate.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0);
+            if (anyMatch) file.IsExpanded = true;
+        }
     }
 
     /// <summary>
-    /// Scans all 3 directories, groups by filename, and shows only the
-    /// highest-priority version per rule (TiaProject > Local > Shared).
-    /// Lower-priority versions are stored in OverriddenVersions for reset.
+    /// Scans Project / Local / Shared directories. Files with the same name
+    /// across multiple sources are grouped — the highest-priority version wins
+    /// and the others become <see cref="RuleFileViewModel.OverriddenVersions"/>.
     /// </summary>
     private void LoadAllFiles()
     {
         RuleFiles.Clear();
 
-        // Read shared directory from existing config
         var config = _configLoader.GetConfig();
         SharedRulesDirectory = config?.RulesDirectory ?? "";
 
-        // Load all files into a flat list first
         var allFiles = new List<RuleFileViewModel>();
 
         if (!string.IsNullOrWhiteSpace(SharedRulesDirectory))
@@ -125,10 +193,9 @@ public class ConfigEditorViewModel : ViewModelBase
         if (projectDir != null && Directory.Exists(projectDir))
             LoadFilesFromDirectory(projectDir, RuleSource.TiaProject, allFiles);
 
-        // Group by path pattern, keep highest priority, attach overridden versions.
-        // Skip duplicates that point to the same physical file (e.g. shared==local dir).
-        var groups = allFiles
-            .GroupBy(f => f.PathPattern, StringComparer.OrdinalIgnoreCase);
+        // Group by filename (override unit is the file). Same physical path
+        // across sources (shared==local) gets deduped first.
+        var groups = allFiles.GroupBy(f => f.FileName, StringComparer.OrdinalIgnoreCase);
 
         foreach (var group in groups)
         {
@@ -146,6 +213,7 @@ public class ConfigEditorViewModel : ViewModelBase
             if (effective.OverriddenVersions.Count > 0)
                 effective.IsOverride = true;
 
+            effective.NotifyOverrideChanged();
             RuleFiles.Add(effective);
         }
     }
@@ -189,9 +257,6 @@ public class ConfigEditorViewModel : ViewModelBase
         return rulesDir;
     }
 
-    /// <summary>
-    /// Returns the default save directory based on destination.
-    /// </summary>
     private string? GetDirectoryForSource(RuleSource source)
     {
         return source switch
@@ -204,26 +269,25 @@ public class ConfigEditorViewModel : ViewModelBase
         };
     }
 
+    /// <summary>
+    /// Adds a new rule to the currently selected file. If no file is selected
+    /// (e.g. first-run, empty editor) we create a new file with the rule inside.
+    /// </summary>
     private void ExecuteNewRule()
     {
         try
         {
-            var defaultSource = GetDefaultNewFileSource();
-            var dir = GetDirectoryForSource(defaultSource);
-            if (dir == null) { ValidationMessage = "No valid save directory available."; return; }
-
-            var fileName = GenerateUniqueNewRuleFileName(dir);
-            var vm = new RuleFileViewModel
+            var file = SelectedFile ?? SelectedRule?.ParentFile;
+            if (file == null)
             {
-                FileName = fileName,
-                FilePath = Path.Combine(dir, fileName),
-                Source = defaultSource,
-                SaveDestination = defaultSource,
-                FileType = "Rule",
-                IsNew = true
-            };
-            RuleFiles.Add(vm);
-            SelectedFile = vm;
+                ExecuteNewFile();
+                return;
+            }
+
+            var rule = new RuleViewModel { IsNew = true };
+            file.Rules.Add(rule);
+            file.IsExpanded = true;
+            SelectedRule = rule;
             ValidationMessage = "";
         }
         catch (Exception ex)
@@ -233,40 +297,67 @@ public class ConfigEditorViewModel : ViewModelBase
         }
     }
 
-    private void ExecuteDuplicateSelected()
+    /// <summary>Creates a new file with one starter rule and selects it.</summary>
+    private void ExecuteNewFile()
     {
-        if (SelectedFile == null) return;
         try
         {
-            var source = SelectedFile;
-            var destination = source.SaveDestination;
-            var dir = GetDirectoryForSource(destination) ?? GetDirectoryForSource(GetDefaultNewFileSource());
+            var defaultSource = GetDefaultNewFileSource();
+            var dir = GetDirectoryForSource(defaultSource);
             if (dir == null) { ValidationMessage = "No valid save directory available."; return; }
 
-            // Order matters: set the fields first (with IsNew=false so the pattern setter
-            // does not auto-rename the file to the source's filename), then assign the
-            // unique filename, then flip IsNew=true so subsequent pattern edits auto-sync.
-            var vm = new RuleFileViewModel
+            var fileName = GenerateUniqueNewFileName(dir);
+            var file = new RuleFileViewModel
             {
-                FileType = source.FileType,
-                Source = destination,
-                SaveDestination = destination,
-                PathPattern = source.PathPattern,
-                Datatype = source.Datatype,
-                TagTableName = source.TagTableName,
-                RequireTagTableValue = source.RequireTagTableValue,
-                Min = source.Min,
-                Max = source.Max,
-                AllowedValues = source.AllowedValues,
-                CommentTemplate = source.CommentTemplate,
-                ExcludeFromSetpoints = source.ExcludeFromSetpoints
+                FileName = fileName,
+                FilePath = Path.Combine(dir, fileName),
+                Source = defaultSource,
+                SaveDestination = defaultSource,
+                FileType = "Rule",
+                IsNew = true,
+                IsExpanded = true
             };
-            var fileName = GenerateUniqueNewRuleFileName(dir);
-            vm.FileName = fileName;
-            vm.FilePath = Path.Combine(dir, fileName);
-            vm.IsNew = true;
-            RuleFiles.Add(vm);
-            SelectedFile = vm;
+            var rule = new RuleViewModel { IsNew = true };
+            file.Rules.Add(rule);
+
+            RuleFiles.Add(file);
+            SelectedRule = rule;
+            SelectedFile = file;
+            ValidationMessage = "";
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "ExecuteNewFile failed");
+            ValidationMessage = $"Could not create new file: {ex.Message}";
+        }
+    }
+
+    private void ExecuteDuplicateSelected()
+    {
+        if (SelectedRule == null) return;
+        try
+        {
+            var src = SelectedRule;
+            var file = src.ParentFile;
+            if (file == null) return;
+
+            var copy = new RuleViewModel
+            {
+                PathPattern = src.PathPattern,
+                Datatype = src.Datatype,
+                TagTableName = src.TagTableName,
+                RequireTagTableValue = src.RequireTagTableValue,
+                Min = src.Min,
+                Max = src.Max,
+                AllowedValues = src.AllowedValues,
+                CommentTemplate = src.CommentTemplate,
+                ExcludeFromSetpoints = src.ExcludeFromSetpoints,
+                IsNew = true
+            };
+            var idx = file.Rules.IndexOf(src);
+            file.Rules.Insert(idx + 1, copy);
+            file.IsExpanded = true;
+            SelectedRule = copy;
             ValidationMessage = "";
         }
         catch (Exception ex)
@@ -277,13 +368,10 @@ public class ConfigEditorViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Returns a filename that does not collide with an existing file on disk
-    /// or an unsaved rule already staged in memory. Two successive "+"-clicks
-    /// previously produced two rules pointing at the same "new-rule.json",
-    /// which caused the second Save to overwrite — and in some environments
-    /// crashed the DataGrid when the new row was committed over a pending edit.
+    /// Tracks unique filenames against staged + on-disk files so successive
+    /// "+ File" clicks don't both produce "new-rule.json".
     /// </summary>
-    private string GenerateUniqueNewRuleFileName(string dir)
+    private string GenerateUniqueNewFileName(string dir)
     {
         var stagedNames = new HashSet<string>(
             RuleFiles.Select(r => r.FileName),
@@ -300,50 +388,79 @@ public class ConfigEditorViewModel : ViewModelBase
         return $"{baseName}-{Guid.NewGuid():N}.json";
     }
 
-
     private RuleSource GetDefaultNewFileSource()
     {
-        // Prefer Project if available, otherwise Local
         var projectDir = _configLoader.GetTiaProjectRulesDirectory();
         return projectDir != null ? RuleSource.TiaProject : RuleSource.Local;
     }
 
+    /// <summary>
+    /// Context-aware delete: removes the selected rule. If it's the last rule
+    /// in the file, the file is removed from disk too.
+    /// </summary>
     private void ExecuteDeleteSelected()
     {
-        if (SelectedFile == null) return;
-
-        // Delete the file from disk if it exists
-        if (File.Exists(SelectedFile.FilePath))
+        if (SelectedRule != null)
         {
-            try
+            var file = SelectedRule.ParentFile;
+            if (file == null) return;
+
+            file.Rules.Remove(SelectedRule);
+            SelectedRule = null;
+
+            if (file.Rules.Count == 0)
             {
-                File.Delete(SelectedFile.FilePath);
+                DeleteFileFromDisk(file);
+                RuleFiles.Remove(file);
+                if (SelectedFile == file) SelectedFile = null;
             }
-            catch (Exception ex)
-            {
-                ValidationMessage = $"Cannot delete file: {ex.Message}";
-                return;
-            }
+
+            _configLoader.Invalidate();
+            return;
         }
 
-        RuleFiles.Remove(SelectedFile);
-        SelectedFile = null;
+        if (SelectedFile != null)
+        {
+            ExecuteDeleteFile(SelectedFile);
+        }
+    }
+
+    private void ExecuteDeleteFile(RuleFileViewModel? file)
+    {
+        if (file == null) return;
+        DeleteFileFromDisk(file);
+        RuleFiles.Remove(file);
+        if (SelectedFile == file) SelectedFile = null;
+        if (SelectedRule?.ParentFile == file) SelectedRule = null;
         _configLoader.Invalidate();
     }
 
+    private void DeleteFileFromDisk(RuleFileViewModel file)
+    {
+        if (!File.Exists(file.FilePath)) return;
+        try
+        {
+            File.Delete(file.FilePath);
+        }
+        catch (Exception ex)
+        {
+            ValidationMessage = $"Cannot delete file: {ex.Message}";
+        }
+    }
+
     /// <summary>
-    /// Deletes the current override and reveals the next-priority version.
+    /// Deletes the current override file and reveals the next-priority version.
+    /// Operates at the file level — all rules in the file are reset together.
     /// </summary>
     private void ExecuteResetToBase()
     {
         if (SelectedFile == null || SelectedFile.OverriddenVersions.Count == 0) return;
 
         var current = SelectedFile;
-        var baseRule = current.OverriddenVersions[0];
+        var baseFile = current.OverriddenVersions[0];
 
-        // Delete the override file (only if physically different from the base)
         var currentPath = Path.GetFullPath(current.FilePath);
-        var basePath = Path.GetFullPath(baseRule.FilePath);
+        var basePath = Path.GetFullPath(baseFile.FilePath);
         if (File.Exists(currentPath)
             && !string.Equals(currentPath, basePath, StringComparison.OrdinalIgnoreCase))
         {
@@ -358,16 +475,16 @@ public class ConfigEditorViewModel : ViewModelBase
             }
         }
 
-        // Reload deferred to avoid collection modification during active bindings
-        var patternToSelect = baseRule.PathPattern;
+        var nameToSelect = baseFile.FileName;
         _configLoader.Invalidate();
         Dispatcher.CurrentDispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
         {
+            SelectedRule = null;
             SelectedFile = null;
             LoadAllFiles();
             FilteredRuleFiles.Refresh();
             SelectedFile = RuleFiles.FirstOrDefault(f =>
-                string.Equals(f.PathPattern, patternToSelect, StringComparison.OrdinalIgnoreCase));
+                string.Equals(f.FileName, nameToSelect, StringComparison.OrdinalIgnoreCase));
         }));
     }
 
@@ -391,23 +508,47 @@ public class ConfigEditorViewModel : ViewModelBase
             RequestClose?.Invoke();
     }
 
-    /// <summary>
-    /// Rebuilds the rule list after save to update override grouping.
-    /// Deferred via Dispatcher to avoid modifying the collection during active bindings.
-    /// </summary>
+    /// <summary>UI-only stub. Logic intentionally out of scope.</summary>
+    private void ExecuteImportFiles()
+    {
+        ValidationMessage = "Import is not yet implemented.";
+    }
+
+    /// <summary>UI-only stub. Logic intentionally out of scope.</summary>
+    private void ExecuteExportSelected()
+    {
+        ExecuteExportFile(SelectedFile);
+    }
+
+    /// <summary>UI-only stub. Logic intentionally out of scope.</summary>
+    private void ExecuteExportFile(RuleFileViewModel? file)
+    {
+        ValidationMessage = file != null
+            ? $"Export of '{file.FileName}' is not yet implemented."
+            : "Export is not yet implemented.";
+    }
+
     private void ReloadAfterSave()
     {
-        var selectedPattern = SelectedFile?.PathPattern;
+        var selectedFileName = SelectedFile?.FileName;
+        var selectedRulePattern = SelectedRule?.PathPattern;
         Dispatcher.CurrentDispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
         {
             try
             {
+                SelectedRule = null;
                 SelectedFile = null;
                 LoadAllFiles();
                 FilteredRuleFiles.Refresh();
-                if (selectedPattern != null)
-                    SelectedFile = RuleFiles.FirstOrDefault(f =>
-                        string.Equals(f.PathPattern, selectedPattern, StringComparison.OrdinalIgnoreCase));
+                if (selectedFileName != null)
+                {
+                    var file = RuleFiles.FirstOrDefault(f =>
+                        string.Equals(f.FileName, selectedFileName, StringComparison.OrdinalIgnoreCase));
+                    SelectedFile = file;
+                    if (file != null && selectedRulePattern != null)
+                        SelectedRule = file.Rules.FirstOrDefault(r =>
+                            string.Equals(r.PathPattern, selectedRulePattern, StringComparison.OrdinalIgnoreCase));
+                }
             }
             catch (Exception ex)
             {
@@ -416,27 +557,37 @@ public class ConfigEditorViewModel : ViewModelBase
         }));
     }
 
-    /// <summary>
-    /// Validates and saves all modified files. Returns true on success.
-    /// </summary>
     private bool SaveAll()
     {
-        // Validate all files
+        // Auto-derive filename for new files whose first rule's pattern was edited
         foreach (var file in RuleFiles)
         {
+            if (file.IsNew)
+            {
+                var derived = file.DeriveFileNameFromFirstRule();
+                if (!string.Equals(file.FileName, derived, StringComparison.OrdinalIgnoreCase)
+                    && (file.FileName == "" || file.FileName.StartsWith("new-rule", StringComparison.OrdinalIgnoreCase)))
+                {
+                    file.FileName = derived;
+                    var dir = Path.GetDirectoryName(file.FilePath);
+                    if (!string.IsNullOrEmpty(dir))
+                        file.FilePath = Path.Combine(dir, derived);
+                }
+            }
+
             var error = file.Validate();
             if (error != null)
             {
                 ValidationMessage = error;
                 SelectedFile = file;
+                if (file.Rules.Count > 0)
+                    SelectedRule = file.Rules.FirstOrDefault(r => r.Validate(file.FileName) != null) ?? file.Rules[0];
                 return false;
             }
         }
 
-        // Save shared directory setting to config.json
         SaveSharedDirectorySetting();
 
-        // Save each file to its destination
         foreach (var file in RuleFiles)
         {
             try
@@ -452,7 +603,6 @@ public class ConfigEditorViewModel : ViewModelBase
                 var config = file.ToBulkChangeConfig();
                 _configLoader.SaveRuleFile(targetPath, config);
 
-                // Update file's path and source to new location
                 file.FilePath = targetPath;
                 file.Source = file.SaveDestination;
                 file.MarkClean();
@@ -475,5 +625,4 @@ public class ConfigEditorViewModel : ViewModelBase
         _configLoader.SaveSharedRulesDirectory(
             string.IsNullOrWhiteSpace(SharedRulesDirectory) ? null : SharedRulesDirectory);
     }
-
 }

--- a/src/BlockParam/UI/ConfigEditorViewModel.cs
+++ b/src/BlockParam/UI/ConfigEditorViewModel.cs
@@ -6,6 +6,7 @@ using System.Windows.Input;
 using System.Windows.Threading;
 using BlockParam.Diagnostics;
 using BlockParam.Config;
+using BlockParam.Localization;
 
 namespace BlockParam.UI;
 
@@ -300,7 +301,7 @@ public class ConfigEditorViewModel : ViewModelBase
         catch (Exception ex)
         {
             Log.Error(ex, "ExecuteNewRule failed");
-            ValidationMessage = $"Could not create new rule: {ex.Message}";
+            ValidationMessage = Res.Format("ConfigEditor_NewRule_Failed", ex.Message);
         }
     }
 
@@ -311,7 +312,7 @@ public class ConfigEditorViewModel : ViewModelBase
         {
             var defaultSource = GetDefaultNewFileSource();
             var dir = GetDirectoryForSource(defaultSource);
-            if (dir == null) { ValidationMessage = "No valid save directory available."; return; }
+            if (dir == null) { ValidationMessage = Res.Get("ConfigEditor_NewFile_NoDir"); return; }
 
             var fileName = GenerateUniqueNewFileName(dir);
             var file = new RuleFileViewModel
@@ -335,7 +336,7 @@ public class ConfigEditorViewModel : ViewModelBase
         catch (Exception ex)
         {
             Log.Error(ex, "ExecuteNewFile failed");
-            ValidationMessage = $"Could not create new file: {ex.Message}";
+            ValidationMessage = Res.Format("ConfigEditor_NewFile_Failed", ex.Message);
         }
     }
 
@@ -370,7 +371,7 @@ public class ConfigEditorViewModel : ViewModelBase
         catch (Exception ex)
         {
             Log.Error(ex, "ExecuteDuplicateSelected failed");
-            ValidationMessage = $"Could not duplicate rule: {ex.Message}";
+            ValidationMessage = Res.Format("ConfigEditor_Duplicate_Failed", ex.Message);
         }
     }
 
@@ -451,7 +452,7 @@ public class ConfigEditorViewModel : ViewModelBase
         }
         catch (Exception ex)
         {
-            ValidationMessage = $"Cannot delete file: {ex.Message}";
+            ValidationMessage = Res.Format("ConfigEditor_DeleteFile_Failed", ex.Message);
         }
     }
 
@@ -518,7 +519,7 @@ public class ConfigEditorViewModel : ViewModelBase
     /// <summary>UI-only stub. Logic intentionally out of scope.</summary>
     private void ExecuteImportFiles()
     {
-        ValidationMessage = "Import is not yet implemented.";
+        ValidationMessage = Res.Get("ConfigEditor_Import_NotImplemented");
     }
 
     /// <summary>UI-only stub. Logic intentionally out of scope.</summary>
@@ -531,8 +532,8 @@ public class ConfigEditorViewModel : ViewModelBase
     private void ExecuteExportFile(RuleFileViewModel? file)
     {
         ValidationMessage = file != null
-            ? $"Export of '{file.FileName}' is not yet implemented."
-            : "Export is not yet implemented.";
+            ? Res.Format("ConfigEditor_ExportFile_NotImplemented", file.FileName)
+            : Res.Get("ConfigEditor_Export_NotImplemented");
     }
 
     private void ReloadAfterSave()

--- a/src/BlockParam/UI/ConfigEditorViewModel.cs
+++ b/src/BlockParam/UI/ConfigEditorViewModel.cs
@@ -18,6 +18,7 @@ namespace BlockParam.UI;
 public class ConfigEditorViewModel : ViewModelBase
 {
     private readonly ConfigLoader _configLoader;
+    private readonly Dispatcher _dispatcher;
     private string _sharedRulesDirectory = "";
     private string _validationMessage = "";
     private string _filterText = "";
@@ -29,6 +30,11 @@ public class ConfigEditorViewModel : ViewModelBase
         IEnumerable<string>? tagTableNames = null)
     {
         _configLoader = configLoader;
+        // Capture the UI-thread dispatcher at construction. Save flows defer
+        // a reload via this dispatcher; using Dispatcher.CurrentDispatcher
+        // inside the deferred callback would be wrong if Save was ever
+        // invoked from a non-UI thread.
+        _dispatcher = Dispatcher.CurrentDispatcher;
 
         RuleFiles = new ObservableCollection<RuleFileViewModel>();
         TagTableNames = new ObservableCollection<string>();
@@ -136,9 +142,6 @@ public class ConfigEditorViewModel : ViewModelBase
     /// <summary>UI-only stub: export a specific file (used by the file-header overflow).</summary>
     public ICommand ExportFileCommand { get; }
 
-    /// <summary>True when the import/export flow is implemented. Always false until logic lands.</summary>
-    public bool IsImportExportImplemented => false;
-
     private bool FilterFile(object obj)
     {
         if (string.IsNullOrWhiteSpace(_filterText)) return true;
@@ -147,22 +150,25 @@ public class ConfigEditorViewModel : ViewModelBase
         if (file.FileName.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0)
             return true;
 
-        return file.Rules.Any(r =>
-            r.PathPattern.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
-            || r.TagTableName.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
-            || r.CommentTemplate.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0);
+        return file.Rules.Any(RuleMatchesFilter);
     }
+
+    private bool RuleMatchesFilter(RuleViewModel r) =>
+        r.PathPattern.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
+        || r.TagTableName.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
+        || r.CommentTemplate.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
+        || r.Datatype.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
+        || r.AllowedValues.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
+        || r.Min.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
+        || r.Max.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0;
 
     private void AutoExpandMatches()
     {
         if (string.IsNullOrWhiteSpace(_filterText)) return;
         foreach (var file in RuleFiles)
         {
-            var anyMatch = file.Rules.Any(r =>
-                r.PathPattern.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
-                || r.TagTableName.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
-                || r.CommentTemplate.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0);
-            if (anyMatch) file.IsExpanded = true;
+            if (file.Rules.Any(RuleMatchesFilter))
+                file.IsExpanded = true;
         }
     }
 
@@ -477,7 +483,7 @@ public class ConfigEditorViewModel : ViewModelBase
 
         var nameToSelect = baseFile.FileName;
         _configLoader.Invalidate();
-        Dispatcher.CurrentDispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
+        _dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
         {
             SelectedRule = null;
             SelectedFile = null;
@@ -532,7 +538,7 @@ public class ConfigEditorViewModel : ViewModelBase
     {
         var selectedFileName = SelectedFile?.FileName;
         var selectedRulePattern = SelectedRule?.PathPattern;
-        Dispatcher.CurrentDispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
+        _dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
         {
             try
             {
@@ -559,14 +565,17 @@ public class ConfigEditorViewModel : ViewModelBase
 
     private bool SaveAll()
     {
-        // Auto-derive filename for new files whose first rule's pattern was edited
+        // Auto-derive filename for new files whose name still matches the
+        // placeholder pattern (^new-rule(-\d+)?\.json$). Once the user types
+        // anything else, IsAutoNamed flips to false and we keep their name —
+        // so a file the user explicitly named "my-rules.json" never gets
+        // silently renamed to a pattern-derived name on save.
         foreach (var file in RuleFiles)
         {
-            if (file.IsNew)
+            if (file.IsNew && file.IsAutoNamed)
             {
                 var derived = file.DeriveFileNameFromFirstRule();
-                if (!string.Equals(file.FileName, derived, StringComparison.OrdinalIgnoreCase)
-                    && (file.FileName == "" || file.FileName.StartsWith("new-rule", StringComparison.OrdinalIgnoreCase)))
+                if (!string.Equals(file.FileName, derived, StringComparison.OrdinalIgnoreCase))
                 {
                     file.FileName = derived;
                     var dir = Path.GetDirectoryName(file.FilePath);

--- a/src/BlockParam/UI/Converters.cs
+++ b/src/BlockParam/UI/Converters.cs
@@ -72,6 +72,26 @@ public class RuleSourceToBoolConverter : IValueConverter
     }
 }
 
+/// <summary>
+/// Converts a RuleSource enum to its localized label
+/// (Project / Local / Shared). One-way; ConvertBack is unused.
+/// </summary>
+public class RuleSourceToLabelConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is RuleSource source)
+        {
+            var key = source == RuleSource.TiaProject ? "Project" : source.ToString();
+            return Localization.Res.Get($"ConfigEditor_{key}");
+        }
+        return value?.ToString() ?? "";
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => System.Windows.Data.Binding.DoNothing;
+}
+
 public class StringNotEmptyToVisibilityConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/BlockParam/UI/RuleFileViewModel.cs
+++ b/src/BlockParam/UI/RuleFileViewModel.cs
@@ -29,6 +29,9 @@ public class RuleFileViewModel : ViewModelBase
         "Timer", "Counter"
     };
 
+    private static readonly Regex AutoNamePattern =
+        new(@"^new-rule(-\d+)?\.json$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
     private string _fileName = "";
     private string _filePath = "";
     private RuleSource _source;
@@ -40,8 +43,20 @@ public class RuleFileViewModel : ViewModelBase
     private bool _isNew;
     private bool _isExpanded = true;
 
+    /// <summary>
+    /// Tracks which rules we've subscribed to. Doubles as the source of truth
+    /// for <see cref="NotifyCollectionChangedAction.Reset"/>, where neither
+    /// OldItems nor NewItems is populated — without this, Reset would leak
+    /// PropertyChanged subscriptions on the cleared rules.
+    /// </summary>
+    private readonly HashSet<RuleViewModel> _subscribedRules = new();
+
     public RuleFileViewModel()
     {
+        // Stable per-instance identifier — used as RadioButton GroupName so
+        // each file's source pills stay grouped only with each other, even
+        // across save/reload cycles where FilePath transitions briefly.
+        GroupId = Guid.NewGuid().ToString("N");
         Rules = new ObservableCollection<RuleViewModel>();
         Rules.CollectionChanged += OnRulesCollectionChanged;
     }
@@ -51,15 +66,54 @@ public class RuleFileViewModel : ViewModelBase
     /// </summary>
     public ObservableCollection<RuleViewModel> Rules { get; }
 
+    /// <summary>Stable per-instance ID for grouping the file's source RadioButtons.</summary>
+    public string GroupId { get; }
+
+    private void Subscribe(RuleViewModel r)
+    {
+        if (_subscribedRules.Add(r))
+        {
+            r.ParentFile = this;
+            r.PropertyChanged += OnRulePropertyChanged;
+        }
+    }
+
+    private void Unsubscribe(RuleViewModel r)
+    {
+        if (_subscribedRules.Remove(r))
+        {
+            r.PropertyChanged -= OnRulePropertyChanged;
+            if (ReferenceEquals(r.ParentFile, this))
+                r.ParentFile = null;
+        }
+    }
+
+    /// <summary>
+    /// Re-parents rules and (un)subscribes to their PropertyChanged so the
+    /// file's aggregate <see cref="IsDirty"/> updates without each rule
+    /// setter having to call back. Handles Add / Remove / Replace / Reset.
+    /// </summary>
     private void OnRulesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        if (e.NewItems != null)
-            foreach (RuleViewModel r in e.NewItems)
-                r.ParentFile = this;
-        if (e.OldItems != null)
-            foreach (RuleViewModel r in e.OldItems)
-                if (ReferenceEquals(r.ParentFile, this))
-                    r.ParentFile = null;
+        if (e.Action == NotifyCollectionChangedAction.Reset)
+        {
+            // Reset (e.g. Rules.Clear()) populates neither OldItems nor NewItems.
+            // Diff against our subscription set: drop anything no longer present,
+            // pick up anything new.
+            foreach (var r in _subscribedRules.ToList())
+                if (!Rules.Contains(r)) Unsubscribe(r);
+            foreach (var r in Rules) Subscribe(r);
+        }
+        else
+        {
+            // OldItems first: a Replace event populates both OldItems and
+            // NewItems with the (potentially same) instances. Subscribing
+            // last guarantees ParentFile ends up correct on Replace.
+            if (e.OldItems != null)
+                foreach (RuleViewModel r in e.OldItems) Unsubscribe(r);
+            if (e.NewItems != null)
+                foreach (RuleViewModel r in e.NewItems) Subscribe(r);
+        }
 
         OnPropertyChanged(nameof(RuleCount));
         OnPropertyChanged(nameof(HasMultipleRules));
@@ -67,10 +121,13 @@ public class RuleFileViewModel : ViewModelBase
         OnPropertyChanged(nameof(HeaderSummary));
     }
 
-    /// <summary>Called by child <see cref="RuleViewModel"/> when its dirty state may have changed.</summary>
-    internal void NotifyChildChanged()
+    private void OnRulePropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        OnPropertyChanged(nameof(IsDirty));
+        if (e.PropertyName == nameof(RuleViewModel.IsDirty)
+            || string.IsNullOrEmpty(e.PropertyName))
+        {
+            OnPropertyChanged(nameof(IsDirty));
+        }
     }
 
     public int RuleCount => Rules.Count;
@@ -85,9 +142,19 @@ public class RuleFileViewModel : ViewModelBase
             {
                 OnPropertyChanged(nameof(IsDirty));
                 OnPropertyChanged(nameof(HeaderSummary));
+                OnPropertyChanged(nameof(IsAutoNamed));
             }
         }
     }
+
+    /// <summary>
+    /// True when the filename still matches the placeholder auto-name pattern
+    /// produced by <c>GenerateUniqueNewFileName</c>. Used by SaveAll to decide
+    /// whether to derive the final filename from the first rule's pathPattern.
+    /// Once the user types anything else, this becomes false and the user's
+    /// name is preserved verbatim.
+    /// </summary>
+    public bool IsAutoNamed => AutoNamePattern.IsMatch(_fileName);
 
     public string FilePath
     {

--- a/src/BlockParam/UI/RuleFileViewModel.cs
+++ b/src/BlockParam/UI/RuleFileViewModel.cs
@@ -29,6 +29,15 @@ public class RuleFileViewModel : ViewModelBase
         "Timer", "Counter"
     };
 
+    /// <summary>The three sources a user can save a rule file to. Inline rules
+    /// live in DB/UDT comments and are not authored through this editor.</summary>
+    public static readonly RuleSource[] UserSelectableSources =
+    {
+        RuleSource.TiaProject,
+        RuleSource.Local,
+        RuleSource.Shared,
+    };
+
     private static readonly Regex AutoNamePattern =
         new(@"^new-rule(-\d+)?\.json$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 

--- a/src/BlockParam/UI/RuleFileViewModel.cs
+++ b/src/BlockParam/UI/RuleFileViewModel.cs
@@ -1,3 +1,5 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.IO;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
@@ -7,15 +9,14 @@ using BlockParam.Services;
 namespace BlockParam.UI;
 
 /// <summary>
-/// ViewModel representing a single rule file from any source (Project/Local/Shared).
-/// Supports two file types: Rule, Excludes.
-/// Comment templates are now part of Rule files (per-rule, not a separate file type).
+/// ViewModel representing a single rule file (one .json on disk).
+/// A file contains 1..N <see cref="RuleViewModel"/> entries — issue #70 fix:
+/// the editor now round-trips the entire <c>rules[]</c> array instead of
+/// silently dropping rules 2..N on save.
 /// </summary>
 public class RuleFileViewModel : ViewModelBase
 {
-    /// <summary>
-    /// Well-known TIA Portal primitive data types for the Datatype dropdown.
-    /// </summary>
+    /// <summary>Well-known TIA Portal primitive data types for the Datatype dropdown.</summary>
     public static readonly string[] TiaDataTypes =
     {
         "", "Bool", "Byte", "Word", "DWord", "LWord",
@@ -34,35 +35,58 @@ public class RuleFileViewModel : ViewModelBase
     private string _fileType = "Rule";
     private bool _isOverride;
     private RuleSource _saveDestination;
-    private bool _isNew;
-
-    // Rule fields
-    private string _pathPattern = "";
-    private string _datatype = "";
-    private string _tagTableName = "";
-    private bool _requireTagTableValue;
-    private string _min = "";
-    private string _max = "";
-    private string _allowedValues = "";
-    private string _commentTemplate = "";
-    private bool _excludeFromSetpoints;
-
-    // Snapshot of saved state for dirty tracking
-    private string _savedPathPattern = "";
-    private string _savedDatatype = "";
-    private string _savedTagTableName = "";
-    private bool _savedRequireTagTableValue;
-    private string _savedMin = "";
-    private string _savedMax = "";
-    private string _savedAllowedValues = "";
-    private string _savedCommentTemplate = "";
-    private bool _savedExcludeFromSetpoints;
     private RuleSource _savedSaveDestination;
+    private string _savedFileName = "";
+    private bool _isNew;
+    private bool _isExpanded = true;
+
+    public RuleFileViewModel()
+    {
+        Rules = new ObservableCollection<RuleViewModel>();
+        Rules.CollectionChanged += OnRulesCollectionChanged;
+    }
+
+    /// <summary>
+    /// Rules contained in this file. Order is preserved on save.
+    /// </summary>
+    public ObservableCollection<RuleViewModel> Rules { get; }
+
+    private void OnRulesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.NewItems != null)
+            foreach (RuleViewModel r in e.NewItems)
+                r.ParentFile = this;
+        if (e.OldItems != null)
+            foreach (RuleViewModel r in e.OldItems)
+                if (ReferenceEquals(r.ParentFile, this))
+                    r.ParentFile = null;
+
+        OnPropertyChanged(nameof(RuleCount));
+        OnPropertyChanged(nameof(HasMultipleRules));
+        OnPropertyChanged(nameof(IsDirty));
+        OnPropertyChanged(nameof(HeaderSummary));
+    }
+
+    /// <summary>Called by child <see cref="RuleViewModel"/> when its dirty state may have changed.</summary>
+    internal void NotifyChildChanged()
+    {
+        OnPropertyChanged(nameof(IsDirty));
+    }
+
+    public int RuleCount => Rules.Count;
+    public bool HasMultipleRules => Rules.Count > 1;
 
     public string FileName
     {
         get => _fileName;
-        set => SetProperty(ref _fileName, value);
+        set
+        {
+            if (SetProperty(ref _fileName, value))
+            {
+                OnPropertyChanged(nameof(IsDirty));
+                OnPropertyChanged(nameof(HeaderSummary));
+            }
+        }
     }
 
     public string FilePath
@@ -74,7 +98,11 @@ public class RuleFileViewModel : ViewModelBase
     public RuleSource Source
     {
         get => _source;
-        set => SetProperty(ref _source, value);
+        set
+        {
+            if (SetProperty(ref _source, value))
+                OnPropertyChanged(nameof(SourceDisplay));
+        }
     }
 
     public string SourceDisplay => Source switch
@@ -85,6 +113,7 @@ public class RuleFileViewModel : ViewModelBase
         _ => Source.ToString()
     };
 
+    /// <summary>Kept for backwards compat with tests; "Rule" is the only supported value.</summary>
     public string FileType
     {
         get => _fileType;
@@ -101,21 +130,19 @@ public class RuleFileViewModel : ViewModelBase
         }
     }
 
-    /// <summary>Lower-priority versions that this rule overrides (same path pattern).</summary>
+    /// <summary>Lower-priority versions of this file (same filename in another source).</summary>
     public List<RuleFileViewModel> OverriddenVersions { get; } = new();
 
-    /// <summary>True when this rule overrides a lower-priority version.</summary>
     public bool HasOverrides => OverriddenVersions.Count > 0;
 
-    /// <summary>Notifies the UI that override state changed.</summary>
     public void NotifyOverrideChanged()
     {
         OnPropertyChanged(nameof(HasOverrides));
         OnPropertyChanged(nameof(StatusDisplay));
         OnPropertyChanged(nameof(IsOverride));
+        OnPropertyChanged(nameof(HeaderSummary));
     }
 
-    /// <summary>Display text showing what this rule overrides.</summary>
     public string StatusDisplay
     {
         get
@@ -123,6 +150,21 @@ public class RuleFileViewModel : ViewModelBase
             if (OverriddenVersions.Count == 0) return "";
             var sources = string.Join(", ", OverriddenVersions.Select(v => v.SourceDisplay));
             return $"overrides {sources}";
+        }
+    }
+
+    /// <summary>
+    /// One-line summary used as the secondary text in the file header
+    /// (e.g. "Project · 11 rules · overrides Local").
+    /// </summary>
+    public string HeaderSummary
+    {
+        get
+        {
+            var parts = new List<string> { SourceDisplay };
+            parts.Add(RuleCount == 1 ? "1 rule" : $"{RuleCount} rules");
+            if (HasOverrides) parts.Add(StatusDisplay);
+            return string.Join(" · ", parts);
         }
     }
 
@@ -136,224 +178,63 @@ public class RuleFileViewModel : ViewModelBase
         }
     }
 
-    /// <summary>True for newly created rules that haven't been saved yet.</summary>
+    /// <summary>True for files created in the editor that haven't been written to disk yet.</summary>
     public bool IsNew
     {
         get => _isNew;
-        set => SetProperty(ref _isNew, value);
+        set
+        {
+            if (SetProperty(ref _isNew, value))
+                OnPropertyChanged(nameof(IsDirty));
+        }
     }
 
-    /// <summary>True when any field differs from its last-saved state.</summary>
+    /// <summary>UI-only state: whether the file's rule list is expanded in the left panel.</summary>
+    public bool IsExpanded
+    {
+        get => _isExpanded;
+        set => SetProperty(ref _isExpanded, value);
+    }
+
+    /// <summary>True when any field — file-level metadata or any contained rule — has changed since last save.</summary>
     public bool IsDirty =>
         IsNew
-        || _pathPattern != _savedPathPattern
-        || _datatype != _savedDatatype
-        || _tagTableName != _savedTagTableName
-        || _requireTagTableValue != _savedRequireTagTableValue
-        || _min != _savedMin
-        || _max != _savedMax
-        || _allowedValues != _savedAllowedValues
-        || _commentTemplate != _savedCommentTemplate
-        || _excludeFromSetpoints != _savedExcludeFromSetpoints
-        || _saveDestination != _savedSaveDestination;
+        || _saveDestination != _savedSaveDestination
+        || _fileName != _savedFileName
+        || Rules.Any(r => r.IsDirty);
 
-    /// <summary>Captures the current field values as the "saved" baseline.</summary>
     public void MarkClean()
     {
         IsNew = false;
-        _savedPathPattern = _pathPattern;
-        _savedDatatype = _datatype;
-        _savedTagTableName = _tagTableName;
-        _savedRequireTagTableValue = _requireTagTableValue;
-        _savedMin = _min;
-        _savedMax = _max;
-        _savedAllowedValues = _allowedValues;
-        _savedCommentTemplate = _commentTemplate;
-        _savedExcludeFromSetpoints = _excludeFromSetpoints;
         _savedSaveDestination = _saveDestination;
+        _savedFileName = _fileName;
+        foreach (var r in Rules) r.MarkClean();
         OnPropertyChanged(nameof(IsDirty));
     }
 
-    // --- Rule fields ---
-
-    public string PathPattern
-    {
-        get => _pathPattern;
-        set
-        {
-            if (SetProperty(ref _pathPattern, value))
-            {
-                OnPropertyChanged(nameof(IsDirty));
-                SyncFileNameFromPattern();
-            }
-        }
-    }
-
-    public string Datatype
-    {
-        get => _datatype;
-        set
-        {
-            if (SetProperty(ref _datatype, value))
-            {
-                OnPropertyChanged(nameof(IsDirty));
-                OnPropertyChanged(nameof(IsMinMaxSupported));
-
-                // Clear Min/Max when switching to unsupported type
-                if (!IsMinMaxSupported)
-                {
-                    Min = "";
-                    Max = "";
-                }
-
-                // Re-validate existing Min/Max against new datatype
-                ValidateMinMax();
-            }
-        }
-    }
-
     /// <summary>
-    /// True when the selected data type supports Min/Max constraints.
-    /// Empty datatype = true (conservative: rule might match various types).
-    /// </summary>
-    public bool IsMinMaxSupported =>
-        string.IsNullOrEmpty(Datatype) || TiaDataTypeValidator.SupportsMinMax(Datatype);
-
-    public string TagTableName
-    {
-        get => _tagTableName;
-        set
-        {
-            if (SetProperty(ref _tagTableName, value))
-                OnPropertyChanged(nameof(IsDirty));
-        }
-    }
-
-    public bool RequireTagTableValue
-    {
-        get => _requireTagTableValue;
-        set
-        {
-            if (SetProperty(ref _requireTagTableValue, value))
-                OnPropertyChanged(nameof(IsDirty));
-        }
-    }
-
-    public string Min
-    {
-        get => _min;
-        set
-        {
-            if (SetProperty(ref _min, value))
-            {
-                OnPropertyChanged(nameof(IsDirty));
-                ValidateMinMax();
-            }
-        }
-    }
-
-    public string Max
-    {
-        get => _max;
-        set
-        {
-            if (SetProperty(ref _max, value))
-            {
-                OnPropertyChanged(nameof(IsDirty));
-                ValidateMinMax();
-            }
-        }
-    }
-
-    private string _minError = "";
-    private string _maxError = "";
-
-    /// <summary>Validation error for Min field, or empty if valid.</summary>
-    public string MinError
-    {
-        get => _minError;
-        private set => SetProperty(ref _minError, value);
-    }
-
-    /// <summary>Validation error for Max field, or empty if valid.</summary>
-    public string MaxError
-    {
-        get => _maxError;
-        private set => SetProperty(ref _maxError, value);
-    }
-
-    private void ValidateMinMax()
-    {
-        var dt = string.IsNullOrWhiteSpace(Datatype) ? null : Datatype;
-
-        // Validate Min format against datatype
-        MinError = !string.IsNullOrWhiteSpace(Min) && dt != null
-            ? TiaDataTypeValidator.Validate(Min.Trim(), dt) ?? ""
-            : "";
-
-        // Validate Max format against datatype
-        MaxError = !string.IsNullOrWhiteSpace(Max) && dt != null
-            ? TiaDataTypeValidator.Validate(Max.Trim(), dt) ?? ""
-            : "";
-    }
-
-    public string AllowedValues
-    {
-        get => _allowedValues;
-        set
-        {
-            if (SetProperty(ref _allowedValues, value))
-                OnPropertyChanged(nameof(IsDirty));
-        }
-    }
-
-    public string CommentTemplate
-    {
-        get => _commentTemplate;
-        set
-        {
-            if (SetProperty(ref _commentTemplate, value))
-                OnPropertyChanged(nameof(IsDirty));
-        }
-    }
-
-    public bool ExcludeFromSetpoints
-    {
-        get => _excludeFromSetpoints;
-        set
-        {
-            if (SetProperty(ref _excludeFromSetpoints, value))
-                OnPropertyChanged(nameof(IsDirty));
-        }
-    }
-
-    /// <summary>
-    /// Derives a safe filename from the path pattern.
-    /// Replaces characters that are invalid in filenames.
+    /// Derives a safe filename from a rule's path pattern. Used when a new file
+    /// is being authored — auto-syncs filename to match the pattern.
     /// </summary>
     public static string PatternToFileName(string pattern)
     {
         if (string.IsNullOrWhiteSpace(pattern)) return "new-rule.json";
 
-        // Replace path separators and common glob tokens with readable alternatives
         var name = pattern
-            .Replace("\\.", ".")       // unescape dots first
-            .Replace(".*", "_any_")    // regex wildcard
-            .Replace(".+", "_some_")   // regex one-or-more
-            .Replace("$", "")          // anchor
-            .Replace("^", "");         // anchor
+            .Replace("\\.", ".")
+            .Replace(".*", "_any_")
+            .Replace(".+", "_some_")
+            .Replace("$", "")
+            .Replace("^", "");
 
-        // Replace {token:value} with just value
         name = Regex.Replace(name, @"\{[^:}]+:([^}]+)\}", "$1");
-        // Replace remaining {token} with token
         name = Regex.Replace(name, @"\{([^}]+)\}", "$1");
 
-        // Replace invalid filename characters with underscore
-        var invalidChars = new HashSet<char>(Path.GetInvalidFileNameChars()) { '*', '?', '{', '}', '[', ']', '|', '\\', '/' };
+        var invalidChars = new HashSet<char>(Path.GetInvalidFileNameChars())
+            { '*', '?', '{', '}', '[', ']', '|', '\\', '/' };
         var chars = name.Select(c => invalidChars.Contains(c) ? '_' : c).ToArray();
         name = new string(chars);
 
-        // Collapse consecutive underscores, trim trailing only
         name = Regex.Replace(name, @"_+", "_").TrimEnd('_', '.').TrimStart('.');
 
         if (string.IsNullOrWhiteSpace(name)) return "new-rule.json";
@@ -361,28 +242,8 @@ public class RuleFileViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Updates FileName to match the current PathPattern (auto-sync).
-    /// Only auto-syncs for new rules or when the filename was previously derived from the pattern.
-    /// </summary>
-    private void SyncFileNameFromPattern()
-    {
-        // Only auto-sync for new (unsaved) rules
-        if (!IsNew) return;
-
-        var derived = PatternToFileName(_pathPattern);
-        FileName = derived;
-
-        // Also update FilePath if directory is known
-        var dir = Path.GetDirectoryName(FilePath);
-        if (!string.IsNullOrEmpty(dir))
-            FilePath = Path.Combine(dir, derived);
-    }
-
-    /// <summary>True when FileType is "Rule" (used for XAML binding).</summary>
-    public bool IsRuleType => FileType == "Rule";
-
-    /// <summary>
-    /// Loads a rule file from disk and creates a RuleFileViewModel.
+    /// Loads a rule file from disk. Returns null when the file is missing,
+    /// unreadable, or doesn't carry the BlockParam version sentinel.
     /// </summary>
     public static RuleFileViewModel? FromFile(string filePath, RuleSource source)
     {
@@ -392,7 +253,10 @@ public class RuleFileViewModel : ViewModelBase
         try { json = File.ReadAllText(filePath); }
         catch { return null; }
 
-        var config = JsonConvert.DeserializeObject<BulkChangeConfig>(json);
+        BulkChangeConfig? config;
+        try { config = JsonConvert.DeserializeObject<BulkChangeConfig>(json); }
+        catch (JsonException) { return null; }
+
         if (config == null || string.IsNullOrEmpty(config.Version))
             return null;
 
@@ -401,25 +265,15 @@ public class RuleFileViewModel : ViewModelBase
             FileName = Path.GetFileName(filePath),
             FilePath = filePath,
             Source = source,
-            SaveDestination = source
+            SaveDestination = source,
+            FileType = "Rule"
         };
 
-        // Populate fields from first rule
-        vm.FileType = "Rule";
-        if (config.Rules.Count > 0)
+        foreach (var rule in config.Rules)
         {
-            var rule = config.Rules[0];
-            vm.PathPattern = rule.PathPattern ?? "";
-            vm.Datatype = rule.Datatype ?? "";
-            vm.Min = rule.Constraints?.Min?.ToString() ?? "";
-            vm.Max = rule.Constraints?.Max?.ToString() ?? "";
-            vm.RequireTagTableValue = rule.Constraints?.RequireTagTableValue ?? false;
-            vm.AllowedValues = rule.Constraints?.AllowedValues != null
-                ? string.Join(", ", rule.Constraints.AllowedValues)
-                : "";
-            vm.TagTableName = rule.TagTableReference?.TableName ?? "";
-            vm.CommentTemplate = rule.CommentTemplate ?? "";
-            vm.ExcludeFromSetpoints = rule.ExcludeFromSetpoints;
+            var rvm = new RuleViewModel();
+            rvm.LoadFromRule(rule);
+            vm.Rules.Add(rvm);
         }
 
         vm.MarkClean();
@@ -427,72 +281,41 @@ public class RuleFileViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Converts this ViewModel back to a BulkChangeConfig for serialization.
+    /// Serializes the file back into a <see cref="BulkChangeConfig"/>. All rules
+    /// are emitted in order — preserving multi-rule files (issue #70).
     /// </summary>
     public BulkChangeConfig ToBulkChangeConfig()
     {
         var config = new BulkChangeConfig { Version = "1.0" };
-
-        var rule = new MemberRule
-        {
-            PathPattern = PathPattern,
-            Datatype = string.IsNullOrWhiteSpace(Datatype) ? null : Datatype,
-            CommentTemplate = string.IsNullOrWhiteSpace(CommentTemplate) ? null : CommentTemplate,
-            ExcludeFromSetpoints = ExcludeFromSetpoints
-        };
-
-        if (!string.IsNullOrWhiteSpace(Min) || !string.IsNullOrWhiteSpace(Max)
-            || !string.IsNullOrWhiteSpace(AllowedValues) || RequireTagTableValue)
-        {
-            rule.Constraints = new ValueConstraint();
-            if (!string.IsNullOrWhiteSpace(Min))
-                rule.Constraints.Min = double.TryParse(Min, out var minNum) ? (object)minNum : Min.Trim();
-            if (!string.IsNullOrWhiteSpace(Max))
-                rule.Constraints.Max = double.TryParse(Max, out var maxNum) ? (object)maxNum : Max.Trim();
-            rule.Constraints.RequireTagTableValue = RequireTagTableValue;
-            if (!string.IsNullOrWhiteSpace(AllowedValues))
-            {
-                rule.Constraints.AllowedValues = AllowedValues
-                    .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
-                    .Select(v => v.Trim())
-                    .Select(v => (object)v)
-                    .ToList();
-            }
-        }
-
-        if (!string.IsNullOrWhiteSpace(TagTableName))
-        {
-            rule.TagTableReference = new TagTableReference { TableName = TagTableName };
-        }
-
-        config.Rules.Add(rule);
-
+        foreach (var rule in Rules)
+            config.Rules.Add(rule.ToMemberRule());
         return config;
     }
 
     /// <summary>
-    /// Returns the validation error for this file, or null if valid.
+    /// Validates every rule in the file. Returns the first error encountered,
+    /// or null when all rules are valid.
     /// </summary>
     public string? Validate()
     {
-        if (FileType == "Rule" && string.IsNullOrWhiteSpace(PathPattern))
-            return $"Rule '{FileName}' must have a path pattern.";
+        if (Rules.Count == 0)
+            return $"File '{FileName}' has no rules.";
 
-        if (FileType == "Rule" && !string.IsNullOrWhiteSpace(Min) && !string.IsNullOrWhiteSpace(Max))
+        foreach (var r in Rules)
         {
-            // Use TIA-aware parsing when datatype is known (handles T#, D#, 16# etc.)
-            var dt = string.IsNullOrWhiteSpace(Datatype) ? null : Datatype;
-            bool minParsed = dt != null
-                ? TiaDataTypeValidator.TryParseNumericValue(Min.Trim(), dt, out var minVal)
-                : double.TryParse(Min, out minVal);
-            bool maxParsed = dt != null
-                ? TiaDataTypeValidator.TryParseNumericValue(Max.Trim(), dt, out var maxVal)
-                : double.TryParse(Max, out maxVal);
-
-            if (minParsed && maxParsed && minVal > maxVal)
-                return $"Rule '{FileName}': Min ({Min}) must be ≤ Max ({Max}).";
+            var err = r.Validate(FileName);
+            if (err != null) return err;
         }
-
         return null;
+    }
+
+    /// <summary>
+    /// Convenience accessor: filename auto-derive from the first rule's pattern,
+    /// used while the file is still <see cref="IsNew"/>. Returns a safe filename.
+    /// </summary>
+    public string DeriveFileNameFromFirstRule()
+    {
+        var first = Rules.FirstOrDefault();
+        return PatternToFileName(first?.PathPattern ?? "");
     }
 }

--- a/src/BlockParam/UI/RuleFileViewModel.cs
+++ b/src/BlockParam/UI/RuleFileViewModel.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using BlockParam.Config;
+using BlockParam.Localization;
 using BlockParam.Services;
 
 namespace BlockParam.UI;
@@ -238,7 +239,9 @@ public class RuleFileViewModel : ViewModelBase
         get
         {
             var parts = new List<string> { SourceDisplay };
-            parts.Add(RuleCount == 1 ? "1 rule" : $"{RuleCount} rules");
+            parts.Add(RuleCount == 1
+                ? Res.Get("ConfigEditor_HeaderSummary_OneRule")
+                : Res.Format("ConfigEditor_HeaderSummary_NRules", RuleCount));
             if (HasOverrides) parts.Add(StatusDisplay);
             return string.Join(" · ", parts);
         }

--- a/src/BlockParam/UI/RuleViewModel.cs
+++ b/src/BlockParam/UI/RuleViewModel.cs
@@ -1,0 +1,342 @@
+using BlockParam.Config;
+using BlockParam.Services;
+
+namespace BlockParam.UI;
+
+/// <summary>
+/// One rule inside a <see cref="RuleFileViewModel"/>. Holds the per-rule fields
+/// previously colocated on RuleFileViewModel — the split is what fixes #70:
+/// a file may now contain N rules, all of which round-trip through
+/// <see cref="RuleFileViewModel.ToBulkChangeConfig"/>.
+/// </summary>
+public class RuleViewModel : ViewModelBase
+{
+    private RuleFileViewModel? _parentFile;
+
+    private string _pathPattern = "";
+    private string _datatype = "";
+    private string _tagTableName = "";
+    private bool _requireTagTableValue;
+    private string _min = "";
+    private string _max = "";
+    private string _allowedValues = "";
+    private string _commentTemplate = "";
+    private bool _excludeFromSetpoints;
+    private bool _isNew;
+    private bool _isSelected;
+
+    private string _savedPathPattern = "";
+    private string _savedDatatype = "";
+    private string _savedTagTableName = "";
+    private bool _savedRequireTagTableValue;
+    private string _savedMin = "";
+    private string _savedMax = "";
+    private string _savedAllowedValues = "";
+    private string _savedCommentTemplate = "";
+    private bool _savedExcludeFromSetpoints;
+
+    private string _minError = "";
+    private string _maxError = "";
+
+    /// <summary>The file that owns this rule. Set by <see cref="RuleFileViewModel"/>.</summary>
+    public RuleFileViewModel? ParentFile
+    {
+        get => _parentFile;
+        internal set => SetProperty(ref _parentFile, value);
+    }
+
+    public string PathPattern
+    {
+        get => _pathPattern;
+        set
+        {
+            if (SetProperty(ref _pathPattern, value))
+            {
+                OnPropertyChanged(nameof(IsDirty));
+                OnPropertyChanged(nameof(SecondaryDisplay));
+                ParentFile?.NotifyChildChanged();
+            }
+        }
+    }
+
+    public string Datatype
+    {
+        get => _datatype;
+        set
+        {
+            if (SetProperty(ref _datatype, value))
+            {
+                OnPropertyChanged(nameof(IsDirty));
+                OnPropertyChanged(nameof(IsMinMaxSupported));
+                if (!IsMinMaxSupported)
+                {
+                    Min = "";
+                    Max = "";
+                }
+                ValidateMinMax();
+                ParentFile?.NotifyChildChanged();
+            }
+        }
+    }
+
+    /// <summary>True when the data type supports Min/Max (empty == permissive).</summary>
+    public bool IsMinMaxSupported =>
+        string.IsNullOrEmpty(Datatype) || TiaDataTypeValidator.SupportsMinMax(Datatype);
+
+    public string TagTableName
+    {
+        get => _tagTableName;
+        set
+        {
+            if (SetProperty(ref _tagTableName, value))
+            {
+                OnPropertyChanged(nameof(IsDirty));
+                OnPropertyChanged(nameof(SecondaryDisplay));
+                ParentFile?.NotifyChildChanged();
+            }
+        }
+    }
+
+    public bool RequireTagTableValue
+    {
+        get => _requireTagTableValue;
+        set
+        {
+            if (SetProperty(ref _requireTagTableValue, value))
+            {
+                OnPropertyChanged(nameof(IsDirty));
+                ParentFile?.NotifyChildChanged();
+            }
+        }
+    }
+
+    public string Min
+    {
+        get => _min;
+        set
+        {
+            if (SetProperty(ref _min, value))
+            {
+                OnPropertyChanged(nameof(IsDirty));
+                ValidateMinMax();
+                ParentFile?.NotifyChildChanged();
+            }
+        }
+    }
+
+    public string Max
+    {
+        get => _max;
+        set
+        {
+            if (SetProperty(ref _max, value))
+            {
+                OnPropertyChanged(nameof(IsDirty));
+                ValidateMinMax();
+                ParentFile?.NotifyChildChanged();
+            }
+        }
+    }
+
+    public string MinError
+    {
+        get => _minError;
+        private set => SetProperty(ref _minError, value);
+    }
+
+    public string MaxError
+    {
+        get => _maxError;
+        private set => SetProperty(ref _maxError, value);
+    }
+
+    public string AllowedValues
+    {
+        get => _allowedValues;
+        set
+        {
+            if (SetProperty(ref _allowedValues, value))
+            {
+                OnPropertyChanged(nameof(IsDirty));
+                OnPropertyChanged(nameof(SecondaryDisplay));
+                ParentFile?.NotifyChildChanged();
+            }
+        }
+    }
+
+    public string CommentTemplate
+    {
+        get => _commentTemplate;
+        set
+        {
+            if (SetProperty(ref _commentTemplate, value))
+            {
+                OnPropertyChanged(nameof(IsDirty));
+                OnPropertyChanged(nameof(SecondaryDisplay));
+                ParentFile?.NotifyChildChanged();
+            }
+        }
+    }
+
+    public bool ExcludeFromSetpoints
+    {
+        get => _excludeFromSetpoints;
+        set
+        {
+            if (SetProperty(ref _excludeFromSetpoints, value))
+            {
+                OnPropertyChanged(nameof(IsDirty));
+                ParentFile?.NotifyChildChanged();
+            }
+        }
+    }
+
+    /// <summary>True for rules created in the editor that haven't been written to disk.</summary>
+    public bool IsNew
+    {
+        get => _isNew;
+        set => SetProperty(ref _isNew, value);
+    }
+
+    /// <summary>UI-only: highlights the rule row when it's the active SelectedRule.</summary>
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set => SetProperty(ref _isSelected, value);
+    }
+
+    public bool IsDirty =>
+        IsNew
+        || _pathPattern != _savedPathPattern
+        || _datatype != _savedDatatype
+        || _tagTableName != _savedTagTableName
+        || _requireTagTableValue != _savedRequireTagTableValue
+        || _min != _savedMin
+        || _max != _savedMax
+        || _allowedValues != _savedAllowedValues
+        || _commentTemplate != _savedCommentTemplate
+        || _excludeFromSetpoints != _savedExcludeFromSetpoints;
+
+    /// <summary>
+    /// First non-empty descriptor for the rule list row. Helps users distinguish
+    /// sibling rules in a multi-rule file at a glance.
+    /// </summary>
+    public string SecondaryDisplay
+    {
+        get
+        {
+            if (!string.IsNullOrWhiteSpace(_tagTableName)) return $"tagTable: {_tagTableName}";
+            if (!string.IsNullOrWhiteSpace(_allowedValues)) return $"allowed: {_allowedValues}";
+            if (!string.IsNullOrWhiteSpace(_commentTemplate)) return $"comment: {_commentTemplate}";
+            if (!string.IsNullOrWhiteSpace(_datatype)) return _datatype;
+            return "";
+        }
+    }
+
+    public void MarkClean()
+    {
+        IsNew = false;
+        _savedPathPattern = _pathPattern;
+        _savedDatatype = _datatype;
+        _savedTagTableName = _tagTableName;
+        _savedRequireTagTableValue = _requireTagTableValue;
+        _savedMin = _min;
+        _savedMax = _max;
+        _savedAllowedValues = _allowedValues;
+        _savedCommentTemplate = _commentTemplate;
+        _savedExcludeFromSetpoints = _excludeFromSetpoints;
+        OnPropertyChanged(nameof(IsDirty));
+    }
+
+    private void ValidateMinMax()
+    {
+        var dt = string.IsNullOrWhiteSpace(_datatype) ? null : _datatype;
+
+        MinError = !string.IsNullOrWhiteSpace(_min) && dt != null
+            ? TiaDataTypeValidator.Validate(_min.Trim(), dt) ?? ""
+            : "";
+
+        MaxError = !string.IsNullOrWhiteSpace(_max) && dt != null
+            ? TiaDataTypeValidator.Validate(_max.Trim(), dt) ?? ""
+            : "";
+    }
+
+    /// <summary>Returns the validation error for this rule, or null if valid.</summary>
+    public string? Validate(string fileNameForMessages)
+    {
+        if (string.IsNullOrWhiteSpace(_pathPattern))
+            return $"Rule in '{fileNameForMessages}' must have a path pattern.";
+
+        if (!string.IsNullOrWhiteSpace(_min) && !string.IsNullOrWhiteSpace(_max))
+        {
+            var dt = string.IsNullOrWhiteSpace(_datatype) ? null : _datatype;
+            bool minParsed = dt != null
+                ? TiaDataTypeValidator.TryParseNumericValue(_min.Trim(), dt, out var minVal)
+                : double.TryParse(_min, out minVal);
+            bool maxParsed = dt != null
+                ? TiaDataTypeValidator.TryParseNumericValue(_max.Trim(), dt, out var maxVal)
+                : double.TryParse(_max, out maxVal);
+
+            if (minParsed && maxParsed && minVal > maxVal)
+                return $"Rule '{_pathPattern}' in '{fileNameForMessages}': Min ({_min}) must be ≤ Max ({_max}).";
+        }
+
+        return null;
+    }
+
+    /// <summary>Hydrates this VM from a serialized <see cref="MemberRule"/>.</summary>
+    public void LoadFromRule(MemberRule rule)
+    {
+        _pathPattern = rule.PathPattern ?? "";
+        _datatype = rule.Datatype ?? "";
+        _min = rule.Constraints?.Min?.ToString() ?? "";
+        _max = rule.Constraints?.Max?.ToString() ?? "";
+        _requireTagTableValue = rule.Constraints?.RequireTagTableValue ?? false;
+        _allowedValues = rule.Constraints?.AllowedValues != null
+            ? string.Join(", ", rule.Constraints.AllowedValues)
+            : "";
+        _tagTableName = rule.TagTableReference?.TableName ?? "";
+        _commentTemplate = rule.CommentTemplate ?? "";
+        _excludeFromSetpoints = rule.ExcludeFromSetpoints;
+
+        OnPropertyChanged(string.Empty);
+        ValidateMinMax();
+        MarkClean();
+    }
+
+    /// <summary>Serializes this VM into a <see cref="MemberRule"/>.</summary>
+    public MemberRule ToMemberRule()
+    {
+        var rule = new MemberRule
+        {
+            PathPattern = PathPattern,
+            Datatype = string.IsNullOrWhiteSpace(Datatype) ? null : Datatype,
+            CommentTemplate = string.IsNullOrWhiteSpace(CommentTemplate) ? null : CommentTemplate,
+            ExcludeFromSetpoints = ExcludeFromSetpoints
+        };
+
+        if (!string.IsNullOrWhiteSpace(Min) || !string.IsNullOrWhiteSpace(Max)
+            || !string.IsNullOrWhiteSpace(AllowedValues) || RequireTagTableValue)
+        {
+            rule.Constraints = new ValueConstraint();
+            if (!string.IsNullOrWhiteSpace(Min))
+                rule.Constraints.Min = double.TryParse(Min, out var minNum) ? (object)minNum : Min.Trim();
+            if (!string.IsNullOrWhiteSpace(Max))
+                rule.Constraints.Max = double.TryParse(Max, out var maxNum) ? (object)maxNum : Max.Trim();
+            rule.Constraints.RequireTagTableValue = RequireTagTableValue;
+            if (!string.IsNullOrWhiteSpace(AllowedValues))
+            {
+                rule.Constraints.AllowedValues = AllowedValues
+                    .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(v => v.Trim())
+                    .Select(v => (object)v)
+                    .ToList();
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(TagTableName))
+            rule.TagTableReference = new TagTableReference { TableName = TagTableName };
+
+        return rule;
+    }
+}

--- a/src/BlockParam/UI/RuleViewModel.cs
+++ b/src/BlockParam/UI/RuleViewModel.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using BlockParam.Config;
+using BlockParam.Localization;
 using BlockParam.Services;
 
 namespace BlockParam.UI;
@@ -213,9 +215,12 @@ public class RuleViewModel : ViewModelBase
     {
         get
         {
-            if (!string.IsNullOrWhiteSpace(_tagTableName)) return $"tagTable: {_tagTableName}";
-            if (!string.IsNullOrWhiteSpace(_allowedValues)) return $"allowed: {_allowedValues}";
-            if (!string.IsNullOrWhiteSpace(_commentTemplate)) return $"comment: {_commentTemplate}";
+            if (!string.IsNullOrWhiteSpace(_tagTableName))
+                return Res.Format("ConfigEditor_RuleSecondary_TagTable", _tagTableName);
+            if (!string.IsNullOrWhiteSpace(_allowedValues))
+                return Res.Format("ConfigEditor_RuleSecondary_Allowed", _allowedValues);
+            if (!string.IsNullOrWhiteSpace(_commentTemplate))
+                return Res.Format("ConfigEditor_RuleSecondary_Comment", _commentTemplate);
             if (!string.IsNullOrWhiteSpace(_datatype)) return _datatype;
             return "";
         }
@@ -253,20 +258,21 @@ public class RuleViewModel : ViewModelBase
     public string? Validate(string fileNameForMessages)
     {
         if (string.IsNullOrWhiteSpace(_pathPattern))
-            return $"Rule in '{fileNameForMessages}' must have a path pattern.";
+            return Res.Format("ConfigEditor_RuleValidation_NeedsPathPattern", fileNameForMessages);
 
         if (!string.IsNullOrWhiteSpace(_min) && !string.IsNullOrWhiteSpace(_max))
         {
             var dt = string.IsNullOrWhiteSpace(_datatype) ? null : _datatype;
             bool minParsed = dt != null
                 ? TiaDataTypeValidator.TryParseNumericValue(_min.Trim(), dt, out var minVal)
-                : double.TryParse(_min, out minVal);
+                : double.TryParse(_min, NumberStyles.Float, CultureInfo.InvariantCulture, out minVal);
             bool maxParsed = dt != null
                 ? TiaDataTypeValidator.TryParseNumericValue(_max.Trim(), dt, out var maxVal)
-                : double.TryParse(_max, out maxVal);
+                : double.TryParse(_max, NumberStyles.Float, CultureInfo.InvariantCulture, out maxVal);
 
             if (minParsed && maxParsed && minVal > maxVal)
-                return $"Rule '{_pathPattern}' in '{fileNameForMessages}': Min ({_min}) must be ≤ Max ({_max}).";
+                return Res.Format("ConfigEditor_RuleValidation_MinGtMax",
+                    _pathPattern, fileNameForMessages, _min, _max);
         }
 
         return null;
@@ -277,8 +283,8 @@ public class RuleViewModel : ViewModelBase
     {
         _pathPattern = rule.PathPattern ?? "";
         _datatype = rule.Datatype ?? "";
-        _min = rule.Constraints?.Min?.ToString() ?? "";
-        _max = rule.Constraints?.Max?.ToString() ?? "";
+        _min = FormatNumeric(rule.Constraints?.Min);
+        _max = FormatNumeric(rule.Constraints?.Max);
         _requireTagTableValue = rule.Constraints?.RequireTagTableValue ?? false;
         _allowedValues = rule.Constraints?.AllowedValues != null
             ? string.Join(", ", rule.Constraints.AllowedValues)
@@ -308,9 +314,9 @@ public class RuleViewModel : ViewModelBase
         {
             rule.Constraints = new ValueConstraint();
             if (!string.IsNullOrWhiteSpace(Min))
-                rule.Constraints.Min = double.TryParse(Min, out var minNum) ? (object)minNum : Min.Trim();
+                rule.Constraints.Min = double.TryParse(Min, NumberStyles.Float, CultureInfo.InvariantCulture, out var minNum) ? (object)minNum : Min.Trim();
             if (!string.IsNullOrWhiteSpace(Max))
-                rule.Constraints.Max = double.TryParse(Max, out var maxNum) ? (object)maxNum : Max.Trim();
+                rule.Constraints.Max = double.TryParse(Max, NumberStyles.Float, CultureInfo.InvariantCulture, out var maxNum) ? (object)maxNum : Max.Trim();
             rule.Constraints.RequireTagTableValue = RequireTagTableValue;
             if (!string.IsNullOrWhiteSpace(AllowedValues))
             {
@@ -327,4 +333,16 @@ public class RuleViewModel : ViewModelBase
 
         return rule;
     }
+
+    private static string FormatNumeric(object? value) => value switch
+    {
+        null => "",
+        double d => d.ToString(CultureInfo.InvariantCulture),
+        float f => f.ToString(CultureInfo.InvariantCulture),
+        decimal m => m.ToString(CultureInfo.InvariantCulture),
+        long l => l.ToString(CultureInfo.InvariantCulture),
+        int i => i.ToString(CultureInfo.InvariantCulture),
+        IFormattable f => f.ToString(null, CultureInfo.InvariantCulture),
+        _ => value.ToString() ?? ""
+    };
 }

--- a/src/BlockParam/UI/RuleViewModel.cs
+++ b/src/BlockParam/UI/RuleViewModel.cs
@@ -54,7 +54,6 @@ public class RuleViewModel : ViewModelBase
             {
                 OnPropertyChanged(nameof(IsDirty));
                 OnPropertyChanged(nameof(SecondaryDisplay));
-                ParentFile?.NotifyChildChanged();
             }
         }
     }
@@ -68,13 +67,13 @@ public class RuleViewModel : ViewModelBase
             {
                 OnPropertyChanged(nameof(IsDirty));
                 OnPropertyChanged(nameof(IsMinMaxSupported));
+                OnPropertyChanged(nameof(SecondaryDisplay));
                 if (!IsMinMaxSupported)
                 {
                     Min = "";
                     Max = "";
                 }
                 ValidateMinMax();
-                ParentFile?.NotifyChildChanged();
             }
         }
     }
@@ -92,7 +91,6 @@ public class RuleViewModel : ViewModelBase
             {
                 OnPropertyChanged(nameof(IsDirty));
                 OnPropertyChanged(nameof(SecondaryDisplay));
-                ParentFile?.NotifyChildChanged();
             }
         }
     }
@@ -103,10 +101,7 @@ public class RuleViewModel : ViewModelBase
         set
         {
             if (SetProperty(ref _requireTagTableValue, value))
-            {
                 OnPropertyChanged(nameof(IsDirty));
-                ParentFile?.NotifyChildChanged();
-            }
         }
     }
 
@@ -119,7 +114,6 @@ public class RuleViewModel : ViewModelBase
             {
                 OnPropertyChanged(nameof(IsDirty));
                 ValidateMinMax();
-                ParentFile?.NotifyChildChanged();
             }
         }
     }
@@ -133,7 +127,6 @@ public class RuleViewModel : ViewModelBase
             {
                 OnPropertyChanged(nameof(IsDirty));
                 ValidateMinMax();
-                ParentFile?.NotifyChildChanged();
             }
         }
     }
@@ -159,7 +152,6 @@ public class RuleViewModel : ViewModelBase
             {
                 OnPropertyChanged(nameof(IsDirty));
                 OnPropertyChanged(nameof(SecondaryDisplay));
-                ParentFile?.NotifyChildChanged();
             }
         }
     }
@@ -173,7 +165,6 @@ public class RuleViewModel : ViewModelBase
             {
                 OnPropertyChanged(nameof(IsDirty));
                 OnPropertyChanged(nameof(SecondaryDisplay));
-                ParentFile?.NotifyChildChanged();
             }
         }
     }
@@ -184,10 +175,7 @@ public class RuleViewModel : ViewModelBase
         set
         {
             if (SetProperty(ref _excludeFromSetpoints, value))
-            {
                 OnPropertyChanged(nameof(IsDirty));
-                ParentFile?.NotifyChildChanged();
-            }
         }
     }
 


### PR DESCRIPTION
## Summary

Substantial rule editor overhaul, plus surrounding additions:

- **File/rule split in the left pane** — files become collapsible sections; each rule is its own row with a sticky file header that scrolls naturally and stays expanded across reloads
- **Inspector chrome on the right** — dirty/new banners, override info, validation, source picker (User/Project/Shared) lives in the file header
- **Multi-rule round-trip** — load, edit, and save files containing more than one rule (was previously dropping rules past the first — closes #70)
- **Selection highlight fix** — local `Background=\"White\"` on the rule row beat the `IsSelected`/`IsDirty`/`IsNew` triggers in WPF property precedence; moved into a Style setter so the row actually repaints on click
- **Header click is structural only** — toggling a section no longer auto-selects the file's first rule (matches VS Code / JetBrains / Settings panes)
- **Update notice** in-app for new GitHub releases (with tests for `VersionTag`, `GitHubReleaseFetcher`, `UpdateCheckService`, settings)
- **Licensing**: `LocalUsageTracker` + `LicensedUsageTracker` shaped behind `IUsageTracker`; doc updates
- Misc localization, converters, and test coverage

## Closes

Closes #70

## Test plan

- [ ] Open ConfigEditor in DevLauncher; click rule rows — selected row paints blue (`#D6E5FA`)
- [ ] Click a file header — section expands/collapses; SelectedRule does NOT change
- [ ] Open a file with multiple rules — all rules visible, each editable, save round-trips
- [ ] Dirty rule shows yellow tint; selecting it still shows blue selection
- [ ] Sticky file header stays pinned during scroll
- [ ] Build clean on V20 target; all tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)