### PR TITLE
docs: Terms and Privacy for Lemon Squeezy submission

### DIFF
--- a/docs/legal/index.md
+++ b/docs/legal/index.md
@@ -1,24 +1,42 @@
 # Legal
 
-Documents to satisfy Lemon Squeezy's seller requirements and EU/GDPR
-obligations.
+Public-facing legal documents for the BlockParam Add-In and the Pro license
+service. Source files live here so they version with the codebase; the
+marketing site `blockparam.lautimweb.de` should render from these markdown
+sources at build time.
 
 | Document | Purpose |
 |---|---|
 | [Terms and Conditions](terms.md) | Pro license grant, refund pointer to Lemon Squeezy, warranty disclaimer, liability cap, governing law. |
-| [Privacy Policy](privacy.md) | What the Add-In sends to the license server, what Lemon Squeezy processes for billing, GDPR rights, sub-processors. |
+| [Privacy Policy](privacy.md) | What the Add-In sends to the license server, what Lemon Squeezy processes for billing, GDPR rights, sub-processors, supervisory authority. |
 
-Both documents have placeholders that **must be filled before publishing**:
+## Vendor & jurisdiction (for reference)
 
-- `[LEGAL ENTITY NAME]` — registered company / sole-trader name.
-- `[REGISTERED ADDRESS]` — full postal address (Impressum).
-- `[VAT-ID]` — German USt-ID (or local equivalent).
-- `[GOVERNING LAW]` and `[COURT]` — jurisdiction.
-- `[HOSTING PROVIDER]` — operator of `license.lautimweb.de`.
-- `[SUPERVISORY AUTHORITY]` — competent data-protection authority.
-- `[YYYY-MM-DD]` — effective date.
-- A few smaller analytics / cookie / log-retention specifics noted inline.
+| Field | Value |
+|---|---|
+| Legal entity | Tobias Laubscher (Einzelunternehmer, trading as *lautimweb*) |
+| Address | Enkenbacher Str. 55, 67691 Hochspeyer, Germany |
+| Phone | +49 176 21156188 |
+| Email | [support@lautimweb.de](mailto:support@lautimweb.de) |
+| VAT-ID | DE313892898 (USt-IdNr. gem. § 27 a UStG) |
+| Commercial register | Not applicable — Einzelunternehmer |
+| Governing law | Federal Republic of Germany (CISG excluded) |
+| Place of jurisdiction | Court competent for the registered seat in Rheinland-Pfalz |
+| Supervisory authority (DPA) | LfDI Rheinland-Pfalz, Hintere Bleiche 34, 55116 Mainz |
+| License-server host | ALL-INKL.COM (Neue Medien Münnich), Germany |
+| Marketing-site analytics | Self-hosted Matomo, anonymised IPs |
+| Effective date | 2026-05-06 |
 
-When publishing on `blockparam.lautimweb.de`, link to the rendered versions of
-these markdown files (or copy-render them into the marketing site). Lemon Squeezy
-needs both URLs in the **Store Settings → Legal** form.
+## Lemon Squeezy submission
+
+Lemon Squeezy needs **public URLs** for both documents on the seller's site
+before approving the store. Until the store is approved, the GitHub-rendered
+versions of these markdown files serve as the canonical link to share with the
+LS reviewer:
+
+- `https://github.com/Sawascwoolf/BlockParam/blob/main/docs/legal/terms.md`
+- `https://github.com/Sawascwoolf/BlockParam/blob/main/docs/legal/privacy.md`
+
+After approval, the marketing site should expose them at stable URLs (e.g.
+`/legal/terms`, `/legal/privacy`) and replace any phrasing like "trading as
+*lautimweb*" with the final go-live wording if the trading style changes.

--- a/docs/legal/index.md
+++ b/docs/legal/index.md
@@ -1,0 +1,24 @@
+# Legal
+
+Documents to satisfy Lemon Squeezy's seller requirements and EU/GDPR
+obligations.
+
+| Document | Purpose |
+|---|---|
+| [Terms and Conditions](terms.md) | Pro license grant, refund pointer to Lemon Squeezy, warranty disclaimer, liability cap, governing law. |
+| [Privacy Policy](privacy.md) | What the Add-In sends to the license server, what Lemon Squeezy processes for billing, GDPR rights, sub-processors. |
+
+Both documents have placeholders that **must be filled before publishing**:
+
+- `[LEGAL ENTITY NAME]` — registered company / sole-trader name.
+- `[REGISTERED ADDRESS]` — full postal address (Impressum).
+- `[VAT-ID]` — German USt-ID (or local equivalent).
+- `[GOVERNING LAW]` and `[COURT]` — jurisdiction.
+- `[HOSTING PROVIDER]` — operator of `license.lautimweb.de`.
+- `[SUPERVISORY AUTHORITY]` — competent data-protection authority.
+- `[YYYY-MM-DD]` — effective date.
+- A few smaller analytics / cookie / log-retention specifics noted inline.
+
+When publishing on `blockparam.lautimweb.de`, link to the rendered versions of
+these markdown files (or copy-render them into the marketing site). Lemon Squeezy
+needs both URLs in the **Store Settings → Legal** form.

--- a/docs/legal/privacy.md
+++ b/docs/legal/privacy.md
@@ -1,0 +1,186 @@
+# Privacy Policy
+
+_Last updated: **[YYYY-MM-DD — fill in before publishing]**_
+
+This Privacy Policy explains what personal data the **BlockParam** TIA Portal
+Add-In and the related Pro license service collect, why, and what your rights
+are. We aim to collect as little as possible.
+
+## 1. Controller
+
+The controller for the data processing described here is:
+
+> **[LEGAL ENTITY NAME]**
+> [REGISTERED ADDRESS]
+> [COUNTRY]
+> Email: [support@lautimweb.de](mailto:support@lautimweb.de)
+
+A statutory Data Protection Officer (*Datenschutzbeauftragter*) is **[appointed
+/ not appointed — fill in]**. For data-protection requests, write to the address
+above with the subject "Privacy".
+
+## 2. TL;DR — what BlockParam sends and stores
+
+| What | Where it goes | Why |
+|---|---|---|
+| **License key, instance ID, machine name, Add-In version** | Our license server `https://license.lautimweb.de` (every activation + every 2 h heartbeat) | Verify your Pro entitlement and enforce the per-key concurrent-session limit |
+| **Your name, email, billing address, payment data, country, VAT-ID, IP** | Lemon Squeezy (only during checkout) | Take payment, calculate tax, issue invoices, comply with tax law |
+| `config.json`, rule files, log file | **Local only** — `%APPDATA%\BlockParam\` on your machine | Save your settings and rules between sessions |
+| DB exports, tag tables (DevLauncher only) | **Local only** — `%TEMP%\BlockParam\` | Cache TIA exports for the development launcher |
+
+What we **do not** collect:
+
+- DB content, tag values, or any project data.
+- TIA Portal project paths or file names.
+- Telemetry, usage statistics, error reports (unless you actively email a log
+  to support).
+- Cookies in the Add-In (it's a desktop app — no browser, no cookies).
+
+## 3. Detail: license server (`license.lautimweb.de`)
+
+When you activate Pro and while the Add-In's dialog is open, the Add-In sends
+the following to our license server over HTTPS:
+
+| Field | Example | Purpose |
+|---|---|---|
+| `licenseKey` | `PRO-XXXX-XXXX-XXXX` | Identify which subscription |
+| `instanceId` | random GUID generated on first activation | Distinguish concurrent seats |
+| `machineName` | `WS-PLC-12` | Show in support tickets when you ask "which machine is holding my seat?" |
+| `addinVersion` | `0.7.2` | Diagnostics, deprecation handling |
+| `osLanguage` (optional) | `de-DE` | Localised error messages |
+
+The server also logs the **request timestamp and source IP** at the
+infrastructure level (standard web-server logs), retained for **[N] days** for
+abuse-prevention and debugging.
+
+**Legal basis (GDPR):**
+
+- Activation and heartbeat: **Art. 6(1)(b) GDPR** — performance of the contract
+  to provide the Pro service.
+- IP / access logs: **Art. 6(1)(f) GDPR** — legitimate interest in operating
+  and securing the service.
+
+**Retention:**
+
+- Active license records are kept while the subscription is active.
+- License records and invoice records are then retained for the
+  statutory tax-law period (**up to 10 years** under German *Abgabenordnung*
+  / equivalent local rules).
+- Web-server access logs: **[N] days**, then deleted.
+
+**Recipients / sub-processors for the license server:**
+
+| Provider | Role | Location | Safeguard |
+|---|---|---|---|
+| [HOSTING PROVIDER — e.g. Hetzner Online GmbH] | Server hosting | [Germany / EU] | Data-Processing Agreement (Art. 28 GDPR), EU-based |
+
+## 4. Detail: payment via Lemon Squeezy
+
+When you buy Pro at `blockparam.lemonsqueezy.com`, **Lemon Squeezy LLC is the
+Merchant of Record and the controller for the payment transaction**, not us. We
+receive only:
+
+- The customer email and name (so we can send the license key and respond to
+  support requests).
+- The order ID and product / variant.
+- The payment status and renewal events (via webhook).
+
+We do **not** receive your full credit-card number, CVV, bank account, or full
+billing address. Those are processed by Lemon Squeezy and their payment
+processors.
+
+| | |
+|---|---|
+| Merchant of Record | Lemon Squeezy LLC |
+| Their privacy policy | [lemonsqueezy.com/privacy](https://www.lemonsqueezy.com/privacy) |
+| Buyer terms | [lemonsqueezy.com/buyer-terms](https://www.lemonsqueezy.com/buyer-terms) |
+
+Legal basis for our processing of the data we receive from Lemon Squeezy:
+**Art. 6(1)(b) GDPR** (contract performance) and **Art. 6(1)(c) GDPR**
+(compliance with tax-record retention obligations).
+
+## 5. Detail: data on your local machine
+
+The Add-In stores the following on your computer. None of it is sent to us.
+
+| Path | Content | When it's written |
+|---|---|---|
+| `%APPDATA%\BlockParam\config.json` | Add-In settings, license-server URL override, telemetry toggle (none), language | Whenever you change a setting |
+| `%APPDATA%\BlockParam\rules\*.json` | Your rule definitions | When you save a rule |
+| `%APPDATA%\BlockParam\license.cache` | Encrypted cache of the last successful license check (for the 48 h offline window) | After every successful heartbeat |
+| `%APPDATA%\BlockParam\blockparam.log` | Diagnostic log: warnings, errors, license-check round-trips. **No DB content.** | While the Add-In runs |
+| `%TEMP%\BlockParam\` | Dev-launcher only — cached TIA exports for UI testing | Only when running the DevLauncher |
+
+You can delete any of these at any time. Deleting `license.cache` simply forces
+a fresh check on next start.
+
+## 6. Marketing website
+
+If you visit our website at **[https://blockparam.lautimweb.de]** the hosting
+provider stores standard access logs (URL, IP, user-agent, referrer, timestamp).
+
+| | |
+|---|---|
+| Cookies | **[None / list strictly necessary cookies]** |
+| Analytics | **[None / list provider — e.g. Plausible, EU, no cookies]** |
+| Embedded fonts | **[Self-hosted / Google Fonts — fill in]** |
+| Embedded videos | **[None / YouTube nocookie / self-hosted MP4]** |
+
+Legal basis: **Art. 6(1)(f) GDPR** (legitimate interest in operating a website),
+or your consent under **Art. 6(1)(a) GDPR** where required (e.g. non-essential
+cookies).
+
+## 7. Recipients outside the EU
+
+| Provider | Country | Mechanism |
+|---|---|---|
+| Lemon Squeezy LLC | USA | Standard Contractual Clauses (EU Commission Decision 2021/914), see [Lemon Squeezy DPA](https://www.lemonsqueezy.com/dpa) |
+
+We do not otherwise transfer personal data outside the EU/EEA.
+
+## 8. Your rights under GDPR
+
+You can exercise the following rights at any time, free of charge, by emailing
+[support@lautimweb.de](mailto:support@lautimweb.de):
+
+- **Access** to the personal data we hold about you (Art. 15).
+- **Rectification** of inaccurate data (Art. 16).
+- **Erasure** ("right to be forgotten", Art. 17).
+- **Restriction** of processing (Art. 18).
+- **Portability** in a machine-readable format (Art. 20).
+- **Objection** to processing based on legitimate interest (Art. 21).
+- **Withdrawal of consent** at any time, with effect for the future (Art. 7(3)),
+  where processing is based on consent.
+
+You also have the right to **lodge a complaint with a supervisory authority**
+(Art. 77). For us, the competent authority is **[SUPERVISORY AUTHORITY — e.g.
+Der Bayerische Landesbeauftragte für den Datenschutz]**.
+
+## 9. Children
+
+The Add-In is a professional engineering tool not directed at children. We do
+not knowingly process personal data of persons under 16.
+
+## 10. Security
+
+- All client–server traffic uses TLS (HTTPS).
+- The license cache is signed so it can't be silently extended past 48 h.
+- Server-side license records are stored in [DATABASE — e.g. PostgreSQL on the
+  EU-hosted infrastructure listed above].
+- Access to the license server is restricted to the operator and is logged.
+
+## 11. Changes to this policy
+
+We may update this policy. Material changes will be announced in the release
+notes and on the landing page. The Git history of this file in the
+[BlockParam repository](https://github.com/Sawascwoolf/BlockParam) is the
+authoritative changelog.
+
+## 12. Contact
+
+| | |
+|---|---|
+| Controller | **[LEGAL ENTITY]** |
+| Address | [REGISTERED ADDRESS] |
+| Email | [support@lautimweb.de](mailto:support@lautimweb.de) |
+| Subject line | "Privacy" |

--- a/docs/legal/privacy.md
+++ b/docs/legal/privacy.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-_Last updated: **[YYYY-MM-DD — fill in before publishing]**_
+_Last updated: **2026-05-06**_
 
 This Privacy Policy explains what personal data the **BlockParam** TIA Portal
 Add-In and the related Pro license service collect, why, and what your rights
@@ -10,14 +10,19 @@ are. We aim to collect as little as possible.
 
 The controller for the data processing described here is:
 
-> **[LEGAL ENTITY NAME]**
-> [REGISTERED ADDRESS]
-> [COUNTRY]
+> **Tobias Laubscher** (Einzelunternehmer, trading as *lautimweb*)
+> Enkenbacher Str. 55
+> 67691 Hochspeyer
+> Germany
+> Phone: +49 176 21156188
 > Email: [support@lautimweb.de](mailto:support@lautimweb.de)
+> VAT-ID: DE313892898
 
-A statutory Data Protection Officer (*Datenschutzbeauftragter*) is **[appointed
-/ not appointed — fill in]**. For data-protection requests, write to the address
-above with the subject "Privacy".
+A statutory Data Protection Officer (*Datenschutzbeauftragter*) is **not
+appointed** — the controller is an Einzelunternehmer below the §38 BDSG
+threshold of 20 persons regularly engaged in automated processing of personal
+data. For data-protection requests, write to the address above with the subject
+"Privacy".
 
 ## 2. TL;DR — what BlockParam sends and stores
 
@@ -50,7 +55,7 @@ the following to our license server over HTTPS:
 | `osLanguage` (optional) | `de-DE` | Localised error messages |
 
 The server also logs the **request timestamp and source IP** at the
-infrastructure level (standard web-server logs), retained for **[N] days** for
+infrastructure level (standard web-server logs), retained for **30 days** for
 abuse-prevention and debugging.
 
 **Legal basis (GDPR):**
@@ -66,13 +71,13 @@ abuse-prevention and debugging.
 - License records and invoice records are then retained for the
   statutory tax-law period (**up to 10 years** under German *Abgabenordnung*
   / equivalent local rules).
-- Web-server access logs: **[N] days**, then deleted.
+- Web-server access logs: **30 days**, then deleted.
 
 **Recipients / sub-processors for the license server:**
 
 | Provider | Role | Location | Safeguard |
 |---|---|---|---|
-| [HOSTING PROVIDER — e.g. Hetzner Online GmbH] | Server hosting | [Germany / EU] | Data-Processing Agreement (Art. 28 GDPR), EU-based |
+| ALL-INKL.COM — Neue Medien Münnich, Inh. René Münnich | Server hosting | Germany | Data-Processing Agreement (Art. 28 GDPR), EU-based |
 
 ## 4. Detail: payment via Lemon Squeezy
 
@@ -116,15 +121,16 @@ a fresh check on next start.
 
 ## 6. Marketing website
 
-If you visit our website at **[https://blockparam.lautimweb.de]** the hosting
-provider stores standard access logs (URL, IP, user-agent, referrer, timestamp).
+If you visit our website at **https://blockparam.lautimweb.de** the hosting
+provider (ALL-INKL.COM) stores standard access logs (URL, IP, user-agent,
+referrer, timestamp), retained for 30 days.
 
 | | |
 |---|---|
-| Cookies | **[None / list strictly necessary cookies]** |
-| Analytics | **[None / list provider — e.g. Plausible, EU, no cookies]** |
-| Embedded fonts | **[Self-hosted / Google Fonts — fill in]** |
-| Embedded videos | **[None / YouTube nocookie / self-hosted MP4]** |
+| Cookies | None set by us. A self-hosted Matomo session cookie is set only if you have not opted out via the Matomo opt-out toggle on the site. |
+| Analytics | **Self-hosted Matomo** on the same ALL-INKL.COM server. IPs are anonymised before storage; no third-party processor receives the data. |
+| Embedded fonts | Self-hosted (no third-party CDN call). |
+| Embedded videos | Self-hosted MP4 (no YouTube / Vimeo embed). |
 
 Legal basis: **Art. 6(1)(f) GDPR** (legitimate interest in operating a website),
 or your consent under **Art. 6(1)(a) GDPR** where required (e.g. non-essential
@@ -153,8 +159,10 @@ You can exercise the following rights at any time, free of charge, by emailing
   where processing is based on consent.
 
 You also have the right to **lodge a complaint with a supervisory authority**
-(Art. 77). For us, the competent authority is **[SUPERVISORY AUTHORITY — e.g.
-Der Bayerische Landesbeauftragte für den Datenschutz]**.
+(Art. 77). For us, the competent authority is **Der Landesbeauftragte für den
+Datenschutz und die Informationsfreiheit Rheinland-Pfalz (LfDI RLP),
+Hintere Bleiche 34, 55116 Mainz, Germany —
+[https://www.datenschutz.rlp.de](https://www.datenschutz.rlp.de)**.
 
 ## 9. Children
 
@@ -165,8 +173,8 @@ not knowingly process personal data of persons under 16.
 
 - All client–server traffic uses TLS (HTTPS).
 - The license cache is signed so it can't be silently extended past 48 h.
-- Server-side license records are stored in [DATABASE — e.g. PostgreSQL on the
-  EU-hosted infrastructure listed above].
+- Server-side license records are stored in a relational database on the
+  EU-hosted infrastructure listed above (ALL-INKL.COM, Germany).
 - Access to the license server is restricted to the operator and is logged.
 
 ## 11. Changes to this policy
@@ -180,7 +188,9 @@ authoritative changelog.
 
 | | |
 |---|---|
-| Controller | **[LEGAL ENTITY]** |
-| Address | [REGISTERED ADDRESS] |
+| Controller | **Tobias Laubscher** (Einzelunternehmer, trading as *lautimweb*) |
+| Address | Enkenbacher Str. 55, 67691 Hochspeyer, Germany |
+| Phone | +49 176 21156188 |
 | Email | [support@lautimweb.de](mailto:support@lautimweb.de) |
+| VAT-ID | DE313892898 |
 | Subject line | "Privacy" |

--- a/docs/legal/terms.md
+++ b/docs/legal/terms.md
@@ -31,7 +31,7 @@ tiers:
 | Tier | What you get | Price |
 |---|---|---|
 | Free | Full feature set, capped at **200 value changes per calendar day** | € 0 |
-| Pro | Full feature set, **unlimited** value changes | **15 € / year (net)** |
+| Pro | Full feature set, **unlimited** value changes | **50 € / year (net)** |
 
 A "value change" is one individual start-value write to a DB; staging edits in
 the dialog is free; comment writes do not consume the quota. See

--- a/docs/legal/terms.md
+++ b/docs/legal/terms.md
@@ -1,6 +1,6 @@
 # Terms and Conditions
 
-_Last updated: **[YYYY-MM-DD — fill in before publishing]**_
+_Last updated: **2026-05-06**_
 
 These Terms govern your use of the **BlockParam** TIA Portal Add-In ("the Add-In")
 and the related Pro license service. By installing the Add-In or activating a
@@ -12,7 +12,7 @@ If you don't agree, don't install or activate the Add-In.
 
 | Role | Entity |
 |---|---|
-| Provider / publisher of the Add-In | **[LEGAL ENTITY NAME]**, [REGISTERED ADDRESS], [COUNTRY]. VAT-ID: [VAT-ID]. Contact: [support@lautimweb.de](mailto:support@lautimweb.de). Hereafter "we" / "us". |
+| Provider / publisher of the Add-In | **Tobias Laubscher** (Einzelunternehmer, trading as *lautimweb*), Enkenbacher Str. 55, 67691 Hochspeyer, Germany. VAT-ID: DE313892898. Phone: +49 176 21156188. Email: [support@lautimweb.de](mailto:support@lautimweb.de). Hereafter "we" / "us". |
 | Merchant of Record (seller of the Pro license to the buyer) | **Lemon Squeezy LLC** ("Lemon Squeezy"). See [Lemon Squeezy Buyer Terms](https://www.lemonsqueezy.com/buyer-terms). |
 | You | The natural or legal person installing the Add-In or buying a Pro license. |
 
@@ -151,7 +151,7 @@ caused by us, and under the German Product Liability Act
 | Channel | Scope | Response target |
 |---|---|---|
 | [GitHub Issues](https://github.com/Sawascwoolf/BlockParam/issues) | Bugs, feature requests (Free + Pro) | Best effort |
-| [support@lautimweb.de](mailto:support@lautimweb.de) | Billing, license, Pro support | Best effort, business days, [TIMEZONE] |
+| [support@lautimweb.de](mailto:support@lautimweb.de) | Billing, license, Pro support | Best effort, business days, Europe/Berlin |
 
 We do **not** offer a contractual SLA for Free or Pro at the standard price.
 Custom SLAs are available on request for multi-seat customers.
@@ -179,13 +179,13 @@ authoritative changelog.
 
 ## 12. Governing law and jurisdiction
 
-These Terms are governed by the laws of **[GOVERNING LAW — e.g. Federal Republic
-of Germany]**, excluding the UN Convention on Contracts for the International
-Sale of Goods (CISG).
+These Terms are governed by the laws of the **Federal Republic of Germany**,
+excluding the UN Convention on Contracts for the International Sale of Goods
+(CISG).
 
 Place of jurisdiction for disputes with merchants, legal persons under public
-law, or special funds under public law is **[COURT — e.g. the courts competent
-for our registered seat]**.
+law, or special funds under public law is **the court competent for our
+registered seat in Rheinland-Pfalz, Germany**.
 
 EU consumers may also bring proceedings under the consumer-protection laws of
 their country of residence and may use the EU
@@ -202,9 +202,11 @@ provisions remain in full force.
 
 | | |
 |---|---|
-| Provider | **[LEGAL ENTITY]** |
-| Address | [REGISTERED ADDRESS] |
+| Provider | **Tobias Laubscher** (Einzelunternehmer, trading as *lautimweb*) |
+| Address | Enkenbacher Str. 55, 67691 Hochspeyer, Germany |
+| Phone | +49 176 21156188 |
 | Email | [support@lautimweb.de](mailto:support@lautimweb.de) |
 | Web | [https://blockparam.lautimweb.de](https://blockparam.lautimweb.de) |
-| VAT-ID | [VAT-ID] |
-| Commercial register | [HRB ... — if applicable] |
+| VAT-ID | DE313892898 (USt-IdNr. gem. § 27 a UStG) |
+| Commercial register | _Not applicable — Einzelunternehmer_ |
+| Editorially responsible (§ 18 Abs. 2 MStV) | Tobias Laubscher (address as above) |

--- a/docs/legal/terms.md
+++ b/docs/legal/terms.md
@@ -1,0 +1,210 @@
+# Terms and Conditions
+
+_Last updated: **[YYYY-MM-DD — fill in before publishing]**_
+
+These Terms govern your use of the **BlockParam** TIA Portal Add-In ("the Add-In")
+and the related Pro license service. By installing the Add-In or activating a
+Pro license, you agree to these Terms.
+
+If you don't agree, don't install or activate the Add-In.
+
+## 1. Parties
+
+| Role | Entity |
+|---|---|
+| Provider / publisher of the Add-In | **[LEGAL ENTITY NAME]**, [REGISTERED ADDRESS], [COUNTRY]. VAT-ID: [VAT-ID]. Contact: [support@lautimweb.de](mailto:support@lautimweb.de). Hereafter "we" / "us". |
+| Merchant of Record (seller of the Pro license to the buyer) | **Lemon Squeezy LLC** ("Lemon Squeezy"). See [Lemon Squeezy Buyer Terms](https://www.lemonsqueezy.com/buyer-terms). |
+| You | The natural or legal person installing the Add-In or buying a Pro license. |
+
+When you buy a Pro license through `blockparam.lemonsqueezy.com`, **Lemon Squeezy
+is the seller of record**. The contract for the *purchase transaction* (payment,
+tax, refunds, chargebacks, invoicing) is between you and Lemon Squeezy under their
+terms. The contract for the *Add-In itself and the Pro service* is between you
+and us under these Terms.
+
+## 2. The product
+
+BlockParam is a TIA Portal Add-In that bulk-edits Data Block start values. It
+runs locally inside Siemens TIA Portal on your machine. It is distributed in two
+tiers:
+
+| Tier | What you get | Price |
+|---|---|---|
+| Free | Full feature set, capped at **200 value changes per calendar day** | € 0 |
+| Pro | Full feature set, **unlimited** value changes | **15 € / year (net)** |
+
+A "value change" is one individual start-value write to a DB; staging edits in
+the dialog is free; comment writes do not consume the quota. See
+[`docs/user/licensing.md`](../user/licensing.md) for the precise counting rules.
+
+The source code is published under the [MIT License](../../LICENSE). The MIT
+licence covers the code; **the Pro license** is a separate commercial entitlement
+to use the unlimited tier and is governed by these Terms.
+
+## 3. Pro license grant
+
+When your Pro purchase is completed, we grant you a **non-exclusive,
+non-transferable, worldwide license** to use the Pro tier of the Add-In for the
+duration of the active subscription, subject to these Terms.
+
+**Per-key limits**
+
+- Default Pro plan: **1 concurrent session** per license key.
+- Activating on a second machine while the first is still active will fail with
+  a "too many sessions" error.
+- Multi-seat plans are available — contact [support@lautimweb.de](mailto:support@lautimweb.de).
+
+**You may**
+
+- Use the Add-In on as many machines as you own, sequentially, by releasing the
+  seat on the old machine and re-activating on the new one.
+- Deploy the license key via SCCM, Intune, GPO or other IT tooling for managed
+  multi-seat plans (see [`docs/admin-license-deployment.md`](../admin-license-deployment.md)).
+- Read, fork and modify the source code under the MIT License.
+
+**You may not**
+
+- Share, resell, sublicense, or publish your Pro license key.
+- Circumvent or attempt to circumvent the license check, the daily quota, or the
+  license server (e.g. by patching the binary, spoofing the heartbeat, or
+  re-routing `license.lautimweb.de`). Note: forking the MIT source and removing
+  the check in your own build is permitted by the MIT licence — but the resulting
+  build is no longer "BlockParam Pro" and is not covered by Pro support.
+- Use the Pro tier without a valid, paid-up license key.
+
+## 4. Subscription, billing, refunds
+
+- The Pro tier is sold as an **annual subscription**. It auto-renews on the
+  anniversary date unless cancelled.
+- All payment, tax collection, invoicing, chargebacks and refunds are handled by
+  Lemon Squeezy as Merchant of Record. Manage your subscription at
+  [app.lemonsqueezy.com/my-orders](https://app.lemonsqueezy.com/my-orders).
+- **Refunds**: subject to Lemon Squeezy's refund policy. EU consumers retain
+  their statutory right of withdrawal (14 days) for digital subscriptions where
+  applicable. Contact billing support via Lemon Squeezy or
+  [support@lautimweb.de](mailto:support@lautimweb.de).
+- **Lapsed subscription**: if a renewal payment fails or you cancel, the license
+  server stops returning a valid Pro response on the next heartbeat. The Add-In
+  remains Pro for the 48 h offline cache window, then drops back to Free. Your
+  data, configs and rules are not affected.
+
+## 5. License verification & connectivity
+
+The Pro tier requires periodic contact with our license server at
+`https://license.lautimweb.de`:
+
+- One activation request when you paste the key.
+- A heartbeat every **2 hours** while the dialog is open, used to release the
+  seat when you stop using it.
+- A **48 h offline cache**: if the server is unreachable, the Add-In stays Pro
+  for 48 h before falling back to Free.
+
+If you're behind a corporate firewall, your IT must allow HTTPS to
+`license.lautimweb.de`.
+
+The data sent in these requests is described in the
+[Privacy Policy](privacy.md) — it does not include any of your project, DB or
+process data.
+
+## 6. Acceptable use
+
+You agree to use the Add-In only with TIA Portal projects that you have the
+right to modify. **You are solely responsible for the changes the Add-In writes
+to your DBs.** We strongly recommend:
+
+- Running BlockParam against a project copy first.
+- Using the bulk-preview before clicking Apply.
+- Keeping a backup / version-control snapshot of the project before bulk Apply.
+
+## 7. No warranty / disclaimer
+
+The Add-In is provided **"as is"**, without warranty of any kind, to the maximum
+extent permitted by applicable law. This restates the MIT disclaimer in the
+[`LICENSE`](../../LICENSE) file. We do not warrant that:
+
+- The Add-In is free of bugs.
+- It will be compatible with every TIA Portal version, project structure, UDT
+  layout, or third-party Add-In.
+- A bulk operation will produce the result you intended on every input.
+
+In particular, Siemens, the TIA Portal product, the Openness API and the
+Xcelerator Marketplace are **not** endorsements or warranties by Siemens of this
+Add-In.
+
+## 8. Limitation of liability
+
+To the maximum extent permitted by applicable law, our aggregate liability under
+or in connection with these Terms is **limited to the amount you paid us for
+the Pro license in the 12 months preceding the event giving rise to the claim**.
+
+We are **not liable** for indirect, incidental, special, consequential, or
+punitive damages, including lost profits, lost production time, downtime, data
+loss, or damage to PLC programs, even if we were advised of the possibility.
+
+Statutory rights that cannot be waived under mandatory consumer law (EU/national)
+are not affected. Liability for intent and gross negligence, for personal injury
+caused by us, and under the German Product Liability Act
+(*Produkthaftungsgesetz*) is unaffected.
+
+## 9. Support
+
+| Channel | Scope | Response target |
+|---|---|---|
+| [GitHub Issues](https://github.com/Sawascwoolf/BlockParam/issues) | Bugs, feature requests (Free + Pro) | Best effort |
+| [support@lautimweb.de](mailto:support@lautimweb.de) | Billing, license, Pro support | Best effort, business days, [TIMEZONE] |
+
+We do **not** offer a contractual SLA for Free or Pro at the standard price.
+Custom SLAs are available on request for multi-seat customers.
+
+## 10. Termination
+
+- You can terminate at any time by cancelling the subscription in the
+  Lemon Squeezy customer portal. Pro access remains until the end of the paid
+  period.
+- We may terminate your Pro license, with or without notice, if you breach
+  these Terms (e.g. key sharing, circumventing the license check, illegal use).
+- On termination of Pro, the Add-In falls back to Free. Your local data,
+  configs, and rules are kept on your machine.
+
+## 11. Changes to these Terms
+
+We may update these Terms to reflect changes in the product, pricing, or law.
+Material changes will be announced on the BlockParam landing page and in the
+release notes. Continued use of Pro after the effective date of a change
+constitutes acceptance.
+
+The Git history of this file in the
+[BlockParam repository](https://github.com/Sawascwoolf/BlockParam) is the
+authoritative changelog.
+
+## 12. Governing law and jurisdiction
+
+These Terms are governed by the laws of **[GOVERNING LAW — e.g. Federal Republic
+of Germany]**, excluding the UN Convention on Contracts for the International
+Sale of Goods (CISG).
+
+Place of jurisdiction for disputes with merchants, legal persons under public
+law, or special funds under public law is **[COURT — e.g. the courts competent
+for our registered seat]**.
+
+EU consumers may also bring proceedings under the consumer-protection laws of
+their country of residence and may use the EU
+[Online Dispute Resolution platform](https://ec.europa.eu/consumers/odr). We are
+not obliged to participate in dispute-resolution proceedings before a consumer
+arbitration board.
+
+## 13. Severability
+
+If any provision of these Terms is held invalid or unenforceable, the remaining
+provisions remain in full force.
+
+## 14. Contact
+
+| | |
+|---|---|
+| Provider | **[LEGAL ENTITY]** |
+| Address | [REGISTERED ADDRESS] |
+| Email | [support@lautimweb.de](mailto:support@lautimweb.de) |
+| Web | [https://blockparam.lautimweb.de](https://blockparam.lautimweb.de) |
+| VAT-ID | [VAT-ID] |
+| Commercial register | [HRB ... — if applicable] |

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -26,6 +26,7 @@ start with [Getting Started](getting-started.md).
 - [`docs/configuration.md`](../configuration.md) — JSON schema reference for rule files.
 - [`docs/example-config.jsonc`](../example-config.jsonc) — annotated sample config.
 - [`docs/admin-license-deployment.md`](../admin-license-deployment.md) — multi-seat license rollout via SCCM / Intune / GPO.
+- [`docs/legal/`](../legal/index.md) — Terms and Conditions, Privacy Policy.
 
 Found a gap or a stale screenshot? Open an issue at
 [github.com/Sawascwoolf/BlockParam/issues](https://github.com/Sawascwoolf/BlockParam/issues).

--- a/docs/user/licensing.md
+++ b/docs/user/licensing.md
@@ -6,7 +6,7 @@ the daily quota and funds further development.
 | Tier | Daily limit | Price |
 |---|---|---|
 | **Free** | 200 value changes per calendar day | € 0 |
-| **Pro** | Unlimited | 15 € / year (net) |
+| **Pro** | Unlimited | 50 € / year (net) |
 
 The daily counter resets at **local midnight**.
 


### PR DESCRIPTION
## Summary

- Adds `docs/legal/{terms,privacy,index}.md` so the active Lemon Squeezy onboarding can link to a Terms and a Privacy Policy.
- Aligns `docs/user/licensing.md` and the new Terms with the website's Pro price (50 EUR/year — the previous 15 EUR/year was stale).
- Fills in vendor / jurisdiction / sub-processor / analytics details from the Impressum, so no `[BRACKETED]` placeholders remain.

Both documents reflect the Lemon Squeezy Merchant-of-Record split (LS handles payment, tax, refunds, chargebacks; we handle the Add-In and the Pro license itself), and the Privacy Policy enumerates exactly what the license server sends — no DB content, no telemetry.

Vendor reference (now in `docs/legal/index.md`):

- Tobias Laubscher (Einzelunternehmer, trading as *lautimweb*), Enkenbacher Str. 55, 67691 Hochspeyer, Germany
- VAT-ID DE313892898 (USt-IdNr. § 27 a UStG)
- Governing law: Germany; jurisdiction: registered seat in Rheinland-Pfalz
- License-server host: ALL-INKL.COM, Germany
- Supervisory authority: LfDI Rheinland-Pfalz
- Marketing-site analytics: self-hosted Matomo, anonymised IPs
- DPO: not appointed (below § 38 BDSG threshold)
- Effective date: 2026-05-06

## Test plan

- [x] `grep` for unfilled `[BRACKETED]` placeholders returns zero hits in `docs/legal/`.
- [x] `grep` for `15 €` / `15 EUR` returns zero hits across docs / CLAUDE.md / README / web.
- [x] Terms and Privacy reference each other via relative links that resolve on GitHub.
- [x] `docs/user/index.md` links to the new `docs/legal/` section.
- [ ] After merge: share `https://github.com/Sawascwoolf/BlockParam/blob/main/docs/legal/{terms,privacy}.md` with Gargi (Lemon Squeezy reviewer) — draft already in Gmail.

https://claude.ai/code/session_01QzfJ9Snd4Ckiw9PD28C8c9

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzfJ9Snd4Ckiw9PD28C8c9)_