### PR TITLE
refactor(storage): centralise file I/O behind IBlockParamStorage

### DIFF
--- a/src/BlockParam.Tests/Storage/CacheCleanupScheduleStorageTests.cs
+++ b/src/BlockParam.Tests/Storage/CacheCleanupScheduleStorageTests.cs
@@ -1,0 +1,48 @@
+using System;
+using BlockParam.Services;
+using BlockParam.Services.Storage;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests.Storage;
+
+/// <summary>
+/// Targets the new <see cref="IBlockParamStorage"/>-aware overloads added in
+/// #85. The legacy string-based overload is exercised by
+/// <see cref="CacheCleanupScheduleTests"/>; this suite proves the new path
+/// runs entirely against an in-memory fake — no real disk involvement.
+/// </summary>
+public class CacheCleanupScheduleStorageTests
+{
+    private static StoragePath StateFile =>
+        StoragePath.FromAbsolute(@"C:\appdata") / "BlockParam" / "cache-cleanup.txt";
+
+    [Fact]
+    public void IsDue_against_in_memory_storage_returns_true_when_missing()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        CacheCleanupSchedule.IsDue(fs, StateFile).Should().BeTrue();
+    }
+
+    [Fact]
+    public void SetNextRun_persists_to_in_memory_storage_only()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var now = new DateTime(2026, 4, 1, 12, 0, 0);
+
+        CacheCleanupSchedule.SetNextRun(fs, StateFile, now.AddDays(1));
+
+        fs.FileExists(StateFile).Should().BeTrue();
+        CacheCleanupSchedule.IsDue(fs, StateFile, now.AddHours(12)).Should().BeFalse();
+        CacheCleanupSchedule.IsDue(fs, StateFile, now.AddDays(2)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Corrupt_state_file_is_treated_as_due()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        fs.WriteAllText(StateFile, "not a timestamp");
+
+        CacheCleanupSchedule.IsDue(fs, StateFile).Should().BeTrue();
+    }
+}

--- a/src/BlockParam.Tests/Storage/FileSystemBlockParamStorageTests.cs
+++ b/src/BlockParam.Tests/Storage/FileSystemBlockParamStorageTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.IO;
+using System.Linq;
+using BlockParam.Services.Storage;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests.Storage;
+
+/// <summary>
+/// Happy-path coverage of <see cref="FileSystemBlockParamStorage"/> against
+/// a real temp directory. The in-memory fake gets the bulk of the unit test
+/// budget; this suite exists so a parameter-order or auto-create regression
+/// in the FS adapter can't slip past tests that never hit a disk.
+/// </summary>
+public class FileSystemBlockParamStorageTests : IDisposable
+{
+    private readonly string _rootDir;
+    private readonly StoragePath _root;
+    private readonly FileSystemBlockParamStorage _fs;
+
+    public FileSystemBlockParamStorageTests()
+    {
+        _rootDir = Path.Combine(Path.GetTempPath(), "BlockParamTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_rootDir);
+        _root = StoragePath.FromAbsolute(_rootDir);
+        _fs = new FileSystemBlockParamStorage();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_rootDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void WriteAllText_then_ReadAllText_roundtrips_through_disk()
+    {
+        var path = _root / "sample.json";
+
+        _fs.WriteAllText(path, "{\"k\":1}");
+
+        _fs.FileExists(path).Should().BeTrue();
+        _fs.ReadAllText(path).Should().Be("{\"k\":1}");
+        File.ReadAllText(path.FullPath).Should().Be("{\"k\":1}"); // really on disk
+    }
+
+    [Fact]
+    public void WriteAllText_auto_creates_parent_directory_chain()
+    {
+        var nested = _root / "a" / "b" / "c.txt";
+
+        _fs.WriteAllText(nested, "x");
+
+        Directory.Exists(Path.Combine(_rootDir, "a", "b")).Should().BeTrue();
+        _fs.FileExists(nested).Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnumerateFiles_returns_empty_for_missing_directory()
+    {
+        _fs.EnumerateFiles(_root / "never-created").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EnumerateFiles_recursive_matches_pattern()
+    {
+        _fs.WriteAllText(_root / "a.json", "");
+        _fs.WriteAllText(_root / "sub" / "b.json", "");
+        _fs.WriteAllText(_root / "sub" / "c.txt", "");
+
+        var jsons = _fs.EnumerateFiles(_root, "*.json", recursive: true)
+            .Select(p => p.FileName)
+            .OrderBy(n => n)
+            .ToList();
+
+        jsons.Should().BeEquivalentTo("a.json", "b.json");
+    }
+
+    [Fact]
+    public void GetLastWriteTime_on_missing_file_returns_FILETIME_epoch()
+    {
+        // Documented contract — both FS and in-memory return 1601-01-01 for
+        // missing files rather than throwing.
+        _fs.GetLastWriteTime(_root / "missing").Should().Be(new DateTime(1601, 1, 1));
+    }
+
+    [Fact]
+    public void DeleteDirectory_throws_when_non_empty()
+    {
+        _fs.WriteAllText(_root / "child.txt", "");
+
+        Action act = () => _fs.DeleteDirectory(_root);
+        act.Should().Throw<IOException>();
+        _fs.DirectoryExists(_root).Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasAnyEntries_distinguishes_empty_missing_and_populated()
+    {
+        var emptyDir = _root / "empty";
+        _fs.EnsureDirectory(emptyDir);
+        _fs.HasAnyEntries(emptyDir).Should().BeFalse();
+        _fs.HasAnyEntries(_root / "never-created").Should().BeFalse();
+
+        _fs.WriteAllText(emptyDir / "now-has-a-file.txt", "");
+        _fs.HasAnyEntries(emptyDir).Should().BeTrue();
+    }
+}

--- a/src/BlockParam.Tests/Storage/InMemoryBlockParamStorageTests.cs
+++ b/src/BlockParam.Tests/Storage/InMemoryBlockParamStorageTests.cs
@@ -137,6 +137,51 @@ public class InMemoryBlockParamStorageTests
     }
 
     [Fact]
+    public void HasAnyEntries_false_when_directory_missing()
+    {
+        // TempCacheCleanup relies on this: a never-created dir must be
+        // indistinguishable from an empty one so the bottom-up sweeper
+        // doesn't try to delete something that isn't there.
+        var fs = new InMemoryBlockParamStorage();
+        fs.HasAnyEntries(Root / "never-created").Should().BeFalse();
+    }
+
+    [Fact]
+    public void DeleteDirectory_throws_when_non_empty()
+    {
+        // Mirrors Directory.Delete(path) without recursive=true. The catch
+        // in TempCacheCleanup.DeleteEmptyDirectories swallows this — so the
+        // throw is the load-bearing signal that "this dir isn't safe to
+        // remove yet"; silently succeeding would cascade orphans.
+        var fs = new InMemoryBlockParamStorage();
+        fs.WriteAllText(Root / "child.txt", "");
+
+        Action act = () => fs.DeleteDirectory(Root);
+        act.Should().Throw<IOException>();
+        fs.DirectoryExists(Root).Should().BeTrue();
+    }
+
+    [Fact]
+    public void OpenRead_returns_non_writable_stream()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        fs.WriteAllText(Root / "f.txt", "x");
+
+        using var s = fs.OpenRead(Root / "f.txt");
+        s.CanRead.Should().BeTrue();
+        s.CanWrite.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetLastWriteTime_on_missing_file_returns_FILETIME_epoch()
+    {
+        // Aligns with File.GetLastWriteTime — callers that race against
+        // external deletes don't need a separate existence check.
+        var fs = new InMemoryBlockParamStorage();
+        fs.GetLastWriteTime(Root / "missing").Should().Be(new DateTime(1601, 1, 1));
+    }
+
+    [Fact]
     public void GetLastWriteTime_uses_clock_at_write_unless_overridden()
     {
         var fs = new InMemoryBlockParamStorage();

--- a/src/BlockParam.Tests/Storage/InMemoryBlockParamStorageTests.cs
+++ b/src/BlockParam.Tests/Storage/InMemoryBlockParamStorageTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using BlockParam.Services.Storage;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests.Storage;
+
+public class InMemoryBlockParamStorageTests
+{
+    private static StoragePath Root => StoragePath.FromAbsolute(@"C:\bp-tests");
+
+    [Fact]
+    public void WriteAllText_then_ReadAllText_roundtrips()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var path = Root / "config.json";
+
+        fs.WriteAllText(path, "hello");
+
+        fs.FileExists(path).Should().BeTrue();
+        fs.ReadAllText(path).Should().Be("hello");
+    }
+
+    [Fact]
+    public void WriteAllBytes_returns_a_defensive_copy()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var path = Root / "blob.bin";
+        var bytes = new byte[] { 1, 2, 3 };
+
+        fs.WriteAllBytes(path, bytes);
+        bytes[0] = 99;
+
+        fs.ReadAllBytes(path).Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public void ReadAllText_on_missing_file_throws()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        Action act = () => fs.ReadAllText(Root / "nope.txt");
+        act.Should().Throw<FileNotFoundException>();
+    }
+
+    [Fact]
+    public void Write_auto_creates_parent_directory()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var nested = Root / "a" / "b" / "c.txt";
+
+        fs.WriteAllText(nested, "x");
+
+        fs.DirectoryExists(Root / "a" / "b").Should().BeTrue();
+        fs.DirectoryExists(Root / "a").Should().BeTrue();
+        fs.DirectoryExists(Root).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AppendAllText_concatenates_existing_content()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var path = Root / "log.txt";
+
+        fs.AppendAllText(path, "one\n");
+        fs.AppendAllText(path, "two\n");
+
+        fs.ReadAllText(path).Should().Be("one\ntwo\n");
+    }
+
+    [Fact]
+    public void DeleteFile_removes_entry_silently_if_missing()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var path = Root / "gone.txt";
+
+        Action act = () => fs.DeleteFile(path); // missing
+        act.Should().NotThrow();
+
+        fs.WriteAllText(path, "");
+        fs.DeleteFile(path);
+        fs.FileExists(path).Should().BeFalse();
+    }
+
+    [Fact]
+    public void EnumerateFiles_returns_empty_when_directory_missing()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        fs.EnumerateFiles(Root / "missing").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EnumerateFiles_recursive_walks_subtree()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        fs.WriteAllText(Root / "a.txt", "");
+        fs.WriteAllText(Root / "sub" / "b.txt", "");
+        fs.WriteAllText(Root / "sub" / "deep" / "c.txt", "");
+
+        fs.EnumerateFiles(Root, "*", recursive: false)
+            .Select(p => p.FileName)
+            .Should().BeEquivalentTo("a.txt");
+
+        fs.EnumerateFiles(Root, "*", recursive: true)
+            .Select(p => p.FileName)
+            .Should().BeEquivalentTo("a.txt", "b.txt", "c.txt");
+    }
+
+    [Fact]
+    public void EnumerateFiles_applies_wildcard_pattern()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        fs.WriteAllText(Root / "a.json", "");
+        fs.WriteAllText(Root / "b.txt", "");
+        fs.WriteAllText(Root / "c.json", "");
+
+        fs.EnumerateFiles(Root, "*.json")
+            .Select(p => p.FileName)
+            .Should().BeEquivalentTo("a.json", "c.json");
+    }
+
+    [Fact]
+    public void HasAnyEntries_true_for_files_or_subdirs_and_false_for_empty()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        fs.EnsureDirectory(Root);
+        fs.HasAnyEntries(Root).Should().BeFalse();
+
+        fs.EnsureDirectory(Root / "sub");
+        fs.HasAnyEntries(Root).Should().BeTrue();
+
+        fs.HasAnyEntries(Root / "sub").Should().BeFalse();
+        fs.WriteAllText(Root / "sub" / "x", "");
+        fs.HasAnyEntries(Root / "sub").Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetLastWriteTime_uses_clock_at_write_unless_overridden()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var t = new DateTime(2026, 1, 1, 12, 0, 0);
+        fs.Clock = () => t;
+
+        var p = Root / "f.txt";
+        fs.WriteAllText(p, "");
+        fs.GetLastWriteTime(p).Should().Be(t);
+
+        fs.SetLastWriteTime(p, new DateTime(2020, 1, 1));
+        fs.GetLastWriteTime(p).Should().Be(new DateTime(2020, 1, 1));
+    }
+
+    [Fact]
+    public void OpenRead_returns_readable_stream_of_contents()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        fs.WriteAllText(Root / "x.txt", "hello");
+
+        using var s = fs.OpenRead(Root / "x.txt");
+        using var r = new StreamReader(s, Encoding.UTF8);
+        r.ReadToEnd().Should().Be("hello");
+    }
+}

--- a/src/BlockParam.Tests/Storage/StoragePathTests.cs
+++ b/src/BlockParam.Tests/Storage/StoragePathTests.cs
@@ -1,0 +1,56 @@
+using System.IO;
+using BlockParam.Services.Storage;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests.Storage;
+
+public class StoragePathTests
+{
+    [Fact]
+    public void Slash_operator_composes_path_segments()
+    {
+        var p = StoragePath.FromAbsolute(@"C:\root") / "sub" / "leaf.json";
+
+        p.FullPath.Should().Be(Path.Combine(@"C:\root", "sub", "leaf.json"));
+    }
+
+    [Fact]
+    public void FileName_returns_terminal_segment()
+    {
+        var p = StoragePath.FromAbsolute(@"C:\root") / "config.json";
+        p.FileName.Should().Be("config.json");
+    }
+
+    [Fact]
+    public void Parent_returns_enclosing_directory()
+    {
+        var p = StoragePath.FromAbsolute(@"C:\root") / "sub" / "leaf.json";
+        p.Parent.FullPath.Should().Be(Path.Combine(@"C:\root", "sub"));
+    }
+
+    [Fact]
+    public void Equality_is_case_insensitive()
+    {
+        var a = StoragePath.FromAbsolute(@"C:\Foo\Bar.txt");
+        var b = StoragePath.FromAbsolute(@"c:\foo\bar.txt");
+
+        (a == b).Should().BeTrue();
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Default_struct_is_empty()
+    {
+        default(StoragePath).IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AppData_root_points_at_AppDirectories_constant()
+    {
+        StoragePath.AppData.FullPath.Should().Be(BlockParam.Services.AppDirectories.AppData);
+        StoragePath.Temp.FullPath.Should().Be(BlockParam.Services.AppDirectories.Temp);
+        StoragePath.Logs.FullPath.Should().Be(BlockParam.Services.AppDirectories.LogsDir);
+        StoragePath.ProgramData.FullPath.Should().Be(BlockParam.Services.AppDirectories.ProgramData);
+    }
+}

--- a/src/BlockParam.Tests/Storage/TempCacheCleanupStorageTests.cs
+++ b/src/BlockParam.Tests/Storage/TempCacheCleanupStorageTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Linq;
+using BlockParam.Services;
+using BlockParam.Services.Storage;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests.Storage;
+
+/// <summary>
+/// Mirrors a subset of <see cref="TempCacheCleanupTests"/> through the new
+/// in-memory storage seam. Real-disk coverage stays in that suite; this one
+/// proves the storage-injecting overload is wired correctly and that stale-vs-fresh
+/// classification works without touching the file system.
+/// </summary>
+public class TempCacheCleanupStorageTests
+{
+    private static readonly TimeSpan MaxAge = TimeSpan.FromDays(14);
+    private static StoragePath Root => StoragePath.FromAbsolute(@"C:\temp\BlockParam");
+
+    [Fact]
+    public void Missing_root_returns_zero_counts_and_now_plus_maxAge()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var now = new DateTime(2026, 4, 1, 12, 0, 0);
+
+        var (files, dirs, next) = TempCacheCleanup.Run(fs, Root, MaxAge, now);
+
+        files.Should().Be(0);
+        dirs.Should().Be(0);
+        next.Should().Be(now + MaxAge);
+    }
+
+    [Fact]
+    public void Stale_files_are_deleted_and_fresh_files_kept()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var now = new DateTime(2026, 4, 15, 12, 0, 0);
+
+        var stale = Root / "old.xml";
+        var fresh = Root / "new.xml";
+        fs.WriteAllText(stale, "");
+        fs.WriteAllText(fresh, "");
+        fs.SetLastWriteTime(stale, now - TimeSpan.FromDays(30));
+        fs.SetLastWriteTime(fresh, now - TimeSpan.FromDays(2));
+
+        var (files, _, _) = TempCacheCleanup.Run(fs, Root, MaxAge, now);
+
+        files.Should().Be(1);
+        fs.FileExists(stale).Should().BeFalse();
+        fs.FileExists(fresh).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Now_empty_subdirectories_are_removed_bottom_up()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var now = new DateTime(2026, 4, 15, 12, 0, 0);
+
+        var leaf = Root / "scope" / "stale.xml";
+        fs.WriteAllText(leaf, "");
+        fs.SetLastWriteTime(leaf, now - TimeSpan.FromDays(30));
+
+        var (files, dirs, _) = TempCacheCleanup.Run(fs, Root, MaxAge, now);
+
+        files.Should().Be(1);
+        dirs.Should().Be(1);
+        fs.DirectoryExists(Root / "scope").Should().BeFalse();
+        fs.DirectoryExists(Root).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Non_empty_directories_are_left_alone()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var now = new DateTime(2026, 4, 15, 12, 0, 0);
+
+        var kept = Root / "scope" / "fresh.xml";
+        fs.WriteAllText(kept, "");
+        fs.SetLastWriteTime(kept, now - TimeSpan.FromDays(2));
+
+        var (_, dirs, _) = TempCacheCleanup.Run(fs, Root, MaxAge, now);
+
+        dirs.Should().Be(0);
+        fs.DirectoryExists(Root / "scope").Should().BeTrue();
+    }
+
+    [Fact]
+    public void SuggestedNextRun_is_clamped_to_at_least_one_day_ahead()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var now = new DateTime(2026, 4, 15, 12, 0, 0);
+
+        // A file that is freshly aged-out: oldest+maxAge would be today.
+        // Clamp must push it at least 1 day forward.
+        var p = Root / "borderline.xml";
+        fs.WriteAllText(p, "");
+        fs.SetLastWriteTime(p, now - MaxAge - TimeSpan.FromSeconds(1));
+
+        var (_, _, next) = TempCacheCleanup.Run(fs, Root, MaxAge, now);
+
+        next.Should().BeOnOrAfter(now + TimeSpan.FromDays(1));
+    }
+}

--- a/src/BlockParam.Tests/Storage/UiZoomServiceStorageTests.cs
+++ b/src/BlockParam.Tests/Storage/UiZoomServiceStorageTests.cs
@@ -1,0 +1,78 @@
+using BlockParam.Services;
+using BlockParam.Services.Storage;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests.Storage;
+
+/// <summary>
+/// Exercises <see cref="UiZoomService"/>'s new storage-injecting constructor.
+/// Disk-based behavior stays in <see cref="UiZoomServiceTests"/>; this suite
+/// uses an in-memory fake so persistence assertions are deterministic.
+/// </summary>
+public class UiZoomServiceStorageTests
+{
+    private static StoragePath SettingsPath =>
+        StoragePath.FromAbsolute(@"C:\appdata") / "BlockParam" / "ui-settings.json";
+
+    [Fact]
+    public void Loads_default_when_settings_file_missing()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var svc = new UiZoomService(fs, SettingsPath);
+
+        svc.ZoomFactor.Should().Be(UiZoomService.DefaultZoom);
+    }
+
+    [Fact]
+    public void Persists_via_injected_storage_only()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var svc = new UiZoomService(fs, SettingsPath);
+
+        svc.SetZoom(1.5);
+        svc.FlushPendingSave();
+
+        fs.FileExists(SettingsPath).Should().BeTrue();
+        fs.ReadAllText(SettingsPath).Should().Contain("1.5");
+    }
+
+    [Fact]
+    public void Reads_previously_written_value_on_second_instance()
+    {
+        var fs = new InMemoryBlockParamStorage();
+
+        var writer = new UiZoomService(fs, SettingsPath);
+        writer.SetZoom(1.5);
+        writer.FlushPendingSave();
+
+        var reader = new UiZoomService(fs, SettingsPath);
+        reader.ZoomFactor.Should().Be(1.5);
+    }
+
+    [Fact]
+    public void Corrupt_settings_falls_back_to_default()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        fs.WriteAllText(SettingsPath, "{not valid json");
+
+        var svc = new UiZoomService(fs, SettingsPath);
+
+        svc.ZoomFactor.Should().Be(UiZoomService.DefaultZoom);
+    }
+
+    [Fact]
+    public void Ephemeral_storage_path_disables_persistence()
+    {
+        var fs = new InMemoryBlockParamStorage();
+
+        // default(StoragePath) signals "no persistence" — same contract as
+        // CreateEphemeral() in the legacy string-based constructor.
+        var svc = new UiZoomService(fs, default);
+
+        svc.SetZoom(1.5);
+        svc.FlushPendingSave();
+
+        fs.FileExists(SettingsPath).Should().BeFalse();
+    }
+}

--- a/src/BlockParam/Services/CacheCleanupSchedule.cs
+++ b/src/BlockParam/Services/CacheCleanupSchedule.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Globalization;
-using System.IO;
 using BlockParam.Diagnostics;
+using BlockParam.Services.Storage;
 
 namespace BlockParam.Services;
 
@@ -12,35 +12,39 @@ namespace BlockParam.Services;
 /// </summary>
 public static class CacheCleanupSchedule
 {
-    public static bool IsDue(string stateFile, DateTime? now = null)
+    public static bool IsDue(string stateFile, DateTime? now = null) =>
+        IsDue(FileSystemBlockParamStorage.Instance, StoragePath.FromAbsolute(stateFile), now);
+
+    public static bool IsDue(IBlockParamStorage storage, StoragePath stateFile, DateTime? now = null)
     {
         var reference = now ?? DateTime.Now;
-        var next = ReadNextRun(stateFile);
+        var next = ReadNextRun(storage, stateFile);
         return !next.HasValue || reference >= next.Value;
     }
 
-    public static void SetNextRun(string stateFile, DateTime nextRun)
+    public static void SetNextRun(string stateFile, DateTime nextRun) =>
+        SetNextRun(FileSystemBlockParamStorage.Instance, StoragePath.FromAbsolute(stateFile), nextRun);
+
+    public static void SetNextRun(IBlockParamStorage storage, StoragePath stateFile, DateTime nextRun)
     {
         try
         {
-            var dir = Path.GetDirectoryName(stateFile);
-            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
-            File.WriteAllText(stateFile, nextRun.ToString("o", CultureInfo.InvariantCulture));
+            storage.WriteAllText(stateFile, nextRun.ToString("o", CultureInfo.InvariantCulture));
         }
         catch (Exception ex)
         {
             // Non-fatal: cleanup just retries next time the add-in loads.
             // Logged at Warning so a corrupted state file is diagnosable.
-            Log.Warning(ex, "CacheCleanupSchedule: could not write {File}", stateFile);
+            Log.Warning(ex, "CacheCleanupSchedule: could not write {File}", stateFile.FullPath);
         }
     }
 
-    private static DateTime? ReadNextRun(string stateFile)
+    private static DateTime? ReadNextRun(IBlockParamStorage storage, StoragePath stateFile)
     {
         try
         {
-            if (!File.Exists(stateFile)) return null;
-            var text = File.ReadAllText(stateFile).Trim();
+            if (!storage.FileExists(stateFile)) return null;
+            var text = storage.ReadAllText(stateFile).Trim();
             if (DateTime.TryParse(text, CultureInfo.InvariantCulture,
                     DateTimeStyles.RoundtripKind, out var dt))
                 return dt;
@@ -48,7 +52,7 @@ public static class CacheCleanupSchedule
         }
         catch (Exception ex)
         {
-            Log.Warning(ex, "CacheCleanupSchedule: could not read {File}", stateFile);
+            Log.Warning(ex, "CacheCleanupSchedule: could not read {File}", stateFile.FullPath);
             return null;
         }
     }

--- a/src/BlockParam/Services/Storage/FileSystemBlockParamStorage.cs
+++ b/src/BlockParam/Services/Storage/FileSystemBlockParamStorage.cs
@@ -54,8 +54,8 @@ public sealed class FileSystemBlockParamStorage : IBlockParamStorage
 
     public void DeleteFile(StoragePath path)
     {
-        if (File.Exists(path.FullPath))
-            File.Delete(path.FullPath);
+        // File.Delete already no-ops on missing files — no Exists check needed.
+        File.Delete(path.FullPath);
     }
 
     public void DeleteDirectory(StoragePath path)

--- a/src/BlockParam/Services/Storage/FileSystemBlockParamStorage.cs
+++ b/src/BlockParam/Services/Storage/FileSystemBlockParamStorage.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace BlockParam.Services.Storage;
+
+/// <summary>
+/// Default production implementation of <see cref="IBlockParamStorage"/> that
+/// delegates to <see cref="File"/> and <see cref="Directory"/>. Adds two
+/// things on top of the BCL calls: auto-creating parent directories for
+/// writes, and treating missing directories as empty in the enumeration APIs.
+///
+/// Exception policy is BCL-default: I/O failures bubble up so callers can
+/// decide whether to log-and-swallow (UI persistence, schedule files) or
+/// surface to the user (license, config). The old per-caller try/catch
+/// blocks lived at the call site for that reason — see e.g.
+/// <c>UiZoomService.Save</c> — and stay there after migration.
+/// </summary>
+public sealed class FileSystemBlockParamStorage : IBlockParamStorage
+{
+    public static readonly FileSystemBlockParamStorage Instance = new();
+
+    public bool FileExists(StoragePath path) => File.Exists(path.FullPath);
+    public bool DirectoryExists(StoragePath path) => Directory.Exists(path.FullPath);
+
+    public string ReadAllText(StoragePath path) => File.ReadAllText(path.FullPath);
+    public byte[] ReadAllBytes(StoragePath path) => File.ReadAllBytes(path.FullPath);
+    public Stream OpenRead(StoragePath path) => File.OpenRead(path.FullPath);
+
+    public void WriteAllText(StoragePath path, string contents)
+    {
+        EnsureParent(path);
+        File.WriteAllText(path.FullPath, contents);
+    }
+
+    public void WriteAllBytes(StoragePath path, byte[] contents)
+    {
+        EnsureParent(path);
+        File.WriteAllBytes(path.FullPath, contents);
+    }
+
+    public void AppendAllText(StoragePath path, string contents)
+    {
+        EnsureParent(path);
+        File.AppendAllText(path.FullPath, contents);
+    }
+
+    public void EnsureDirectory(StoragePath path)
+    {
+        if (!string.IsNullOrEmpty(path.FullPath))
+            Directory.CreateDirectory(path.FullPath);
+    }
+
+    public void DeleteFile(StoragePath path)
+    {
+        if (File.Exists(path.FullPath))
+            File.Delete(path.FullPath);
+    }
+
+    public void DeleteDirectory(StoragePath path)
+    {
+        if (Directory.Exists(path.FullPath))
+            Directory.Delete(path.FullPath);
+    }
+
+    public DateTime GetLastWriteTime(StoragePath path) => File.GetLastWriteTime(path.FullPath);
+
+    public IEnumerable<StoragePath> EnumerateFiles(
+        StoragePath directory, string pattern = "*", bool recursive = false)
+    {
+        if (!Directory.Exists(directory.FullPath))
+            return Array.Empty<StoragePath>();
+
+        var option = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
+        return Directory.EnumerateFiles(directory.FullPath, pattern, option)
+            .Select(p => new StoragePath(p));
+    }
+
+    public IEnumerable<StoragePath> EnumerateDirectories(
+        StoragePath directory, string pattern = "*", bool recursive = false)
+    {
+        if (!Directory.Exists(directory.FullPath))
+            return Array.Empty<StoragePath>();
+
+        var option = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
+        return Directory.EnumerateDirectories(directory.FullPath, pattern, option)
+            .Select(p => new StoragePath(p));
+    }
+
+    public bool HasAnyEntries(StoragePath directory)
+    {
+        if (!Directory.Exists(directory.FullPath)) return false;
+        // GetFileSystemEntries materialises everything; EnumerateFileSystemEntries
+        // returns lazily so we can early-exit on the first hit.
+        using var e = Directory.EnumerateFileSystemEntries(directory.FullPath).GetEnumerator();
+        return e.MoveNext();
+    }
+
+    private static void EnsureParent(StoragePath path)
+    {
+        var parent = Path.GetDirectoryName(path.FullPath);
+        if (!string.IsNullOrEmpty(parent))
+            Directory.CreateDirectory(parent);
+    }
+}

--- a/src/BlockParam/Services/Storage/IBlockParamStorage.cs
+++ b/src/BlockParam/Services/Storage/IBlockParamStorage.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace BlockParam.Services.Storage;
+
+/// <summary>
+/// File-system abstraction for all of BlockParam's persistent state — config,
+/// licensing, cache, logs, UI settings. Centralises the
+/// "create-dir-if-missing + swallow IOException" boilerplate that was
+/// duplicated across 10+ files (#85) and gives tests a seam to substitute
+/// an in-memory implementation without touching the real disk.
+///
+/// Operations are intentionally narrow:
+/// - <b>Reads</b> on a missing file throw <see cref="FileNotFoundException"/>;
+///   callers that want a "exists or default" pattern should call
+///   <see cref="FileExists"/> first.
+/// - <b>Writes</b> auto-create the parent directory (since 100% of the
+///   migrated call sites paired <c>Directory.CreateDirectory</c> with
+///   <c>File.WriteAllText</c> anyway).
+/// - <b>Best-effort cleanup</b> calls (<see cref="DeleteFile"/>,
+///   <see cref="DeleteDirectory"/>) swallow not-found but propagate
+///   permission/lock errors so the caller can log them.
+/// </summary>
+public interface IBlockParamStorage
+{
+    bool FileExists(StoragePath path);
+    bool DirectoryExists(StoragePath path);
+
+    string ReadAllText(StoragePath path);
+    byte[] ReadAllBytes(StoragePath path);
+    Stream OpenRead(StoragePath path);
+
+    void WriteAllText(StoragePath path, string contents);
+    void WriteAllBytes(StoragePath path, byte[] contents);
+    void AppendAllText(StoragePath path, string contents);
+
+    void EnsureDirectory(StoragePath path);
+
+    void DeleteFile(StoragePath path);
+    void DeleteDirectory(StoragePath path);
+
+    DateTime GetLastWriteTime(StoragePath path);
+
+    /// <summary>
+    /// Enumerates files under <paramref name="directory"/> that match
+    /// <paramref name="pattern"/>. Returns an empty sequence if the directory
+    /// does not exist — that's the desired behavior at every migrated caller,
+    /// none of which want to distinguish "missing" from "empty".
+    /// </summary>
+    IEnumerable<StoragePath> EnumerateFiles(
+        StoragePath directory,
+        string pattern = "*",
+        bool recursive = false);
+
+    /// <summary>
+    /// Enumerates subdirectories. Same missing-is-empty contract as
+    /// <see cref="EnumerateFiles"/>.
+    /// </summary>
+    IEnumerable<StoragePath> EnumerateDirectories(
+        StoragePath directory,
+        string pattern = "*",
+        bool recursive = false);
+
+    /// <summary>
+    /// True iff the directory contains at least one file or subdirectory.
+    /// Used by cleanup code that wants to know "is this directory safe to
+    /// remove" without enumerating the entire contents.
+    /// </summary>
+    bool HasAnyEntries(StoragePath directory);
+}

--- a/src/BlockParam/Services/Storage/IBlockParamStorage.cs
+++ b/src/BlockParam/Services/Storage/IBlockParamStorage.cs
@@ -35,11 +35,31 @@ public interface IBlockParamStorage
     void WriteAllBytes(StoragePath path, byte[] contents);
     void AppendAllText(StoragePath path, string contents);
 
+    /// <summary>
+    /// Creates the directory and every missing parent. No-op if it already
+    /// exists. Implementations may cascade past the BlockParam product roots
+    /// (the in-memory fake materialises drive letters too); callers that
+    /// care about "did *I* create this" should track that themselves.
+    /// </summary>
     void EnsureDirectory(StoragePath path);
 
     void DeleteFile(StoragePath path);
+
+    /// <summary>
+    /// Removes <paramref name="path"/> if it exists and is empty. Throws
+    /// <see cref="IOException"/> if the directory still contains files or
+    /// subdirectories — both implementations honour that contract so
+    /// best-effort bottom-up sweepers (see <c>TempCacheCleanup</c>) can rely
+    /// on the failure to skip non-empty dirs.
+    /// </summary>
     void DeleteDirectory(StoragePath path);
 
+    /// <summary>
+    /// Returns the last write time, or the FILETIME epoch
+    /// (<c>1601-01-01</c>) if the file does not exist. Mirrors
+    /// <see cref="File.GetLastWriteTime"/> so callers don't need a separate
+    /// existence check before stat'ing.
+    /// </summary>
     DateTime GetLastWriteTime(StoragePath path);
 
     /// <summary>

--- a/src/BlockParam/Services/Storage/InMemoryBlockParamStorage.cs
+++ b/src/BlockParam/Services/Storage/InMemoryBlockParamStorage.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace BlockParam.Services.Storage;
+
+/// <summary>
+/// In-memory fake of <see cref="IBlockParamStorage"/> for unit tests. Stores
+/// files as <c>byte[]</c> keyed by their absolute path, with an explicit set
+/// of "known" directories so <see cref="DirectoryExists"/> can return false
+/// for paths that have never been created.
+///
+/// Path comparison is case-insensitive to match Windows (the production
+/// target). The fake does not enforce parent-directory existence on writes —
+/// it mirrors <see cref="FileSystemBlockParamStorage"/>, which auto-creates.
+/// </summary>
+public sealed class InMemoryBlockParamStorage : IBlockParamStorage
+{
+    private readonly Dictionary<string, byte[]> _files =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, DateTime> _lastWriteTimes =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _directories =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public Func<DateTime> Clock { get; set; } = () => DateTime.Now;
+
+    public bool FileExists(StoragePath path) => _files.ContainsKey(path.FullPath);
+
+    public bool DirectoryExists(StoragePath path) =>
+        _directories.Contains(NormaliseDir(path.FullPath));
+
+    public string ReadAllText(StoragePath path) =>
+        Encoding.UTF8.GetString(ReadAllBytes(path));
+
+    public byte[] ReadAllBytes(StoragePath path)
+    {
+        if (!_files.TryGetValue(path.FullPath, out var bytes))
+            throw new FileNotFoundException($"In-memory file not found: {path.FullPath}", path.FullPath);
+        return (byte[])bytes.Clone();
+    }
+
+    public Stream OpenRead(StoragePath path) => new MemoryStream(ReadAllBytes(path), writable: false);
+
+    public void WriteAllText(StoragePath path, string contents) =>
+        WriteAllBytes(path, Encoding.UTF8.GetBytes(contents));
+
+    public void WriteAllBytes(StoragePath path, byte[] contents)
+    {
+        if (contents is null) throw new ArgumentNullException(nameof(contents));
+        EnsureParent(path);
+        _files[path.FullPath] = (byte[])contents.Clone();
+        _lastWriteTimes[path.FullPath] = Clock();
+    }
+
+    public void AppendAllText(StoragePath path, string contents)
+    {
+        var addition = Encoding.UTF8.GetBytes(contents);
+        if (_files.TryGetValue(path.FullPath, out var existing))
+        {
+            var combined = new byte[existing.Length + addition.Length];
+            Buffer.BlockCopy(existing, 0, combined, 0, existing.Length);
+            Buffer.BlockCopy(addition, 0, combined, existing.Length, addition.Length);
+            WriteAllBytes(path, combined);
+        }
+        else
+        {
+            WriteAllBytes(path, addition);
+        }
+    }
+
+    public void EnsureDirectory(StoragePath path)
+    {
+        if (string.IsNullOrEmpty(path.FullPath)) return;
+        var current = NormaliseDir(path.FullPath);
+        // Materialise the full chain of parents so DirectoryExists is consistent.
+        while (!string.IsNullOrEmpty(current))
+        {
+            if (!_directories.Add(current)) break;
+            current = NormaliseDir(Path.GetDirectoryName(current) ?? string.Empty);
+        }
+    }
+
+    public void DeleteFile(StoragePath path)
+    {
+        _files.Remove(path.FullPath);
+        _lastWriteTimes.Remove(path.FullPath);
+    }
+
+    public void DeleteDirectory(StoragePath path)
+    {
+        var dir = NormaliseDir(path.FullPath);
+        if (!_directories.Contains(dir)) return;
+        if (_files.Keys.Any(f => IsUnder(f, dir)) ||
+            _directories.Any(d => !string.Equals(d, dir, StringComparison.OrdinalIgnoreCase) && IsUnder(d, dir)))
+        {
+            throw new IOException($"Directory is not empty: {dir}");
+        }
+        _directories.Remove(dir);
+    }
+
+    public DateTime GetLastWriteTime(StoragePath path)
+    {
+        if (_lastWriteTimes.TryGetValue(path.FullPath, out var t)) return t;
+        if (!_files.ContainsKey(path.FullPath))
+            throw new FileNotFoundException($"In-memory file not found: {path.FullPath}", path.FullPath);
+        return default;
+    }
+
+    public IEnumerable<StoragePath> EnumerateFiles(
+        StoragePath directory, string pattern = "*", bool recursive = false)
+    {
+        var dir = NormaliseDir(directory.FullPath);
+        if (!_directories.Contains(dir)) return Array.Empty<StoragePath>();
+
+        var regex = WildcardToRegex(pattern);
+        return _files.Keys
+            .Where(f => IsUnder(f, dir, recursive))
+            .Where(f => regex.IsMatch(Path.GetFileName(f)))
+            .Select(f => new StoragePath(f))
+            .ToList();
+    }
+
+    public IEnumerable<StoragePath> EnumerateDirectories(
+        StoragePath directory, string pattern = "*", bool recursive = false)
+    {
+        var dir = NormaliseDir(directory.FullPath);
+        if (!_directories.Contains(dir)) return Array.Empty<StoragePath>();
+
+        var regex = WildcardToRegex(pattern);
+        return _directories
+            .Where(d => !string.Equals(d, dir, StringComparison.OrdinalIgnoreCase))
+            .Where(d => IsUnder(d, dir, recursive))
+            .Where(d => regex.IsMatch(Path.GetFileName(d)))
+            .Select(d => new StoragePath(d))
+            .ToList();
+    }
+
+    public bool HasAnyEntries(StoragePath directory)
+    {
+        var dir = NormaliseDir(directory.FullPath);
+        if (!_directories.Contains(dir)) return false;
+        return _files.Keys.Any(f => IsUnder(f, dir))
+            || _directories.Any(d => !string.Equals(d, dir, StringComparison.OrdinalIgnoreCase) && IsUnder(d, dir));
+    }
+
+    /// <summary>
+    /// Test-only helper: stamps an explicit last-write time on a file so
+    /// tests can simulate "aged" files without juggling <see cref="Clock"/>.
+    /// </summary>
+    public void SetLastWriteTime(StoragePath path, DateTime when)
+    {
+        if (!_files.ContainsKey(path.FullPath))
+            throw new FileNotFoundException($"In-memory file not found: {path.FullPath}", path.FullPath);
+        _lastWriteTimes[path.FullPath] = when;
+    }
+
+    private void EnsureParent(StoragePath path)
+    {
+        var parent = Path.GetDirectoryName(path.FullPath);
+        if (!string.IsNullOrEmpty(parent)) EnsureDirectory(new StoragePath(parent));
+    }
+
+    private static string NormaliseDir(string p) =>
+        string.IsNullOrEmpty(p) ? string.Empty : p.TrimEnd('\\', '/');
+
+    private static bool IsUnder(string candidate, string dir, bool recursive = true)
+    {
+        if (string.IsNullOrEmpty(dir)) return false;
+        var parent = NormaliseDir(Path.GetDirectoryName(candidate) ?? string.Empty);
+        if (recursive)
+            return parent.Equals(dir, StringComparison.OrdinalIgnoreCase)
+                || parent.StartsWith(dir + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
+                || parent.StartsWith(dir + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+        return parent.Equals(dir, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static Regex WildcardToRegex(string pattern)
+    {
+        var escaped = Regex.Escape(pattern)
+            .Replace(@"\*", ".*")
+            .Replace(@"\?", ".");
+        return new Regex("^" + escaped + "$", RegexOptions.IgnoreCase);
+    }
+}

--- a/src/BlockParam/Services/Storage/InMemoryBlockParamStorage.cs
+++ b/src/BlockParam/Services/Storage/InMemoryBlockParamStorage.cs
@@ -104,10 +104,13 @@ public sealed class InMemoryBlockParamStorage : IBlockParamStorage
 
     public DateTime GetLastWriteTime(StoragePath path)
     {
-        if (_lastWriteTimes.TryGetValue(path.FullPath, out var t)) return t;
-        if (!_files.ContainsKey(path.FullPath))
-            throw new FileNotFoundException($"In-memory file not found: {path.FullPath}", path.FullPath);
-        return default;
+        // Mirrors File.GetLastWriteTime which returns 1601-01-01 (the FILETIME
+        // epoch) for missing files rather than throwing — keeps the FS and
+        // in-memory contracts aligned for TempCacheCleanup-style sweepers
+        // that race against external deletes.
+        return _lastWriteTimes.TryGetValue(path.FullPath, out var t)
+            ? t
+            : new DateTime(1601, 1, 1);
     }
 
     public IEnumerable<StoragePath> EnumerateFiles(

--- a/src/BlockParam/Services/Storage/StoragePath.cs
+++ b/src/BlockParam/Services/Storage/StoragePath.cs
@@ -1,0 +1,85 @@
+using System;
+using System.IO;
+
+namespace BlockParam.Services.Storage;
+
+/// <summary>
+/// Strongly-typed file-system path rooted at one of the BlockParam well-known
+/// directories (<see cref="AppData"/>, <see cref="ProgramData"/>,
+/// <see cref="Temp"/>, <see cref="Logs"/>). Used as the parameter type for
+/// <see cref="IBlockParamStorage"/>.
+///
+/// Compose paths with the <c>/</c> operator, mirroring the
+/// <see cref="Path.Combine(string, string)"/> shape (#85):
+/// <code>
+/// StoragePath p = StoragePath.AppData / "config.json";
+/// StoragePath t = StoragePath.Temp / "TagTables" / fileName;
+/// </code>
+///
+/// The struct is just a wrapper around the absolute path string — it neither
+/// touches the disk nor caches anything. Implementations of
+/// <see cref="IBlockParamStorage"/> read <see cref="FullPath"/> and call into
+/// the BCL (or a test fake) directly.
+/// </summary>
+public readonly struct StoragePath : IEquatable<StoragePath>
+{
+    /// <summary>Absolute path. Never null; may be empty (default struct value).</summary>
+    public string FullPath { get; }
+
+    public StoragePath(string fullPath)
+    {
+        FullPath = fullPath ?? throw new ArgumentNullException(nameof(fullPath));
+    }
+
+    /// <summary>Per-user app data root (<c>%APPDATA%\BlockParam</c>).</summary>
+    public static StoragePath AppData => new(AppDirectories.AppData);
+
+    /// <summary>Machine-wide app data root (<c>%PROGRAMDATA%\BlockParam</c>).</summary>
+    public static StoragePath ProgramData => new(AppDirectories.ProgramData);
+
+    /// <summary>Per-machine TEMP root (<c>%TEMP%\BlockParam</c>).</summary>
+    public static StoragePath Temp => new(AppDirectories.Temp);
+
+    /// <summary>Rolling log directory under <see cref="AppData"/>.</summary>
+    public static StoragePath Logs => new(AppDirectories.LogsDir);
+
+    /// <summary>
+    /// Escape hatch for callers that already hold an absolute path — e.g. a
+    /// user-chosen file from a dialog, or a path read from configuration.
+    /// New code under one of the BlockParam roots should compose from the
+    /// static roots instead so the path convention stays in one place (#86).
+    /// </summary>
+    public static StoragePath FromAbsolute(string absolutePath) => new(absolutePath);
+
+    public static StoragePath operator /(StoragePath left, string segment)
+    {
+        if (segment is null) throw new ArgumentNullException(nameof(segment));
+        return new StoragePath(Path.Combine(left.FullPath, segment));
+    }
+
+    public string FileName => Path.GetFileName(FullPath);
+
+    public StoragePath Parent
+    {
+        get
+        {
+            var dir = Path.GetDirectoryName(FullPath);
+            return new StoragePath(dir ?? string.Empty);
+        }
+    }
+
+    public bool IsEmpty => string.IsNullOrEmpty(FullPath);
+
+    public override string ToString() => FullPath;
+
+    public bool Equals(StoragePath other) =>
+        string.Equals(FullPath, other.FullPath, StringComparison.OrdinalIgnoreCase);
+
+    public override bool Equals(object? obj) => obj is StoragePath sp && Equals(sp);
+
+    public override int GetHashCode() =>
+        FullPath is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(FullPath);
+
+    public static bool operator ==(StoragePath a, StoragePath b) => a.Equals(b);
+    public static bool operator !=(StoragePath a, StoragePath b) => !a.Equals(b);
+}

--- a/src/BlockParam/Services/TempCacheCleanup.cs
+++ b/src/BlockParam/Services/TempCacheCleanup.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using BlockParam.Diagnostics;
+using BlockParam.Services.Storage;
 
 namespace BlockParam.Services;
 
@@ -28,18 +28,25 @@ public static class TempCacheCleanup
     public static (int FilesDeleted, int DirsDeleted, DateTime SuggestedNextRun) Run(
         string rootDir,
         TimeSpan? maxAge = null,
+        DateTime? now = null) =>
+        Run(FileSystemBlockParamStorage.Instance, StoragePath.FromAbsolute(rootDir), maxAge, now);
+
+    public static (int FilesDeleted, int DirsDeleted, DateTime SuggestedNextRun) Run(
+        IBlockParamStorage storage,
+        StoragePath rootDir,
+        TimeSpan? maxAge = null,
         DateTime? now = null)
     {
         var reference = now ?? DateTime.Now;
         var maxAgeValue = maxAge ?? DefaultMaxAge;
 
-        if (!Directory.Exists(rootDir))
+        if (!storage.DirectoryExists(rootDir))
             return (0, 0, reference + maxAgeValue);
 
         var threshold = reference - maxAgeValue;
 
-        var (files, oldestRemaining) = DeleteStaleFilesAndFindOldest(rootDir, threshold);
-        int dirs = DeleteEmptyDirectories(rootDir);
+        var (files, oldestRemaining) = DeleteStaleFilesAndFindOldest(storage, rootDir, threshold);
+        int dirs = DeleteEmptyDirectories(storage, rootDir);
 
         var nextRun = SuggestNextRun(reference, maxAgeValue, oldestRemaining);
         return (files, dirs, nextRun);
@@ -62,18 +69,18 @@ public static class TempCacheCleanup
     /// we wanted to delete but couldn't — they'll still be there next sweep).
     /// </summary>
     private static (int Deleted, DateTime? OldestRemaining) DeleteStaleFilesAndFindOldest(
-        string root, DateTime threshold)
+        IBlockParamStorage storage, StoragePath root, DateTime threshold)
     {
         int count = 0;
         DateTime? oldest = null;
 
-        foreach (var file in SafeList(() => Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories)))
+        foreach (var file in SafeList(() => storage.EnumerateFiles(root, "*", recursive: true)))
         {
             DateTime mt;
-            try { mt = File.GetLastWriteTime(file); }
+            try { mt = storage.GetLastWriteTime(file); }
             catch (Exception ex)
             {
-                Log.Warning(ex, "TempCacheCleanup: could not stat {File}", file);
+                Log.Warning(ex, "TempCacheCleanup: could not stat {File}", file.FullPath);
                 continue;
             }
 
@@ -82,14 +89,14 @@ public static class TempCacheCleanup
             {
                 try
                 {
-                    File.Delete(file);
+                    storage.DeleteFile(file);
                     count++;
                     deleted = true;
                 }
                 catch (Exception ex)
                 {
                     // Best-effort cleanup; locked or read-only files stay.
-                    Log.Warning(ex, "TempCacheCleanup: could not delete {File}", file);
+                    Log.Warning(ex, "TempCacheCleanup: could not delete {File}", file.FullPath);
                 }
             }
 
@@ -100,11 +107,11 @@ public static class TempCacheCleanup
         return (count, oldest);
     }
 
-    private static int DeleteEmptyDirectories(string root)
+    private static int DeleteEmptyDirectories(IBlockParamStorage storage, StoragePath root)
     {
         // Bottom-up so parents are visited after their children are gone.
-        var dirs = SafeList(() => Directory.EnumerateDirectories(root, "*", SearchOption.AllDirectories))
-            .OrderByDescending(d => d.Length)
+        var dirs = SafeList(() => storage.EnumerateDirectories(root, "*", recursive: true))
+            .OrderByDescending(d => d.FullPath.Length)
             .ToList();
 
         int count = 0;
@@ -112,28 +119,28 @@ public static class TempCacheCleanup
         {
             try
             {
-                if (Directory.GetFileSystemEntries(dir).Length == 0)
+                if (!storage.HasAnyEntries(dir))
                 {
-                    Directory.Delete(dir);
+                    storage.DeleteDirectory(dir);
                     count++;
                 }
             }
             catch (Exception ex)
             {
                 // Best-effort: leave non-empty or otherwise undeletable directories alone.
-                Log.Warning(ex, "TempCacheCleanup: could not remove dir {Dir}", dir);
+                Log.Warning(ex, "TempCacheCleanup: could not remove dir {Dir}", dir.FullPath);
             }
         }
         return count;
     }
 
-    private static List<string> SafeList(Func<IEnumerable<string>> source)
+    private static List<StoragePath> SafeList(Func<IEnumerable<StoragePath>> source)
     {
         try { return source().ToList(); }
         catch (Exception ex)
         {
             Log.Warning(ex, "TempCacheCleanup: enumeration failed, skipping");
-            return new List<string>();
+            return new List<StoragePath>();
         }
     }
 }

--- a/src/BlockParam/Services/UiZoomService.cs
+++ b/src/BlockParam/Services/UiZoomService.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading;
 using Newtonsoft.Json;
 using BlockParam.Diagnostics;
+using BlockParam.Services.Storage;
 
 namespace BlockParam.Services;
 
@@ -22,7 +23,8 @@ public class UiZoomService
     // without it the service touches ui-settings.json on every wheel tick.
     private const int SaveDebounceMs = 300;
 
-    private readonly string _settingsPath;
+    private readonly IBlockParamStorage _storage;
+    private readonly StoragePath _settingsPath;
     private readonly object _saveLock = new();
     private double _zoomFactor = DefaultZoom;
     private bool _loaded;
@@ -52,11 +54,20 @@ public class UiZoomService
     public UiZoomService() : this(DefaultSettingsPath()) { }
 
     public UiZoomService(string settingsPath)
+        : this(FileSystemBlockParamStorage.Instance,
+               string.IsNullOrEmpty(settingsPath)
+                   ? default
+                   : StoragePath.FromAbsolute(settingsPath))
     {
+    }
+
+    public UiZoomService(IBlockParamStorage storage, StoragePath settingsPath)
+    {
+        _storage = storage ?? throw new ArgumentNullException(nameof(storage));
         _settingsPath = settingsPath;
     }
 
-    private bool PersistenceEnabled => !string.IsNullOrEmpty(_settingsPath);
+    private bool PersistenceEnabled => !_settingsPath.IsEmpty;
 
     public static string DefaultSettingsPath() => AppDirectories.UiSettingsFile;
 
@@ -106,18 +117,18 @@ public class UiZoomService
         if (_loaded) return;
         _loaded = true;
 
-        if (!PersistenceEnabled || !File.Exists(_settingsPath)) return;
+        if (!PersistenceEnabled || !_storage.FileExists(_settingsPath)) return;
 
         try
         {
-            var json = File.ReadAllText(_settingsPath);
+            var json = _storage.ReadAllText(_settingsPath);
             var parsed = JsonConvert.DeserializeObject<UiSettingsDto>(json);
             if (parsed != null && parsed.Zoom > 0)
                 _zoomFactor = Clamp(parsed.Zoom);
         }
         catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
         {
-            Log.Warning(ex, "UiZoomService: cannot read {Path} — using default zoom", _settingsPath);
+            Log.Warning(ex, "UiZoomService: cannot read {Path} — using default zoom", _settingsPath.FullPath);
         }
     }
 
@@ -145,16 +156,12 @@ public class UiZoomService
         if (!PersistenceEnabled) return;
         try
         {
-            var dir = Path.GetDirectoryName(_settingsPath);
-            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
-                Directory.CreateDirectory(dir);
-
             var json = JsonConvert.SerializeObject(new UiSettingsDto { Zoom = _zoomFactor }, Formatting.Indented);
-            File.WriteAllText(_settingsPath, json);
+            _storage.WriteAllText(_settingsPath, json);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            Log.Warning(ex, "UiZoomService: cannot save {Path}", _settingsPath);
+            Log.Warning(ex, "UiZoomService: cannot save {Path}", _settingsPath.FullPath);
         }
     }
 


### PR DESCRIPTION
## Summary

Introduces `IBlockParamStorage` + `StoragePath` so file I/O has a single seam
unit tests can substitute. Migrates the three untouched callers per the
issue's sequencing; hot files (`OnlineLicenseService`, `ConfigLoader`,
`BulkChangeContextMenu`) follow in PR 2.

- **New** `src/BlockParam/Services/Storage/`: `StoragePath` (rooted at
  `AppDirectories`, composes with `/`), `IBlockParamStorage`,
  `FileSystemBlockParamStorage` (production), `InMemoryBlockParamStorage`
  (tests — case-insensitive, injectable clock).
- **Migrated** `UiZoomService`, `CacheCleanupSchedule`, `TempCacheCleanup` —
  added storage-injecting overloads, kept the legacy `string` ones so
  existing tests + the addin call sites are untouched.
- **Tests** `src/BlockParam.Tests/Storage/` — interface coverage on the
  in-memory fake, real-disk round-trip on the FS adapter, storage-injected
  re-coverage of the three migrated services.
- **Guardrail** updated in `CLAUDE.md` (well, not yet — kept the existing
  wording; the storage seam is now the answer for the "no new file I/O"
  rule).

Closes #85

## Test plan

- [ ] `dotnet test src/BlockParam.Tests` (no SDK in the sandbox where this
  was authored — CI is the ground truth).
- [ ] Verify legacy tests still pass: `UiZoomServiceTests`,
  `CacheCleanupScheduleTests`, `TempCacheCleanupTests` — they exercise the
  preserved string-based overloads.
- [ ] Smoke-test the addin in TIA Portal: open a DB, hit Bulk Change. The
  cache cleanup + UI zoom paths now route through `FileSystemBlockParamStorage`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ENriS1bvKtuyBDHh2HNytV)_