### PR TITLE
refactor: centralise BlockParam path literals in AppDirectories

### DIFF
--- a/src/BlockParam/AddIn/BulkChangeContextMenu.cs
+++ b/src/BlockParam/AddIn/BulkChangeContextMenu.cs
@@ -70,13 +70,10 @@ public class BulkChangeContextMenu : ContextMenuAddIn
         if (Interlocked.Exchange(ref _tempCacheCleanupRan, 1) != 0) return;
         try
         {
-            var stateFile = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "BlockParam", "cache-cleanup.txt");
+            var stateFile = AppDirectories.CacheCleanupStateFile;
             if (!CacheCleanupSchedule.IsDue(stateFile)) return;
 
-            var root = Path.Combine(Path.GetTempPath(), "BlockParam");
-            var (files, dirs, nextRun) = TempCacheCleanup.Run(root);
+            var (files, dirs, nextRun) = TempCacheCleanup.Run(AppDirectories.Temp);
             CacheCleanupSchedule.SetNextRun(stateFile, nextRun);
 
             if (files > 0 || dirs > 0)
@@ -130,12 +127,10 @@ public class BulkChangeContextMenu : ContextMenuAddIn
             // Per-project scope so parallel TIA instances / switched projects cannot share cache dirs (#14).
             var project = _tiaPortal.Projects.FirstOrDefault();
             var scope = ProjectScope.ForPath(project?.Path?.FullName);
-            var tempDir = Path.Combine(Path.GetTempPath(), "BlockParam", scope);
-            var tagTableDir = Path.Combine(tempDir, "TagTables");
-            var udtDir = Path.Combine(tempDir, "UdtTypes");
-            var appDataDir = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "BlockParam");
+            var tempDir = AppDirectories.TempScope(scope);
+            var tagTableDir = AppDirectories.TagTablesCacheDir(scope);
+            var udtDir = AppDirectories.UdtTypesCacheDir(scope);
+            var appDataDir = AppDirectories.AppData;
 
             // Service composition. Each service is a single-responsibility seam (#81):
             // adapter (TIA Openness wrapping), discovery (tree walks), exporter (compile-prompt
@@ -380,9 +375,7 @@ public class BulkChangeContextMenu : ContextMenuAddIn
     {
         var candidates = new[]
         {
-            Path.Combine(Environment.GetFolderPath(
-                Environment.SpecialFolder.ApplicationData),
-                "BlockParam", "config.json"),
+            AppDirectories.ConfigFile,
             Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "config.json"),
         };
 

--- a/src/BlockParam/Config/ConfigLoader.cs
+++ b/src/BlockParam/Config/ConfigLoader.cs
@@ -2,6 +2,7 @@ using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using BlockParam.Diagnostics;
+using BlockParam.Services;
 using BlockParam.Updates;
 
 namespace BlockParam.Config;
@@ -179,10 +180,7 @@ public class ConfigLoader
     /// </summary>
     public void SaveUpdateCheckSettings(UpdateCheckSettings settings)
     {
-        var targetPath = _configPath
-            ?? Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "BlockParam", "config.json");
+        var targetPath = _configPath ?? AppDirectories.ConfigFile;
 
         BulkChangeConfig config;
         if (File.Exists(targetPath))
@@ -215,17 +213,7 @@ public class ConfigLoader
     {
         try
         {
-            string? managedPath;
-            if (ManagedConfigPathOverride != null)
-            {
-                managedPath = ManagedConfigPathOverride;
-            }
-            else
-            {
-                var programData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
-                if (string.IsNullOrEmpty(programData)) return null;
-                managedPath = Path.Combine(programData, "BlockParam", "config.json");
-            }
+            var managedPath = ManagedConfigPathOverride ?? AppDirectories.ProgramDataConfigFile;
             if (!File.Exists(managedPath)) return null;
 
             var json = File.ReadAllText(managedPath);
@@ -285,11 +273,7 @@ public class ConfigLoader
     }
 
     /// <summary>Returns the TIA project rules directory path.</summary>
-    public string? GetTiaProjectRulesDirectory()
-    {
-        if (string.IsNullOrEmpty(_tiaProjectPath)) return null;
-        return Path.Combine(_tiaProjectPath, "UserFiles", "BlockParam");
-    }
+    public string? GetTiaProjectRulesDirectory() => AppDirectories.ProjectRulesDir(_tiaProjectPath);
 
     /// <summary>Returns the local rules directory path.</summary>
     public string GetLocalRulesDirectory()
@@ -300,9 +284,7 @@ public class ConfigLoader
             if (configDir != null)
                 return Path.Combine(configDir, "rules");
         }
-        return Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "BlockParam", "rules");
+        return AppDirectories.LocalRulesDir;
     }
 
     private string ResolveRulesDirectory(string rulesDir)
@@ -354,10 +336,7 @@ public class ConfigLoader
     /// </summary>
     public void SaveSharedRulesDirectory(string? rulesDirectory)
     {
-        var targetPath = _configPath
-            ?? Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "BlockParam", "config.json");
+        var targetPath = _configPath ?? AppDirectories.ConfigFile;
 
         var config = new BulkChangeConfig
         {

--- a/src/BlockParam/Services/AppDirectories.cs
+++ b/src/BlockParam/Services/AppDirectories.cs
@@ -4,20 +4,15 @@ using System.IO;
 namespace BlockParam.Services;
 
 /// <summary>
-/// Single source of truth for paths rooted at the "BlockParam" segment.
+/// Single source of truth for paths rooted at the "BlockParam" segment (#86).
 /// Replaces inline literals like <c>Path.Combine(..., "BlockParam", "logs")</c>
-/// scattered across the codebase (#86) — and is the anchor the new
+/// scattered across the codebase, and is the anchor the
 /// "no new path string literals" CLAUDE.md guardrail points at.
-///
-/// Only the three callers in files untouched by the freemium branch are
-/// migrated in the first pass: <c>Diagnostics.Log</c>, <c>UiZoomService</c>,
-/// and <c>OnlineLicenseService.DefaultSharedLicenseFilePath</c>. The
-/// remaining sites in <c>ConfigLoader</c> and <c>BulkChangeContextMenu</c>
-/// follow once the freemium branch merges.
 /// </summary>
 public static class AppDirectories
 {
     private const string ProductFolder = "BlockParam";
+    private const string ConfigFileName = "config.json";
 
     /// <summary>Per-user app data root: <c>%APPDATA%\BlockParam</c>.</summary>
     public static string AppData => Path.Combine(
@@ -38,9 +33,49 @@ public static class AppDirectories
     /// <summary>Per-user UI zoom / window-state settings file.</summary>
     public static string UiSettingsFile => Path.Combine(AppData, "ui-settings.json");
 
+    /// <summary>Per-user config file (rules dir, language, update-check, ...).</summary>
+    public static string ConfigFile => Path.Combine(AppData, ConfigFileName);
+
+    /// <summary>
+    /// Machine-wide managed config file. IT rolls out a single
+    /// <c>{"updateCheck":{"enabled":false}}</c> / shared rules dir here and
+    /// the override wins over the per-user config on every seat.
+    /// </summary>
+    public static string ProgramDataConfigFile => Path.Combine(ProgramData, ConfigFileName);
+
+    /// <summary>Per-user local rule directory under <see cref="AppData"/>.</summary>
+    public static string LocalRulesDir => Path.Combine(AppData, "rules");
+
+    /// <summary>State file driving the TEMP cache-cleanup schedule.</summary>
+    public static string CacheCleanupStateFile => Path.Combine(AppData, "cache-cleanup.txt");
+
     /// <summary>
     /// Machine-wide shared license file. IT rolls out / rotates the key by
     /// writing here; every seat on the machine adopts it on next start.
     /// </summary>
     public static string SharedLicenseFile => Path.Combine(ProgramData, "license.key");
+
+    /// <summary>
+    /// Per-project scope cache root: <c>%TEMP%\BlockParam\{scope}</c>.
+    /// Scope is derived from the project path (see <c>ProjectScope.ForPath</c>)
+    /// so parallel TIA instances / switched projects cannot share cache dirs.
+    /// </summary>
+    public static string TempScope(string scope) => Path.Combine(Temp, scope);
+
+    /// <summary>Cached tag-table XMLs for a given project scope.</summary>
+    public static string TagTablesCacheDir(string scope) => Path.Combine(TempScope(scope), "TagTables");
+
+    /// <summary>Cached UDT-type XMLs for a given project scope.</summary>
+    public static string UdtTypesCacheDir(string scope) => Path.Combine(TempScope(scope), "UdtTypes");
+
+    /// <summary>
+    /// Project-embedded rules directory:
+    /// <c>{tiaProjectPath}\UserFiles\BlockParam</c>. Returns null when the
+    /// project path is null/empty so callers can short-circuit.
+    /// </summary>
+    public static string? ProjectRulesDir(string? tiaProjectPath)
+    {
+        if (string.IsNullOrEmpty(tiaProjectPath)) return null;
+        return Path.Combine(tiaProjectPath, "UserFiles", ProductFolder);
+    }
 }


### PR DESCRIPTION
## Summary

- Extends `AppDirectories` with the remaining path constants (`ConfigFile`, `ProgramDataConfigFile`, `LocalRulesDir`, `CacheCleanupStateFile`, `TempScope`, `TagTablesCacheDir`, `UdtTypesCacheDir`, `ProjectRulesDir`).
- Migrates the two heavy callers (`BulkChangeContextMenu`, `ConfigLoader`) that were deferred behind the freemium counter branch — every `Path.Combine` against a `"BlockParam"` string literal in the addin project now flows through a single named property.
- No behavior change; pure refactor. `OnlineLicenseService`, `UiZoomService`, `Log` were already on `AppDirectories`.

Closes #86

## Test plan

- [ ] CI build passes on Windows (net48 + WPF)
- [ ] `BlockParam.Tests` (xUnit) green — covers `ConfigLoader` paths (`UpdateCheckSettingsConfigTests`, `RulesDirectoryLoaderTests`, `OnlineLicenseServiceSharedFileTests`)
- [ ] Smoke test: open TIA, right-click DB → "Bulk Change…", confirm `%TEMP%\BlockParam\<scope>\TagTables` and `%APPDATA%\BlockParam\config.json` are still read/written at the same paths

https://claude.ai/code/session_01Asp5gaF7UT68TUw59wfYLo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Asp5gaF7UT68TUw59wfYLo)_