### PR TITLE
Add Architecture Guardrails section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,88 @@ For rebuilding the narrated workflow MP4 (`assets/screenshots/workflow/workflow_
   issues stay open after merge, then use
   `gh issue close <N> -c "Resolved by #<PR>"` to catch up.
 
+## Architecture Guardrails
+
+These rules exist to stop the codebase from drifting further toward the
+maintainability/DRY problems already filed as issues (#78, #79, #80, #81, #82).
+They apply to **new and modified code**. Do not retrofit old code in
+unrelated PRs — fix it under the issue that owns the cleanup.
+
+### Hard rules (must follow in every change)
+
+- **No new file I/O outside a storage layer.** `File.*`, `Directory.*`,
+  `Path.GetTempPath()`, `Environment.GetFolderPath(...)` are 55+ scattered
+  calls today. Do not add a 56th. New code that needs to read/write goes
+  through the existing path-helper or, if none fits, introduce one — don't
+  copy-paste another `Directory.CreateDirectory(...) + try/catch` pair.
+- **No new path string literals.** Anything matching `BlockParam/...`,
+  `%APPDATA%\BlockParam`, `%TEMP%\BlockParam`, or `UserFiles\BlockParam`
+  must reference a single named constant. If the constant doesn't exist
+  yet, add it in one place; don't introduce a sixth duplicate.
+- **No new `_activeDbs` / `_stashedDbs` mutation sites.** Per #78, all
+  active-set changes go through the snapshot setter once it lands. Until
+  then, route any new mutation through the existing `RemoveActiveDb` /
+  `SoloActiveDbByReference` / `ReactivateStashedDb` helpers — do not add a
+  seventh entry path.
+- **No path-string identity for members across DBs.** Per #82, member
+  identity is `(ActiveDb, MemberNode)`. New code that needs to look up a
+  member by path must take the owning `ActiveDb` as a parameter; never
+  scan all roots.
+- **No business logic in code-behind (`*.xaml.cs`).** Selection state,
+  filtering, validation, persistence — these belong in the ViewModel.
+  Code-behind is for: focus, scroll, attached-property bridging, and
+  `InitializeComponent`. If you need shared visual behavior (column sizing,
+  drag-select), write an attached behavior, not another `OnXyzChanged`
+  handler.
+- **No new sync primitives in `OnlineLicenseService` without auditing the
+  existing ones.** The class currently mixes `lock`, `volatile`, and
+  `Interlocked` over overlapping state. Any change touching `_licenseData`,
+  `_cache`, `_proActive`, or `_heartbeatTimer` must pick one model and
+  remove the conflicts within the touched scope. Never call HTTP / I/O
+  inside `lock (_lock)`.
+- **No new user-facing strings inline.** Every string the user sees goes
+  through `Res.Get` / `Res.Format` against `Strings.resx`. Same key for
+  the same concept across files — don't add a near-duplicate key when one
+  exists.
+
+### Default to extracting, not extending, when touching hotspots
+
+If your change adds non-trivial logic to any of the following, prefer
+extracting a small focused class for the new logic (kept in the same
+folder) over enlarging the host:
+
+| Hotspot | Current LOC | Owning issue |
+|---|---:|---|
+| `UI/BulkChangeViewModel.cs` | 4,563 | #80 |
+| `AddIn/BulkChangeContextMenu.cs` | 981 | #81 |
+| `UI/BulkChangeDialog.xaml.cs` | 1,033 | (no issue yet) |
+| `Licensing/OnlineLicenseService.cs` | 565 | (no issue yet) |
+| `Services/TiaDataTypeValidator.cs` | 556 | (no issue yet) |
+
+Adding 50 lines of new feature logic to a 4,500-line ViewModel is not
+"a small change" — it cements the god class. Add a sibling class, wire it
+from the constructor, and bind through it.
+
+### DRY checklist before merging
+
+- Searched for the verb you just wrote (`Filter`, `Match`, `Save`, `Load`,
+  `Export`, `Build`, `Resolve`) in nearby files — used the existing one if
+  it covers your case.
+- No new `if (x.Contains(filter, StringComparison.OrdinalIgnoreCase) || y.Contains(...) || z.Contains(...))`
+  block — that lives in `MemberSearchService` / the planned `StringMatcher`.
+- No new copy of the `if (_field != value) { _field = value; OnPropertyChanged(...) }`
+  shape unless `SetField<T>` truly doesn't fit — and if it doesn't, say why
+  in the PR description.
+- No new `List<T>` field that is mutated from more than one method without
+  a snapshot/setter cascade (#78 / #79).
+
+### When in doubt
+
+File a new issue rather than inflating the host file. Reference the
+relevant existing refactor issue (#78–#82) so reviewers can see the
+seams you're not crossing. The cost of a small new file is much lower
+than the cost of another method on a god class.
+
 ## Project Structure
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,8 +206,9 @@ from the constructor, and bind through it.
 - No new `if (x.Contains(filter, StringComparison.OrdinalIgnoreCase) || y.Contains(...) || z.Contains(...))`
   block — that lives in `MemberSearchService` / the planned `StringMatcher`.
 - No new copy of the `if (_field != value) { _field = value; OnPropertyChanged(...) }`
-  shape unless `SetField<T>` truly doesn't fit — and if it doesn't, say why
-  in the PR description.
+  shape unless `ViewModelBase.SetProperty<T>` truly doesn't fit — and if it
+  doesn't, say why in the PR description. The helper already exists and is
+  used by every VM except `BulkChangeViewModel` (#87).
 - No new `List<T>` field that is mutated from more than one method without
   a snapshot/setter cascade (#78 / #79).
 

--- a/src/BlockParam.Tests/ConfigEditorViewModelTests.cs
+++ b/src/BlockParam.Tests/ConfigEditorViewModelTests.cs
@@ -239,6 +239,51 @@ public class ConfigEditorViewModelTests : IDisposable
     }
 
     [Fact]
+    public void NewFile_TwoNewFilesWithSameAutoName_BothPersisted()
+    {
+        // #72: two "+ File" entries with identical first-rule PathPattern used
+        // to derive the same filename and the second silently overwrote the
+        // first. SaveAll must now suffix the second to keep both on disk.
+        var loader = CreateLoader();
+        var vm = new ConfigEditorViewModel(loader);
+
+        vm.NewFileCommand.Execute(null);
+        var first = vm.RuleFiles[0];
+        first.Rules[0].PathPattern = @".*\.Speed$";
+
+        vm.NewFileCommand.Execute(null);
+        var second = vm.RuleFiles[1];
+        second.Rules[0].PathPattern = @".*\.Speed$";
+
+        vm.SaveCommand.Execute(null);
+
+        File.Exists(Path.Combine(_rulesDir, "_any_.Speed.json")).Should().BeTrue();
+        File.Exists(Path.Combine(_rulesDir, "_any_.Speed-2.json")).Should().BeTrue();
+        vm.RuleFiles.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void NewFile_AutoNameCollidesWithExistingOnDisk_Suffixed()
+    {
+        // #72 sibling case: an on-disk file that loaded as a fixed-name entry
+        // already claims the auto-derived name. The newly added file must
+        // suffix rather than overwrite.
+        WriteRuleFile("_any_.Speed.json",
+            @"{ ""version"": ""1.0"", ""rules"": [{ ""pathPattern"": "".*\\.Speed$"" }] }");
+
+        var loader = CreateLoader();
+        var vm = new ConfigEditorViewModel(loader);
+
+        vm.NewFileCommand.Execute(null);
+        vm.RuleFiles.Last().Rules[0].PathPattern = @".*\.Speed$";
+
+        vm.SaveCommand.Execute(null);
+
+        File.Exists(Path.Combine(_rulesDir, "_any_.Speed.json")).Should().BeTrue();
+        File.Exists(Path.Combine(_rulesDir, "_any_.Speed-2.json")).Should().BeTrue();
+    }
+
+    [Fact]
     public void DeleteSelected_RemovesRuleAndFileWhenLast()
     {
         WriteRuleFile("toDelete.json",

--- a/src/BlockParam/Diagnostics/Log.cs
+++ b/src/BlockParam/Diagnostics/Log.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using BlockParam.Services;
 
 namespace BlockParam.Diagnostics;
 
@@ -89,9 +90,7 @@ public static class Log
     // computation is cheap and Directory.CreateDirectory is idempotent.
     private static string ResolveLogPath()
     {
-        var dir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "BlockParam", "logs");
+        var dir = AppDirectories.LogsDir;
         Directory.CreateDirectory(dir);
         var version = typeof(Log).Assembly.GetName().Version;
         var fileName = $"bulkchange-v{version}-{DateTime.Now:yyyy-MM-dd}.log";

--- a/src/BlockParam/Licensing/OnlineLicenseService.cs
+++ b/src/BlockParam/Licensing/OnlineLicenseService.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using BlockParam.Diagnostics;
+using BlockParam.Services;
 
 namespace BlockParam.Licensing;
 
@@ -57,9 +58,7 @@ public class OnlineLicenseService : ILicenseService
     /// every seat on the machine adopts it on next start. UNC / network
     /// paths are explicitly out of scope — only this local path is read.
     /// </summary>
-    public static string DefaultSharedLicenseFilePath => Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-        "BlockParam", "license.key");
+    public static string DefaultSharedLicenseFilePath => AppDirectories.SharedLicenseFile;
 
     public OnlineLicenseService(
         string storagePath,

--- a/src/BlockParam/Licensing/OnlineLicenseService.cs
+++ b/src/BlockParam/Licensing/OnlineLicenseService.cs
@@ -13,6 +13,20 @@ namespace BlockParam.Licensing;
 /// License service that validates Pro licenses via periodic heartbeats to a remote server.
 /// Tracks concurrent sessions to prevent license sharing across VMs.
 /// Falls back gracefully: cached license (48h) → free tier.
+///
+/// Sync model (single source of truth — see #11 audit on branch
+/// claude/review-code-architecture-lxZvn):
+///   - <c>_lock</c> guards the mutable state bundle: <c>_licenseData</c>,
+///     <c>_cache</c>, <c>_proActive</c>, <c>_retryCount</c>. Every read/write
+///     of those four fields runs inside <c>lock (_lock)</c>.
+///   - <c>volatile</c> is reserved for the lifecycle flag <c>_disposed</c> and
+///     the read-mostly mirror <c>_proActive</c> (read from binding threads
+///     without the lock; the lock provides happens-before for writes).
+///   - <c>_heartbeatTimer</c> is owned via <c>Interlocked.Exchange</c> so a
+///     racing <c>Dispose</c> always wins and never leaks a live timer.
+///   - HTTP calls (<c>PostAsync</c>) MUST run outside the lock — otherwise a
+///     slow server freezes every license read. Lock only the JSON-to-state
+///     copy after the response arrives.
 /// </summary>
 public class OnlineLicenseService : ILicenseService
 {
@@ -34,7 +48,7 @@ public class OnlineLicenseService : ILicenseService
     private CachedLicenseResponse? _cache;
     private volatile bool _proActive;
     private volatile bool _disposed;
-    private volatile bool _isManagedKey;
+    private bool _isManagedKey;
     private int _retryCount;
 
     /// <summary>
@@ -188,13 +202,26 @@ public class OnlineLicenseService : ILicenseService
         if (_disposed || _licenseData == null || string.IsNullOrWhiteSpace(_serverBaseUrl))
             return;
 
-        StopHeartbeat();
-        _retryCount = 0;
-        _heartbeatTimer = new Timer(
+        lock (_lock) { _retryCount = 0; }
+
+        var fresh = new Timer(
             _ => _ = SendHeartbeatAsync(),
             null,
             TimeSpan.Zero,  // First heartbeat immediately
             Timeout.InfiniteTimeSpan);  // One-shot; re-scheduled after each beat
+
+        // Atomic swap so a concurrent StopHeartbeat / Dispose can't leak the
+        // previous timer (or this one — see post-swap _disposed check below).
+        var previous = Interlocked.Exchange(ref _heartbeatTimer, fresh);
+        previous?.Dispose();
+
+        // Lost the race against Dispose: the timer we just installed will
+        // never be reaped by Dispose's Exchange because Dispose already ran.
+        if (_disposed)
+        {
+            var leaked = Interlocked.Exchange(ref _heartbeatTimer, null);
+            leaked?.Dispose();
+        }
     }
 
     private void ScheduleNextHeartbeat(TimeSpan delay)
@@ -260,7 +287,7 @@ public class OnlineLicenseService : ILicenseService
                     EvaluateTier();
                 }
 
-                _retryCount = 0; // Success — reset retry counter
+                lock (_lock) { _retryCount = 0; } // Success — reset retry counter
                 ScheduleNextHeartbeat(HeartbeatInterval);
                 RaiseLicenseStateChanged();
                 return;
@@ -274,34 +301,38 @@ public class OnlineLicenseService : ILicenseService
                     if (_cache != null)
                         _cache.ErrorMessage = "License rejected by server";
                     _proActive = false;
+                    _retryCount = 0; // Server responded clearly — no retry
                 }
-                _retryCount = 0; // Server responded clearly — no retry
                 ScheduleNextHeartbeat(HeartbeatInterval);
                 RaiseLicenseStateChanged();
             }
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
-            Log.Warning(ex, "Heartbeat failed — using cached license (retry {Retry}/{Max})",
-                _retryCount + 1, MaxRetryAttempts);
+            // Read+update _retryCount under the lock so a rapid Stop/Start
+            // cycle (which leaves an in-flight callback) can't race a fresh
+            // heartbeat resetting the counter.
+            int attempt;
+            TimeSpan delay;
             lock (_lock)
             {
                 EvaluateTier(); // Re-evaluate with cache
+                attempt = _retryCount + 1;
+                if (_retryCount < MaxRetryAttempts)
+                {
+                    // Exponential backoff: 30s, 60s, 120s, 240s, then back to 2h
+                    delay = TimeSpan.FromSeconds(30 * Math.Pow(2, _retryCount));
+                    _retryCount++;
+                }
+                else
+                {
+                    delay = HeartbeatInterval;
+                    _retryCount = 0;
+                }
             }
-
-            // Exponential backoff: 30s, 60s, 120s, 240s, then back to 2h
-            if (_retryCount < MaxRetryAttempts)
-            {
-                var delay = TimeSpan.FromSeconds(30 * Math.Pow(2, _retryCount));
-                _retryCount++;
-                ScheduleNextHeartbeat(delay);
-            }
-            else
-            {
-                _retryCount = 0;
-                ScheduleNextHeartbeat(HeartbeatInterval);
-            }
-
+            Log.Warning(ex, "Heartbeat failed — using cached license (retry {Retry}/{Max})",
+                attempt, MaxRetryAttempts);
+            ScheduleNextHeartbeat(delay);
             RaiseLicenseStateChanged();
         }
     }

--- a/src/BlockParam/Services/AppDirectories.cs
+++ b/src/BlockParam/Services/AppDirectories.cs
@@ -1,3 +1,6 @@
+using System;
+using System.IO;
+
 namespace BlockParam.Services;
 
 /// <summary>

--- a/src/BlockParam/Services/AppDirectories.cs
+++ b/src/BlockParam/Services/AppDirectories.cs
@@ -1,0 +1,43 @@
+namespace BlockParam.Services;
+
+/// <summary>
+/// Single source of truth for paths rooted at the "BlockParam" segment.
+/// Replaces inline literals like <c>Path.Combine(..., "BlockParam", "logs")</c>
+/// scattered across the codebase (#86) — and is the anchor the new
+/// "no new path string literals" CLAUDE.md guardrail points at.
+///
+/// Only the three callers in files untouched by the freemium branch are
+/// migrated in the first pass: <c>Diagnostics.Log</c>, <c>UiZoomService</c>,
+/// and <c>OnlineLicenseService.DefaultSharedLicenseFilePath</c>. The
+/// remaining sites in <c>ConfigLoader</c> and <c>BulkChangeContextMenu</c>
+/// follow once the freemium branch merges.
+/// </summary>
+public static class AppDirectories
+{
+    private const string ProductFolder = "BlockParam";
+
+    /// <summary>Per-user app data root: <c>%APPDATA%\BlockParam</c>.</summary>
+    public static string AppData => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        ProductFolder);
+
+    /// <summary>Machine-wide app data root: <c>%PROGRAMDATA%\BlockParam</c>.</summary>
+    public static string ProgramData => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+        ProductFolder);
+
+    /// <summary>Per-machine TEMP root: <c>%TEMP%\BlockParam</c>.</summary>
+    public static string Temp => Path.Combine(Path.GetTempPath(), ProductFolder);
+
+    /// <summary>Rolling log directory under <see cref="AppData"/>.</summary>
+    public static string LogsDir => Path.Combine(AppData, "logs");
+
+    /// <summary>Per-user UI zoom / window-state settings file.</summary>
+    public static string UiSettingsFile => Path.Combine(AppData, "ui-settings.json");
+
+    /// <summary>
+    /// Machine-wide shared license file. IT rolls out / rotates the key by
+    /// writing here; every seat on the machine adopts it on next start.
+    /// </summary>
+    public static string SharedLicenseFile => Path.Combine(ProgramData, "license.key");
+}

--- a/src/BlockParam/Services/MemberSearchService.cs
+++ b/src/BlockParam/Services/MemberSearchService.cs
@@ -28,16 +28,9 @@ public class MemberSearchService
         return new SearchResult(query, matches);
     }
 
-    private static bool IsMatch(MemberNode member, string term)
-    {
-        // Use IndexOf instead of Contains(string, StringComparison) to avoid
-        // dependency on System.Runtime.CompilerServices.Unsafe which is missing
-        // in the TIA Portal host process.
-        return member.Name.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0
-            || member.Datatype.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0
-            || (member.StartValue?.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0)
-            || member.Path.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0;
-    }
+    private static bool IsMatch(MemberNode member, string term) =>
+        StringMatcher.MatchesAny(term,
+            member.Name, member.Datatype, member.StartValue, member.Path);
 }
 
 public class SearchResult

--- a/src/BlockParam/Services/StringMatcher.cs
+++ b/src/BlockParam/Services/StringMatcher.cs
@@ -1,0 +1,32 @@
+namespace BlockParam.Services;
+
+/// <summary>
+/// Case-insensitive substring matching across multiple candidate fields.
+/// Collapses the four duplicate <c>x.IndexOf(filter, ...) || y.IndexOf(filter, ...)</c>
+/// blocks the codebase had grown into (#83).
+///
+/// Uses <see cref="string.IndexOf(string, StringComparison)"/> rather than
+/// <see cref="string.Contains(string, StringComparison)"/> so the assembly
+/// does not pull in <c>System.Runtime.CompilerServices.Unsafe</c>, which is
+/// missing in the TIA Portal partial-trust host.
+/// </summary>
+public static class StringMatcher
+{
+    /// <summary>
+    /// Returns true if <paramref name="filter"/> appears as a case-insensitive
+    /// substring in any non-null field. An empty / whitespace filter matches
+    /// vacuously (returns true) so callers can pass user input directly.
+    /// </summary>
+    public static bool MatchesAny(string? filter, params string?[]? fields)
+    {
+        if (string.IsNullOrWhiteSpace(filter)) return true;
+        if (fields == null) return false;
+        for (int i = 0; i < fields.Length; i++)
+        {
+            var f = fields[i];
+            if (f != null && f.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0)
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/BlockParam/Services/UiZoomService.cs
+++ b/src/BlockParam/Services/UiZoomService.cs
@@ -58,9 +58,7 @@ public class UiZoomService
 
     private bool PersistenceEnabled => !string.IsNullOrEmpty(_settingsPath);
 
-    public static string DefaultSettingsPath() => Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-        "BlockParam", "ui-settings.json");
+    public static string DefaultSettingsPath() => AppDirectories.UiSettingsFile;
 
     public double ZoomFactor
     {

--- a/src/BlockParam/UI/ConfigEditorViewModel.cs
+++ b/src/BlockParam/UI/ConfigEditorViewModel.cs
@@ -7,6 +7,7 @@ using System.Windows.Threading;
 using BlockParam.Diagnostics;
 using BlockParam.Config;
 using BlockParam.Localization;
+using BlockParam.Services;
 
 namespace BlockParam.UI;
 
@@ -149,20 +150,16 @@ public class ConfigEditorViewModel : ViewModelBase
         if (string.IsNullOrWhiteSpace(_filterText)) return true;
         if (obj is not RuleFileViewModel file) return false;
 
-        if (file.FileName.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0)
+        if (StringMatcher.MatchesAny(_filterText, file.FileName))
             return true;
 
         return file.Rules.Any(RuleMatchesFilter);
     }
 
     private bool RuleMatchesFilter(RuleViewModel r) =>
-        r.PathPattern.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
-        || r.TagTableName.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
-        || r.CommentTemplate.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
-        || r.Datatype.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
-        || r.AllowedValues.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
-        || r.Min.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0
-        || r.Max.IndexOf(_filterText, StringComparison.OrdinalIgnoreCase) >= 0;
+        StringMatcher.MatchesAny(_filterText,
+            r.PathPattern, r.TagTableName, r.CommentTemplate,
+            r.Datatype, r.AllowedValues, r.Min, r.Max);
 
     private void AutoExpandMatches()
     {

--- a/src/BlockParam/UI/ConfigEditorViewModel.cs
+++ b/src/BlockParam/UI/ConfigEditorViewModel.cs
@@ -393,6 +393,47 @@ public class ConfigEditorViewModel : ViewModelBase
         return $"{baseName}-{Guid.NewGuid():N}.json";
     }
 
+    /// <summary>
+    /// Lazily seeds a per-directory claim set with the on-disk file names
+    /// already living there. Used by SaveAll to detect collisions between
+    /// auto-derived names, user-typed names, and existing files. Missing
+    /// directory is fine — the claim set just stays seeded with whatever
+    /// in-memory files have already been pre-claimed.
+    /// </summary>
+    private static HashSet<string> ClaimsFor(
+        Dictionary<string, HashSet<string>> cache, string dir)
+    {
+        if (cache.TryGetValue(dir, out var set)) return set;
+        set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            if (Directory.Exists(dir))
+                foreach (var p in Directory.EnumerateFiles(dir, "*.json"))
+                    set.Add(Path.GetFileName(p));
+        }
+        catch { /* unreadable dir → empty seed; SaveRuleFile will fail later with a clearer error */ }
+        cache[dir] = set;
+        return set;
+    }
+
+    /// <summary>
+    /// Returns <paramref name="baseName"/> if free, otherwise appends -2, -3, …
+    /// before the .json extension until a free name is found. Falls back to a
+    /// guid suffix as the absolute last resort.
+    /// </summary>
+    private static string ResolveUniqueFileName(string baseName, HashSet<string> claimed)
+    {
+        if (!claimed.Contains(baseName)) return baseName;
+        var stem = Path.GetFileNameWithoutExtension(baseName);
+        var ext = Path.GetExtension(baseName);
+        for (int i = 2; i < 1000; i++)
+        {
+            var candidate = $"{stem}-{i}{ext}";
+            if (!claimed.Contains(candidate)) return candidate;
+        }
+        return $"{stem}-{Guid.NewGuid():N}{ext}";
+    }
+
     private RuleSource GetDefaultNewFileSource()
     {
         var projectDir = _configLoader.GetTiaProjectRulesDirectory();
@@ -569,17 +610,37 @@ public class ConfigEditorViewModel : ViewModelBase
         // anything else, IsAutoNamed flips to false and we keep their name —
         // so a file the user explicitly named "my-rules.json" never gets
         // silently renamed to a pattern-derived name on save.
+        //
+        // Per-target-dir claim sets prevent two new files with the same
+        // first-rule pattern from both grabbing the same derived name and
+        // silently overwriting each other on save (#72). Pre-claim every
+        // fixed name (user-typed or already-existing on-disk) so auto-names
+        // can only land on free slots; resolution appends -2, -3, … on hit.
+        var claimsByDir = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var file in RuleFiles)
+        {
+            if (file.IsNew && file.IsAutoNamed) continue;
+            var dir = GetDirectoryForSource(file.SaveDestination);
+            if (dir != null)
+                ClaimsFor(claimsByDir, dir).Add(file.FileName);
+        }
+
         foreach (var file in RuleFiles)
         {
             if (file.IsNew && file.IsAutoNamed)
             {
-                var derived = file.DeriveFileNameFromFirstRule();
-                if (!string.Equals(file.FileName, derived, StringComparison.OrdinalIgnoreCase))
+                var dir = GetDirectoryForSource(file.SaveDestination);
+                if (dir != null)
                 {
-                    file.FileName = derived;
-                    var dir = Path.GetDirectoryName(file.FilePath);
-                    if (!string.IsNullOrEmpty(dir))
-                        file.FilePath = Path.Combine(dir, derived);
+                    var derived = file.DeriveFileNameFromFirstRule();
+                    var unique = ResolveUniqueFileName(derived, ClaimsFor(claimsByDir, dir));
+                    ClaimsFor(claimsByDir, dir).Add(unique);
+
+                    if (!string.Equals(file.FileName, unique, StringComparison.OrdinalIgnoreCase))
+                    {
+                        file.FileName = unique;
+                        file.FilePath = Path.Combine(dir, unique);
+                    }
                 }
             }
 


### PR DESCRIPTION
Codifies preventive rules tied to the maintainability/DRY review findings
and existing refactor issues (#78, #79, #80, #81, #82), so new code stops
adding to the mess while the larger refactors land separately.

Bundled fixes/refactors riding alongside the guardrails:
- Tighten OnlineLicenseService concurrency (Interlocked.Exchange for the heartbeat timer; move `_retryCount` updates under `_lock`).
- Extract `Services/StringMatcher.MatchesAny` and migrate the two duplicate sites outside the freemium branch (#83 partial — two further sites stay in `BulkChangeViewModel.cs` until #80).
- Add `Services/AppDirectories` constants and migrate three callers in files untouched by the freemium branch (#86 partial — six remaining sites in `ConfigLoader.cs` / `BulkChangeContextMenu.cs` follow once the freemium branch merges).
- Correct the CLAUDE.md guardrail to point at the real `ViewModelBase.SetProperty<T>` helper (#87).
- SaveAll: prevent two "+ File" entries with the same auto-derived name from silently overwriting each other on disk.

Closes #72