### PR TITLE
fix(ui): replace misleading Yes/No/Cancel prompts with named-button dialogs

### DIFF
--- a/src/BlockParam.Tests/BulkChangeViewModelDbSwitcherTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelDbSwitcherTests.cs
@@ -321,19 +321,51 @@ public class BulkChangeViewModelDbSwitcherTests
             "Apply on B doesn't touch the stash dictionary");
     }
 
+    /// <summary>
+    /// Convenience enum shared across DB-switcher tests. Yes/No/Cancel maps
+    /// onto the three named outcomes for each typed prompt method.
+    /// </summary>
+    private enum YesNoCancelResult { Yes, No, Cancel }
+
     private class FakeMessageBox : IMessageBoxService
     {
         private readonly YesNoCancelResult _result;
         public int AskYesNoCallCount { get; private set; }
+        /// <summary>Counts any 3-way prompt call (ApplyStashCancel, AddOrReplace, CloseWithStash).</summary>
         public int AskYesNoCancelCallCount { get; private set; }
         public FakeMessageBox(YesNoCancelResult result) { _result = result; }
         public bool AskYesNo(string message, string title) { AskYesNoCallCount++; return true; }
         public void ShowError(string message, string title) { }
         public void ShowInfo(string message, string title) { }
-        public YesNoCancelResult AskYesNoCancel(string message, string title)
+        public ApplyStashCancelResult AskApplyStashCancel(string message, string title)
         {
             AskYesNoCancelCallCount++;
-            return _result;
+            return _result switch
+            {
+                YesNoCancelResult.Yes => ApplyStashCancelResult.ApplyAndSwitch,
+                YesNoCancelResult.No  => ApplyStashCancelResult.StashAndSwitch,
+                _                     => ApplyStashCancelResult.Cancel,
+            };
+        }
+        public AddOrReplaceResult AskAddOrReplace(string message, string title)
+        {
+            AskYesNoCancelCallCount++;
+            return _result switch
+            {
+                YesNoCancelResult.Yes => AddOrReplaceResult.Add,
+                YesNoCancelResult.No  => AddOrReplaceResult.Replace,
+                _                     => AddOrReplaceResult.Cancel,
+            };
+        }
+        public CloseWithStashResult AskCloseWithStash(string message, string title)
+        {
+            AskYesNoCancelCallCount++;
+            return _result switch
+            {
+                YesNoCancelResult.Yes => CloseWithStashResult.ApplyActive,
+                YesNoCancelResult.No  => CloseWithStashResult.DiscardAll,
+                _                     => CloseWithStashResult.Cancel,
+            };
         }
     }
 }

--- a/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
@@ -926,6 +926,13 @@ public class BulkChangeViewModelInvariantTests
 
     // ───────────────────────── builder + fakes ─────────────────────────
 
+    /// <summary>
+    /// Convenience enum for scripting 3-way prompt responses in tests.
+    /// Yes/No/Cancel maps onto the named outcomes of each typed prompt method
+    /// (ApplyStashCancel, AddOrReplace, CloseWithStash).
+    /// </summary>
+    private enum YesNoCancelResult { Yes, No, Cancel }
+
     private sealed class ActiveSetTestBuilder
     {
         private readonly List<DbSpec> _activeDbs = new();
@@ -1107,6 +1114,7 @@ public class BulkChangeViewModelInvariantTests
             _results = results;
         }
 
+        /// <summary>Counts any 3-way prompt call (ApplyStashCancel, AddOrReplace, CloseWithStash).</summary>
         public int AskYesNoCancelCallCount { get; private set; }
         public int AskYesNoCallCount { get; private set; }
         public bool AskYesNo(string message, string title)
@@ -1116,14 +1124,45 @@ public class BulkChangeViewModelInvariantTests
         }
         public void ShowError(string message, string title) { }
         public void ShowInfo(string message, string title) { }
-        public YesNoCancelResult AskYesNoCancel(string message, string title)
+
+        private YesNoCancelResult Dequeue(string methodName, string message)
         {
             AskYesNoCancelCallCount++;
             if (_results.Count == 0)
                 throw new System.InvalidOperationException(
-                    $"RecordingFakeMessageBox: AskYesNoCancel call #{AskYesNoCancelCallCount} " +
+                    $"RecordingFakeMessageBox: {methodName} call #{AskYesNoCancelCallCount} " +
                     $"has no scripted response — extend WithPromptResults(...).\nMessage: {message}");
             return _results.Dequeue();
+        }
+
+        public ApplyStashCancelResult AskApplyStashCancel(string message, string title)
+        {
+            return Dequeue(nameof(AskApplyStashCancel), message) switch
+            {
+                YesNoCancelResult.Yes => ApplyStashCancelResult.ApplyAndSwitch,
+                YesNoCancelResult.No  => ApplyStashCancelResult.StashAndSwitch,
+                _                     => ApplyStashCancelResult.Cancel,
+            };
+        }
+
+        public AddOrReplaceResult AskAddOrReplace(string message, string title)
+        {
+            return Dequeue(nameof(AskAddOrReplace), message) switch
+            {
+                YesNoCancelResult.Yes => AddOrReplaceResult.Add,
+                YesNoCancelResult.No  => AddOrReplaceResult.Replace,
+                _                     => AddOrReplaceResult.Cancel,
+            };
+        }
+
+        public CloseWithStashResult AskCloseWithStash(string message, string title)
+        {
+            return Dequeue(nameof(AskCloseWithStash), message) switch
+            {
+                YesNoCancelResult.Yes => CloseWithStashResult.ApplyActive,
+                YesNoCancelResult.No  => CloseWithStashResult.DiscardAll,
+                _                     => CloseWithStashResult.Cancel,
+            };
         }
     }
 }

--- a/src/BlockParam.Tests/BulkChangeViewModelMultiDbTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelMultiDbTests.cs
@@ -781,19 +781,51 @@ public class BulkChangeViewModelMultiDbTests
         restoredLeaf.PendingValue.Should().Be(pending);
     }
 
+    /// <summary>
+    /// Convenience enum shared across multi-DB tests. Yes/No/Cancel maps
+    /// onto the three named outcomes for each typed prompt method.
+    /// </summary>
+    private enum YesNoCancelResult { Yes, No, Cancel }
+
     private sealed class FakeMessageBox : IMessageBoxService
     {
         private readonly YesNoCancelResult _result;
         public FakeMessageBox(YesNoCancelResult r) { _result = r; }
 
+        /// <summary>Counts any 3-way prompt call (ApplyStashCancel, AddOrReplace, CloseWithStash).</summary>
         public int AskYesNoCancelCallCount { get; private set; }
         public bool AskYesNo(string message, string title) => true;
         public void ShowError(string message, string title) { }
         public void ShowInfo(string message, string title) { }
-        public YesNoCancelResult AskYesNoCancel(string message, string title)
+        public ApplyStashCancelResult AskApplyStashCancel(string message, string title)
         {
             AskYesNoCancelCallCount++;
-            return _result;
+            return _result switch
+            {
+                YesNoCancelResult.Yes => ApplyStashCancelResult.ApplyAndSwitch,
+                YesNoCancelResult.No  => ApplyStashCancelResult.StashAndSwitch,
+                _                     => ApplyStashCancelResult.Cancel,
+            };
+        }
+        public AddOrReplaceResult AskAddOrReplace(string message, string title)
+        {
+            AskYesNoCancelCallCount++;
+            return _result switch
+            {
+                YesNoCancelResult.Yes => AddOrReplaceResult.Add,
+                YesNoCancelResult.No  => AddOrReplaceResult.Replace,
+                _                     => AddOrReplaceResult.Cancel,
+            };
+        }
+        public CloseWithStashResult AskCloseWithStash(string message, string title)
+        {
+            AskYesNoCancelCallCount++;
+            return _result switch
+            {
+                YesNoCancelResult.Yes => CloseWithStashResult.ApplyActive,
+                YesNoCancelResult.No  => CloseWithStashResult.DiscardAll,
+                _                     => CloseWithStashResult.Cancel,
+            };
         }
     }
 }

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -339,18 +339,14 @@ Datenbaustein jetzt kompilieren?</value></data>
 
 Fortfahren?</value><comment>{0} = Anzahl ausstehender Änderungen, {1} = Ziel-DB-Name</comment></data>
   <data name="Dialog_SwitchDb_KeepConfirm_Title" xml:space="preserve"><value>Vorgemerkte Änderungen vor dem Wechsel anwenden?</value></data>
-  <data name="Dialog_SwitchDb_KeepConfirm_Text" xml:space="preserve"><value>Sie haben {0} vorgemerkte Änderung(en) an '{1}'.
-
-Ja — In TIA Portal anwenden, dann wechseln.
-Nein — Zwischenspeichern und wechseln.
-Abbrechen — Bei '{1}' bleiben.</value><comment>{0} = Anzahl ausstehender Änderungen, {1} = aktueller DB-Name, {2} = Ziel-DB-Name (ungenutzt)</comment></data>
+  <data name="Dialog_SwitchDb_KeepConfirm_Text" xml:space="preserve"><value>Sie haben {0} vorgemerkte Änderung(en) an '{1}'.</value><comment>{0} = Anzahl ausstehender Änderungen, {1} = aktueller DB-Name</comment></data>
+  <data name="Dialog_SwitchDb_KeepConfirm_ApplyButton" xml:space="preserve"><value>Anwenden &amp; wechseln</value></data>
+  <data name="Dialog_SwitchDb_KeepConfirm_StashButton" xml:space="preserve"><value>Merken &amp; wechseln</value></data>
   <data name="Status_DbSwitch_ApplyBlocked" xml:space="preserve"><value>Vorgemerkte Änderungen können nicht angewendet werden — ungültige Einträge korrigieren oder auf das Zurücksetzen des Tageslimits warten.</value></data>
   <data name="Reactivate_AdditiveOrReplace_Title" xml:space="preserve"><value>Hinzufügen oder ersetzen?</value></data>
-  <data name="Reactivate_AdditiveOrReplace_Text" xml:space="preserve"><value>'{0}' zusätzlich zu den aktuellen DBs einblenden oder ersetzen?
-
-Ja — '{0}' zur aktuellen Sitzung hinzufügen.
-Nein — Aktuelle DBs durch '{0}' ersetzen.
-Abbrechen — Bei den aktuellen DBs bleiben.</value><comment>{0} = Name des wieder aktivierten DB</comment></data>
+  <data name="Reactivate_AdditiveOrReplace_Text" xml:space="preserve"><value>'{0}' zusätzlich zu den aktuellen DBs einblenden oder ersetzen?</value><comment>{0} = Name des wieder aktivierten DB</comment></data>
+  <data name="Reactivate_AdditiveOrReplace_AddButton" xml:space="preserve"><value>Hinzufügen</value></data>
+  <data name="Reactivate_AdditiveOrReplace_ReplaceButton" xml:space="preserve"><value>Ersetzen</value></data>
   <data name="Status_DbSwitched_StashRestored" xml:space="preserve"><value>Zu {0} gewechselt — {1} zwischengespeicherte Änderung(en) wiederhergestellt.</value><comment>{0} = DB-Name, {1} = Anzahl wiederhergestellt</comment></data>
   <data name="Status_DbSwitched_StashPartial" xml:space="preserve"><value>Zu {0} gewechselt — {1} zwischengespeicherte Änderung(en) wiederhergestellt; {2} passen nicht mehr zur aktuellen DB-Struktur.</value><comment>{0} = DB-Name, {1} = Anzahl wiederhergestellt, {2} = Anzahl verworfen</comment></data>
   <data name="Inspector_StashedDb_Header" xml:space="preserve"><value>AUSSTEHEND IN {0}</value><comment>{0} = zwischengespeicherter DB-Name (großgeschrieben, passend zu anderen Abschnittsüberschriften)</comment></data>
@@ -364,9 +360,9 @@ Abbrechen — Bei den aktuellen DBs bleiben.</value><comment>{0} = Name des wied
   <!-- Schließen-Prompt mit zwischengespeicherten Änderungen in anderen DBs (#59) -->
   <data name="Dialog_UnsavedChanges_Prompt_WithStash" xml:space="preserve"><value>Sie haben {0} ausstehende Änderung(en) am aktuellen DB und {1} zwischengespeicherte Änderung(en) in anderen DB(s): {2}.
 
-Ja — Aktuellen DB jetzt anwenden (zwischengespeicherte Änderungen in anderen DBs werden beim Schließen dennoch verworfen).
-Nein — Alles verwerfen und schließen.
-Abbrechen — Im Dialog bleiben.</value><comment>{0} = ausstehende Anzahl, {1} = zwischengespeicherte Anzahl, {2} = kommagetrennte DB-Namen</comment></data>
+Das Anwenden schreibt nur den aktuellen DB zurück — zwischengespeicherte Änderungen in anderen DBs werden beim Schließen dennoch verworfen.</value><comment>{0} = ausstehende Anzahl, {1} = zwischengespeicherte Anzahl, {2} = kommagetrennte DB-Namen</comment></data>
+  <data name="Dialog_UnsavedChanges_ApplyActiveButton" xml:space="preserve"><value>Aktiven anwenden (Zwischenspeicher verwerfen)</value></data>
+  <data name="Dialog_UnsavedChanges_DiscardAllButton" xml:space="preserve"><value>Alles verwerfen</value></data>
   <data name="Dialog_UnsavedChanges_StashOnly" xml:space="preserve"><value>Sie haben {0} zwischengespeicherte Änderung(en) in anderen DB(s): {1}.
 
 Beim Schließen des Dialogs werden sie verworfen. Trotzdem schließen?</value><comment>{0} = zwischengespeicherte Anzahl, {1} = kommagetrennte DB-Namen</comment></data>

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -751,9 +751,6 @@ Applying will commit the current DB only — stashed changes in other DBs are st
   <data name="Dialog_UnsavedChanges_DiscardAllButton" xml:space="preserve">
     <value>Discard all</value>
   </data>
-  <data name="Dialog_Cancel" xml:space="preserve">
-    <value>Cancel</value>
-  </data>
   <!-- Stash-only close prompt (#59 follow-up). Active DB is clean but
        stashes from earlier switches still hold edits the user hasn't
        reviewed. Yes/No is enough — there's nothing to "Apply" here. -->

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -737,16 +737,22 @@ Compile the block now?</value>
     <comment>{0} = number of pending inline edits</comment>
   </data>
   <!-- Combined prompt fired by OnClosing when both active-DB and stashed-DB
-       edits exist (#59 follow-up). Yes applies the active DB only — stashed
-       edits still get discarded; the message spells that out so the user
-       picks knowingly. -->
+       edits exist (#59 follow-up). Button labels carry the action descriptions;
+       the body just states the facts. -->
   <data name="Dialog_UnsavedChanges_Prompt_WithStash" xml:space="preserve">
     <value>You have {0} pending change(s) on the current DB and {1} stashed change(s) in other DB(s): {2}.
 
-Yes — Apply the current DB now (stashed changes in other DBs are still discarded on close).
-No  — Discard everything and close.
-Cancel — Stay in the dialog.</value>
+Applying will commit the current DB only — stashed changes in other DBs are still discarded on close.</value>
     <comment>{0} = active pending count, {1} = stashed count, {2} = comma-separated stashed DB names</comment>
+  </data>
+  <data name="Dialog_UnsavedChanges_ApplyActiveButton" xml:space="preserve">
+    <value>Apply active (discard stash)</value>
+  </data>
+  <data name="Dialog_UnsavedChanges_DiscardAllButton" xml:space="preserve">
+    <value>Discard all</value>
+  </data>
+  <data name="Dialog_Cancel" xml:space="preserve">
+    <value>Cancel</value>
   </data>
   <!-- Stash-only close prompt (#59 follow-up). Active DB is clean but
        stashes from earlier switches still hold edits the user hasn't
@@ -860,35 +866,37 @@ Continue?</value>
     <comment>{0} = pending edit count, {1} = target DB name</comment>
   </data>
   <!-- 3-way prompt fired by SwitchToDataBlock when staged edits exist (#59).
-       Yes = apply to TIA before switching, No = stash in memory and switch,
-       Cancel = stay on the current DB. -->
+       Buttons carry the action labels; body states the facts only. -->
   <data name="Dialog_SwitchDb_KeepConfirm_Title" xml:space="preserve">
     <value>Apply staged changes before switching?</value>
   </data>
   <data name="Dialog_SwitchDb_KeepConfirm_Text" xml:space="preserve">
-    <value>You have {0} staged change(s) on '{1}'.
-
-Yes — Apply to TIA Portal, then switch.
-No — Stash them, then switch.
-Cancel — Stay on '{1}'.</value>
-    <comment>{0} = pending edit count, {1} = current DB name, {2} = target DB name (unused since prompt was tightened)</comment>
+    <value>You have {0} staged change(s) on '{1}'.</value>
+    <comment>{0} = pending edit count, {1} = current DB name</comment>
+  </data>
+  <data name="Dialog_SwitchDb_KeepConfirm_ApplyButton" xml:space="preserve">
+    <value>Apply &amp; switch</value>
+  </data>
+  <data name="Dialog_SwitchDb_KeepConfirm_StashButton" xml:space="preserve">
+    <value>Stash &amp; switch</value>
   </data>
   <data name="Status_DbSwitch_ApplyBlocked" xml:space="preserve">
     <value>Cannot apply staged edits — fix invalid entries or wait for the daily limit to reset.</value>
   </data>
   <!-- 3-way prompt fired when reactivating a stash with ≥2 DBs active (#92).
-       Yes = add the stashed DB alongside (additive), No = replace the
-       current active set with just the stashed DB, Cancel = stay put. -->
+       Buttons carry the action labels; body states the facts only. -->
   <data name="Reactivate_AdditiveOrReplace_Title" xml:space="preserve">
     <value>Add or replace?</value>
   </data>
   <data name="Reactivate_AdditiveOrReplace_Text" xml:space="preserve">
-    <value>Bring back '{0}' alongside the current DBs, or replace them?
-
-Yes — Add '{0}' to the current session.
-No — Replace the current DBs with '{0}'.
-Cancel — Stay on the current DBs.</value>
+    <value>Bring back '{0}' alongside the current DBs, or replace them?</value>
     <comment>{0} = stashed DB name being reactivated</comment>
+  </data>
+  <data name="Reactivate_AdditiveOrReplace_AddButton" xml:space="preserve">
+    <value>Add alongside</value>
+  </data>
+  <data name="Reactivate_AdditiveOrReplace_ReplaceButton" xml:space="preserve">
+    <value>Replace</value>
   </data>
   <data name="Status_DbSwitched_StashRestored" xml:space="preserve">
     <value>Switched to {0} — restored {1} stashed edit(s).</value>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml.cs
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml.cs
@@ -897,6 +897,18 @@ public partial class BulkChangeDialog : Window
         Close();
     }
 
+    /// <summary>
+    /// Runs Apply and reports whether the close can proceed. Apply may bail
+    /// (e.g. user declined the compile prompt on an inconsistent block); in
+    /// that case pending edits are preserved and the caller must keep the
+    /// dialog open so the user can retry or explicitly Discard.
+    /// </summary>
+    private static bool TryApplyAndContinue(BulkChangeViewModel vm)
+    {
+        vm.ApplyCommand.Execute(null);
+        return vm.PendingInlineEditCount == 0;
+    }
+
     protected override void OnClosing(System.ComponentModel.CancelEventArgs e)
     {
         base.OnClosing(e);
@@ -920,12 +932,7 @@ public partial class BulkChangeDialog : Window
             // Both active-DB edits and stashed-DB edits exist.
             // Use a custom dialog with named buttons so the user is not misled
             // by generic Yes/No/Cancel labels (#audit-message-boxes).
-            var closeResult = vm.MessageBoxService.AskCloseWithStash(
-                Res.Format("Dialog_UnsavedChanges_Prompt_WithStash",
-                    active, stashedCount, stashedDbList),
-                Res.Get("Dialog_UnsavedChanges_Title"));
-
-            switch (closeResult)
+            switch (vm.PromptForCloseWithStash())
             {
                 case CloseWithStashResult.ApplyActive:
                     // Apply commits the active DB only. Stashed edits in other
@@ -933,15 +940,7 @@ public partial class BulkChangeDialog : Window
                     // that out so the user picks knowingly. Apply-everything-
                     // across-stashes would need a per-DB switch+commit loop,
                     // which is a much bigger feature.
-                    vm.ApplyCommand.Execute(null);
-                    // Apply may have bailed out (e.g. user declined the compile prompt on an
-                    // inconsistent block). Pending edits are preserved in that case — keep
-                    // the dialog open so the user can retry or explicitly Discard.
-                    if (vm.PendingInlineEditCount > 0)
-                    {
-                        e.Cancel = true;
-                        return;
-                    }
+                    if (!TryApplyAndContinue(vm)) { e.Cancel = true; return; }
                     break;
                 case CloseWithStashResult.DiscardAll:
                     // Discard pending edits. Use the silent variant — the user
@@ -966,12 +965,7 @@ public partial class BulkChangeDialog : Window
             switch (result)
             {
                 case MessageBoxResult.Yes:
-                    vm.ApplyCommand.Execute(null);
-                    if (vm.PendingInlineEditCount > 0)
-                    {
-                        e.Cancel = true;
-                        return;
-                    }
+                    if (!TryApplyAndContinue(vm)) { e.Cancel = true; return; }
                     break;
                 case MessageBoxResult.No:
                     vm.DiscardPendingSilent();

--- a/src/BlockParam/UI/BulkChangeDialog.xaml.cs
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml.cs
@@ -915,22 +915,19 @@ public partial class BulkChangeDialog : Window
             stashedDbList = string.Join(", ", vm.StashedDbs.Select(s => s.DbName));
         }
 
-        if (active > 0)
+        if (active > 0 && stashedCount > 0)
         {
-            var message = stashedCount > 0
-                ? Res.Format("Dialog_UnsavedChanges_Prompt_WithStash",
-                    active, stashedCount, stashedDbList)
-                : Res.Format("Dialog_UnsavedChanges_Prompt", active);
+            // Both active-DB edits and stashed-DB edits exist.
+            // Use a custom dialog with named buttons so the user is not misled
+            // by generic Yes/No/Cancel labels (#audit-message-boxes).
+            var closeResult = vm.MessageBoxService.AskCloseWithStash(
+                Res.Format("Dialog_UnsavedChanges_Prompt_WithStash",
+                    active, stashedCount, stashedDbList),
+                Res.Get("Dialog_UnsavedChanges_Title"));
 
-            var result = MessageBox.Show(
-                message,
-                Res.Get("Dialog_UnsavedChanges_Title"),
-                MessageBoxButton.YesNoCancel,
-                MessageBoxImage.Warning);
-
-            switch (result)
+            switch (closeResult)
             {
-                case MessageBoxResult.Yes:
+                case CloseWithStashResult.ApplyActive:
                     // Apply commits the active DB only. Stashed edits in other
                     // DBs still get discarded on close — the prompt text spells
                     // that out so the user picks knowingly. Apply-everything-
@@ -946,10 +943,37 @@ public partial class BulkChangeDialog : Window
                         return;
                     }
                     break;
-                case MessageBoxResult.No:
+                case CloseWithStashResult.DiscardAll:
                     // Discard pending edits. Use the silent variant — the user
-                    // already confirmed via the Yes/No/Cancel dialog above, a
-                    // second "are you sure?" is noise.
+                    // already confirmed via the named button above, a second
+                    // "are you sure?" is noise.
+                    vm.DiscardPendingSilent();
+                    break;
+                case CloseWithStashResult.Cancel:
+                    e.Cancel = true;
+                    return;
+            }
+        }
+        else if (active > 0)
+        {
+            // Active edits only, no stash — keep the existing two-button prompt.
+            var result = MessageBox.Show(
+                Res.Format("Dialog_UnsavedChanges_Prompt", active),
+                Res.Get("Dialog_UnsavedChanges_Title"),
+                MessageBoxButton.YesNoCancel,
+                MessageBoxImage.Warning);
+
+            switch (result)
+            {
+                case MessageBoxResult.Yes:
+                    vm.ApplyCommand.Execute(null);
+                    if (vm.PendingInlineEditCount > 0)
+                    {
+                        e.Cancel = true;
+                        return;
+                    }
+                    break;
+                case MessageBoxResult.No:
                     vm.DiscardPendingSilent();
                     break;
                 case MessageBoxResult.Cancel:

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -71,9 +71,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private readonly SimaticMLWriter _writer = new();
     private readonly MemberSearchService _searchService = new();
     private readonly IMessageBoxService _messageBox;
-    // Exposed internally so the dialog code-behind can forward the 3-way
-    // close-confirm without duplicating the WpfMessageBoxService instantiation.
-    internal IMessageBoxService MessageBoxService => _messageBox;
     private readonly Action? _onRefreshTagTables;
     private readonly string? _tagTableDir;
     private readonly Action? _onRefreshUdtTypes;
@@ -1779,6 +1776,22 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             ApplyStashCancelResult.StashAndSwitch => PendingDecision.Stash,
             _ => PendingDecision.Cancel,
         };
+    }
+
+    /// <summary>
+    /// Close-confirm prompt fired when both the active DB and stashed DBs
+    /// hold pending edits. Wrapped here so the dialog code-behind doesn't
+    /// need to reach into the VM's message-box service.
+    /// </summary>
+    internal CloseWithStashResult PromptForCloseWithStash()
+    {
+        var active = PendingInlineEditCount;
+        var stashedCount = StashedDbs.Sum(s => s.Count);
+        var stashedDbList = string.Join(", ", StashedDbs.Select(s => s.DbName));
+        return _messageBox.AskCloseWithStash(
+            Res.Format("Dialog_UnsavedChanges_Prompt_WithStash",
+                active, stashedCount, stashedDbList),
+            Res.Get("Dialog_UnsavedChanges_Title"));
     }
 
     /// <summary>

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -71,6 +71,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private readonly SimaticMLWriter _writer = new();
     private readonly MemberSearchService _searchService = new();
     private readonly IMessageBoxService _messageBox;
+    // Exposed internally so the dialog code-behind can forward the 3-way
+    // close-confirm without duplicating the WpfMessageBoxService instantiation.
+    internal IMessageBoxService MessageBoxService => _messageBox;
     private readonly Action? _onRefreshTagTables;
     private readonly string? _tagTableDir;
     private readonly Action? _onRefreshUdtTypes;
@@ -1508,20 +1511,20 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // current has only one DB == target).
         if (current.Dbs.Count >= 2)
         {
-            var decision = _messageBox.AskYesNoCancel(
+            var decision = _messageBox.AskAddOrReplace(
                 Res.Format("Reactivate_AdditiveOrReplace_Text", summary.Name),
                 Res.Get("Reactivate_AdditiveOrReplace_Title"));
-            if (decision == YesNoCancelResult.Cancel)
+            if (decision == AddOrReplaceResult.Cancel)
             {
                 Log.Information("Reactivate cancelled by user for {Name}", summary.Name);
                 return;
             }
-            if (decision == YesNoCancelResult.Yes)
+            if (decision == AddOrReplaceResult.Add)
             {
                 ReactivateStashedDbAdditive(stash);
                 return;
             }
-            // No falls through to the Replace path below.
+            // Replace falls through to the Replace path below.
         }
 
         if (target == null)
@@ -1738,9 +1741,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// <summary>
     /// User's choice in response to the "this DB has pending edits" prompt
     /// raised when removing a DB from the active set (#78). Centralised so
-    /// every remove path maps the underlying <see cref="YesNoCancelResult"/>
-    /// the same way: Yes→Apply, No→Stash, Cancel→Cancel. <c>NoEdits</c> is
-    /// the no-prompt fast path.
+    /// every remove path maps the <see cref="ApplyStashCancelResult"/>
+    /// the same way: ApplyAndSwitch→Apply, StashAndSwitch→Stash, Cancel→Cancel.
+    /// <c>NoEdits</c> is the no-prompt fast path.
     /// </summary>
     private enum PendingDecision { NoEdits, Apply, Stash, Cancel }
 
@@ -1764,7 +1767,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         Log.Information(
             "[prompt] Showing 3-way for {Name} (pending={Pending}) | {State}",
             db.Info.Name, pendingCount, SnapshotState());
-        var result = _messageBox.AskYesNoCancel(
+        var result = _messageBox.AskApplyStashCancel(
             Res.Format("Dialog_SwitchDb_KeepConfirm_Text",
                 pendingCount, db.Info.Name),
             Res.Get("Dialog_SwitchDb_KeepConfirm_Title"));
@@ -1772,8 +1775,8 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             "[prompt] User picked {Result} for {Name}", result, db.Info.Name);
         return result switch
         {
-            YesNoCancelResult.Yes => PendingDecision.Apply,
-            YesNoCancelResult.No => PendingDecision.Stash,
+            ApplyStashCancelResult.ApplyAndSwitch => PendingDecision.Apply,
+            ApplyStashCancelResult.StashAndSwitch => PendingDecision.Stash,
             _ => PendingDecision.Cancel,
         };
     }

--- a/src/BlockParam/UI/IMessageBoxService.cs
+++ b/src/BlockParam/UI/IMessageBoxService.cs
@@ -11,24 +11,30 @@ public interface IMessageBoxService
     void ShowInfo(string message, string title);
 
     /// <summary>
-    /// 3-way prompt used when an action would lose pending work and the user
-    /// has three meaningful choices: commit (Yes), keep-but-don't-commit (No),
-    /// or back out entirely (Cancel). Used by the DB-switcher (#59) to ask
-    /// "apply staged edits to TIA before switching?" without forcing a destructive
-    /// 2-way collapse of "Apply" and "Keep stashed".
+    /// 3-way prompt: Apply &amp; switch / Stash &amp; switch / Cancel.
+    /// Used by the DB-switcher when the current DB has staged edits (#59).
     /// </summary>
-    YesNoCancelResult AskYesNoCancel(string message, string title);
+    ApplyStashCancelResult AskApplyStashCancel(string message, string title);
+
+    /// <summary>
+    /// 3-way prompt: Add alongside / Replace / Cancel.
+    /// Used when reactivating a stashed DB while ≥2 other DBs are active (#92).
+    /// </summary>
+    AddOrReplaceResult AskAddOrReplace(string message, string title);
+
+    /// <summary>
+    /// 3-way prompt: Apply active (discard stash) / Discard all / Cancel.
+    /// Used by the close-confirm when both active-DB and stashed-DB edits exist.
+    /// </summary>
+    CloseWithStashResult AskCloseWithStash(string message, string title);
 }
 
-public enum YesNoCancelResult
-{
-    Yes,
-    No,
-    Cancel,
-}
+public enum ApplyStashCancelResult { ApplyAndSwitch, StashAndSwitch, Cancel }
+public enum AddOrReplaceResult { Add, Replace, Cancel }
+public enum CloseWithStashResult { ApplyActive, DiscardAll, Cancel }
 
 /// <summary>
-/// Default implementation using WPF MessageBox.
+/// Default implementation using custom WPF dialogs with named buttons.
 /// </summary>
 public class WpfMessageBoxService : IMessageBoxService
 {
@@ -57,17 +63,51 @@ public class WpfMessageBoxService : IMessageBoxService
             System.Windows.MessageBoxImage.Information);
     }
 
-    public YesNoCancelResult AskYesNoCancel(string message, string title)
+    public ApplyStashCancelResult AskApplyStashCancel(string message, string title)
     {
-        var result = System.Windows.MessageBox.Show(
+        var dlg = new ThreeButtonDialog(
             message, title,
-            System.Windows.MessageBoxButton.YesNoCancel,
-            System.Windows.MessageBoxImage.Warning);
-        return result switch
+            Localization.Res.Get("Dialog_SwitchDb_KeepConfirm_ApplyButton"),
+            Localization.Res.Get("Dialog_SwitchDb_KeepConfirm_StashButton"),
+            Localization.Res.Get("Dialog_Cancel"));
+        dlg.ShowDialog();
+        return dlg.Choice switch
         {
-            System.Windows.MessageBoxResult.Yes => YesNoCancelResult.Yes,
-            System.Windows.MessageBoxResult.No => YesNoCancelResult.No,
-            _ => YesNoCancelResult.Cancel,
+            ThreeButtonDialog.ButtonChoice.Primary   => ApplyStashCancelResult.ApplyAndSwitch,
+            ThreeButtonDialog.ButtonChoice.Secondary => ApplyStashCancelResult.StashAndSwitch,
+            _                                        => ApplyStashCancelResult.Cancel,
+        };
+    }
+
+    public AddOrReplaceResult AskAddOrReplace(string message, string title)
+    {
+        var dlg = new ThreeButtonDialog(
+            message, title,
+            Localization.Res.Get("Reactivate_AdditiveOrReplace_AddButton"),
+            Localization.Res.Get("Reactivate_AdditiveOrReplace_ReplaceButton"),
+            Localization.Res.Get("Dialog_Cancel"));
+        dlg.ShowDialog();
+        return dlg.Choice switch
+        {
+            ThreeButtonDialog.ButtonChoice.Primary   => AddOrReplaceResult.Add,
+            ThreeButtonDialog.ButtonChoice.Secondary => AddOrReplaceResult.Replace,
+            _                                        => AddOrReplaceResult.Cancel,
+        };
+    }
+
+    public CloseWithStashResult AskCloseWithStash(string message, string title)
+    {
+        var dlg = new ThreeButtonDialog(
+            message, title,
+            Localization.Res.Get("Dialog_UnsavedChanges_ApplyActiveButton"),
+            Localization.Res.Get("Dialog_UnsavedChanges_DiscardAllButton"),
+            Localization.Res.Get("Dialog_Cancel"));
+        dlg.ShowDialog();
+        return dlg.Choice switch
+        {
+            ThreeButtonDialog.ButtonChoice.Primary   => CloseWithStashResult.ApplyActive,
+            ThreeButtonDialog.ButtonChoice.Secondary => CloseWithStashResult.DiscardAll,
+            _                                        => CloseWithStashResult.Cancel,
         };
     }
 }

--- a/src/BlockParam/UI/ThreeButtonDialog.xaml
+++ b/src/BlockParam/UI/ThreeButtonDialog.xaml
@@ -1,0 +1,35 @@
+<Window x:Class="BlockParam.UI.ThreeButtonDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Width="420" SizeToContent="Height"
+        ResizeMode="NoResize"
+        WindowStartupLocation="CenterOwner"
+        FontFamily="Segoe UI" FontSize="12">
+
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Body text -->
+        <TextBlock Grid.Row="0" x:Name="MessageText"
+                   TextWrapping="Wrap" Margin="0,0,0,16"
+                   VerticalAlignment="Top"/>
+
+        <!-- Right-aligned button row -->
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button x:Name="PrimaryButton"
+                    Height="28" MinWidth="90" Padding="12,4" Margin="0,0,8,0"
+                    IsDefault="True"
+                    Click="OnPrimaryClick"/>
+            <Button x:Name="SecondaryButton"
+                    Height="28" MinWidth="90" Padding="12,4" Margin="0,0,8,0"
+                    Click="OnSecondaryClick"/>
+            <Button x:Name="CancelButton"
+                    Height="28" MinWidth="70" Padding="12,4"
+                    IsCancel="True"
+                    Click="OnCancelClick"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/BlockParam/UI/ThreeButtonDialog.xaml
+++ b/src/BlockParam/UI/ThreeButtonDialog.xaml
@@ -1,7 +1,8 @@
 <Window x:Class="BlockParam.UI.ThreeButtonDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Width="420" SizeToContent="Height"
+        SizeToContent="WidthAndHeight"
+        MinWidth="420" MaxWidth="640"
         ResizeMode="NoResize"
         WindowStartupLocation="CenterOwner"
         FontFamily="Segoe UI" FontSize="12">
@@ -11,14 +12,27 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <!-- Warning glyph (matches the yellow triangle of MessageBoxImage.Warning) -->
+        <TextBlock Grid.Row="0" Grid.Column="0"
+                   Text="&#x26A0;"
+                   FontFamily="Segoe UI Symbol" FontSize="32"
+                   Foreground="#E0A800"
+                   VerticalAlignment="Top"
+                   Margin="0,0,12,16"/>
 
         <!-- Body text -->
-        <TextBlock Grid.Row="0" x:Name="MessageText"
+        <TextBlock Grid.Row="0" Grid.Column="1" x:Name="MessageText"
                    TextWrapping="Wrap" Margin="0,0,0,16"
                    VerticalAlignment="Top"/>
 
         <!-- Right-aligned button row -->
-        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">
+        <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                    Orientation="Horizontal" HorizontalAlignment="Right">
             <Button x:Name="PrimaryButton"
                     Height="28" MinWidth="90" Padding="12,4" Margin="0,0,8,0"
                     IsDefault="True"

--- a/src/BlockParam/UI/ThreeButtonDialog.xaml.cs
+++ b/src/BlockParam/UI/ThreeButtonDialog.xaml.cs
@@ -39,18 +39,18 @@ public partial class ThreeButtonDialog : Window
     private void OnPrimaryClick(object sender, RoutedEventArgs e)
     {
         Choice = ButtonChoice.Primary;
-        DialogResult = true;
+        Close();
     }
 
     private void OnSecondaryClick(object sender, RoutedEventArgs e)
     {
         Choice = ButtonChoice.Secondary;
-        DialogResult = false;
+        Close();
     }
 
     private void OnCancelClick(object sender, RoutedEventArgs e)
     {
         Choice = ButtonChoice.Cancel;
-        DialogResult = null;
+        Close();
     }
 }

--- a/src/BlockParam/UI/ThreeButtonDialog.xaml.cs
+++ b/src/BlockParam/UI/ThreeButtonDialog.xaml.cs
@@ -1,0 +1,56 @@
+using System.Linq;
+using System.Windows;
+
+namespace BlockParam.UI;
+
+/// <summary>
+/// A small modal dialog with three named buttons (primary / secondary / cancel).
+/// Used by <see cref="WpfMessageBoxService"/> wherever the conventional Yes/No/Cancel
+/// labels would be misleading because each choice maps to a distinct, non-obvious action.
+/// </summary>
+public partial class ThreeButtonDialog : Window
+{
+    public enum ButtonChoice { Primary, Secondary, Cancel }
+
+    public ButtonChoice Choice { get; private set; } = ButtonChoice.Cancel;
+
+    public ThreeButtonDialog(
+        string message,
+        string title,
+        string primaryLabel,
+        string secondaryLabel,
+        string cancelLabel)
+    {
+        InitializeComponent();
+        WindowIconHelper.SetIcon(this);
+        ZoomHost.Attach(this);
+
+        Title = title;
+        MessageText.Text = message;
+        PrimaryButton.Content = primaryLabel;
+        SecondaryButton.Content = secondaryLabel;
+        CancelButton.Content = cancelLabel;
+
+        Owner = Application.Current?.Windows
+            .OfType<Window>()
+            .FirstOrDefault(w => w.IsActive);
+    }
+
+    private void OnPrimaryClick(object sender, RoutedEventArgs e)
+    {
+        Choice = ButtonChoice.Primary;
+        DialogResult = true;
+    }
+
+    private void OnSecondaryClick(object sender, RoutedEventArgs e)
+    {
+        Choice = ButtonChoice.Secondary;
+        DialogResult = false;
+    }
+
+    private void OnCancelClick(object sender, RoutedEventArgs e)
+    {
+        Choice = ButtonChoice.Cancel;
+        DialogResult = null;
+    }
+}


### PR DESCRIPTION
## Summary

Three `MessageBox.Show(YesNoCancel)` prompts mapped each button to a distinct, non-obvious action — the `Yes`/`No` labels carried no semantic hint and the body legend (`Yes — Apply…` / `No — Stash…`) had to do all the work. Users had to read the body every time. This PR replaces them with custom `ThreeButtonDialog` instances that have explicit named buttons.

### What changed

| Prompt | Before | After |
|---|---|---|
| DB-switcher pending-edits prompt | Yes / No / Cancel | **Apply & switch** / **Stash & switch** / **Cancel** |
| Reactivate stashed DB (additive vs replace) | Yes / No / Cancel | **Add alongside** / **Replace** / **Cancel** |
| Close-confirm with stash (active pending + stash) | Yes / No / Cancel | **Apply active (discard stash)** / **Discard all** / **Cancel** |

The active-only close prompt (`Dialog_UnsavedChanges_Prompt`) was deliberately **not** touched — that one maps cleanly to the conventional Save/Don't Save/Cancel pattern Windows users read on muscle memory.

### How it's wired

- `IMessageBoxService` gains three typed methods (`AskApplyStashCancel` / `AskAddOrReplace` / `AskCloseWithStash`) returning typed result enums.
- `AskYesNoCancel` removed from the interface — was only used by these three call sites.
- New `ThreeButtonDialog` (XAML + code-behind) is a single parameterised dialog reused by all three prompts.
- Resource strings (en + de) have the now-redundant `Yes — … / No — … / Cancel — …` legend lines trimmed and gain explicit button-label keys.
- Test fakes (`RecordingFakeMessageBox` in 3 test files) updated to the new interface; assertions unchanged.

## Test plan

- [ ] `dotnet build` Release succeeds
- [ ] `dotnet test` — all existing invariant + DB-switcher + multi-DB tests pass
- [ ] Manually exercise each prompt in DevLauncher:
  - [ ] Stage edits on DB A, switch to DB B → DB-switcher dialog shows three named buttons; each path behaves as before
  - [ ] Stash a DB, then while ≥2 DBs are active, click the stash header → Add/Replace dialog shows; each path behaves as before
  - [ ] Stage edits on DB A, stash DB B with pending edits, close the dialog → close-with-stash dialog shows; each path behaves as before

## Follow-up

The subagent flagged that the active>0 && stash==0 branch of `OnClosing` still uses raw `MessageBox.Show(YesNoCancel)`. After cross-checking against the original audit, that branch is the canonical Save/Don't Save/Cancel pattern — no fix needed.

https://claude.ai/code/session_01NNCu9j9yLhEwoYXz92PG6J

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNCu9j9yLhEwoYXz92PG6J)_