### PR TITLE
Split BulkChangeViewModel god class (#80, slices 1-5/9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,29 @@ the debugging investment. Regenerate visual assets locally:
 - Screenshots: run the scripts in `assets/screenshots/scripts/` from the repo root.
 - Workflow video: use the `recreate-workflow-video` skill.
 
+### Checking CI status from Claude
+
+When verifying whether a CI run passed or failed:
+
+- **Use `mcp__github__pull_request_read` with `method: "get_check_runs"`.**
+  It returns the actual `conclusion` (`"success"` / `"failure"` /
+  `"skipped"` / `"cancelled"`) for each job.
+- **Do NOT trust `WebFetch` on `/actions` or `/actions/workflows/ci.yml`
+  pages to determine pass/fail.** The status icons are SVGs that don't
+  survive HTML→markdown conversion, so WebFetch reports things like
+  "no failure indicators visible" even when jobs are red. It's fine for
+  reading run numbers, durations, and titles — just not conclusions.
+- **`method: "get_status"` is the legacy commit-status API**, which
+  GitHub Actions doesn't populate. It will return
+  `state: "pending"`, `total_count: 0` even when check-runs have already
+  succeeded or failed. Don't rely on it.
+- For failure details (which step failed, error messages), `WebFetch`
+  on the specific job URL (`/actions/runs/<run_id>/job/<job_id>`) does
+  extract the log text and is reliable.
+- `[run-ci]` push triggers and `pull_request` triggers each produce
+  their own check-runs on the same SHA — expect to see duplicates after
+  opening a PR on a branch that was already CI'd via the marker.
+
 ## DevLauncher (UI Testing without TIA Portal)
 
 The project includes a standalone WPF launcher for testing the UI without TIA Portal:

--- a/src/BlockParam.DevLauncher/CaptureScript.cs
+++ b/src/BlockParam.DevLauncher/CaptureScript.cs
@@ -439,7 +439,7 @@ public static class SceneApplier
         BulkChangeViewModel vm, BulkChangeDialog dialog, string displayName)
     {
         bool matched = false;
-        foreach (var s in vm.FilteredSuggestions)
+        foreach (var s in vm.Autocomplete.FilteredSuggestions)
         {
             if (s.DisplayName == displayName) { s.IsHoverPreview = true; matched = true; }
         }
@@ -460,7 +460,7 @@ public static class SceneApplier
 
     private static void ClearHoverPreview(BulkChangeViewModel vm, BulkChangeDialog dialog)
     {
-        foreach (var s in vm.FilteredSuggestions) s.IsHoverPreview = false;
+        foreach (var s in vm.Autocomplete.FilteredSuggestions) s.IsHoverPreview = false;
         if (dialog.InlineOverlayList.ItemsSource is System.Collections.IEnumerable items)
             foreach (var o in items)
                 if (o is AutocompleteSuggestion s) s.IsHoverPreview = false;

--- a/src/BlockParam.DevLauncher/CaptureScript.cs
+++ b/src/BlockParam.DevLauncher/CaptureScript.cs
@@ -382,7 +382,7 @@ public static class SceneApplier
         if (scene.Sidebar != null)
         {
             if (scene.Sidebar.Collapsed.HasValue)
-                vm.IsInspectorCollapsed = scene.Sidebar.Collapsed.Value;
+                vm.Inspector.IsInspectorCollapsed = scene.Sidebar.Collapsed.Value;
         }
 
         if (scene.InlineEdit != null)
@@ -508,7 +508,7 @@ public static class SceneApplier
         // doesn't inherit them. DiscardPendingSilent skips the confirm dialog.
         if (vm.HasPendingEdits)
             vm.DiscardPendingSilent();
-        vm.IsInspectorCollapsed = false;
+        vm.Inspector.IsInspectorCollapsed = false;
         foreach (var root in vm.RootMembers)
             CollapseRecursive(root);
         vm.SelectedFlatMember = null;

--- a/src/BlockParam.DevLauncher/CaptureScript.cs
+++ b/src/BlockParam.DevLauncher/CaptureScript.cs
@@ -354,18 +354,18 @@ public static class SceneApplier
 
         if (scene.RevertPending != null)
         {
-            var entry = vm.PendingEdits.FirstOrDefault(p => p.Node?.Path == scene.RevertPending);
+            var entry = vm.Pending.PendingEdits.FirstOrDefault(p => p.Node?.Path == scene.RevertPending);
             if (entry == null)
                 Serilog.Log.Warning("Scene {Id}: revertPending path not found in queue: {Path}. Queue: {Paths}",
                     scene.Id, scene.RevertPending,
-                    string.Join(", ", vm.PendingEdits.Select(p => p.Node?.Path ?? "?")));
+                    string.Join(", ", vm.Pending.PendingEdits.Select(p => p.Node?.Path ?? "?")));
             else
                 vm.UndoPendingEdit(entry);
         }
 
         if (scene.DiscardAllPending == true)
         {
-            if (vm.HasPendingEdits)
+            if (vm.Pending.HasPendingEdits)
                 vm.DiscardPendingSilent();
             else
                 Serilog.Log.Warning("Scene {Id}: discardAllPending requested but queue is empty", scene.Id);
@@ -506,7 +506,7 @@ public static class SceneApplier
     {
         // Clear any pending edits staged by a prior scene so a clean run
         // doesn't inherit them. DiscardPendingSilent skips the confirm dialog.
-        if (vm.HasPendingEdits)
+        if (vm.Pending.HasPendingEdits)
             vm.DiscardPendingSilent();
         vm.Inspector.IsInspectorCollapsed = false;
         foreach (var root in vm.RootMembers)

--- a/src/BlockParam.Tests/AutocompleteViewModelTests.cs
+++ b/src/BlockParam.Tests/AutocompleteViewModelTests.cs
@@ -1,0 +1,202 @@
+using System.Collections.Generic;
+using System.Linq;
+using BlockParam.Services;
+using BlockParam.UI;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Focused tests for the autocomplete slice (#80 slice 3).
+/// </summary>
+public class AutocompleteViewModelTests
+{
+    private static AutocompleteSuggestion S(string value, string display = "", string? comment = null) =>
+        new AutocompleteSuggestion(value, string.IsNullOrEmpty(display) ? value : display, comment);
+
+    private static readonly IReadOnlyList<AutocompleteSuggestion> Sample = new[]
+    {
+        S("100", "Speed_Min", "Minimum"),
+        S("200", "Speed_Max", "Maximum"),
+        S("50",  "Pressure_Bar", "in bar"),
+    };
+
+    [Fact]
+    public void Defaults_AreEmpty()
+    {
+        var vm = new AutocompleteViewModel();
+
+        vm.Suggestions.Should().BeEmpty();
+        vm.FilteredSuggestions.Should().BeEmpty();
+        vm.SuggestionProvider.Should().BeNull();
+        vm.HasFilteredSuggestions.Should().BeFalse();
+        vm.SuppressSuggestions.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SetCandidates_PopulatesPool_ClearsFiltered()
+    {
+        var vm = new AutocompleteViewModel();
+        vm.SetCandidates(Sample, new GlobSuggestionProvider(Sample));
+
+        vm.Suggestions.Should().HaveCount(3);
+        vm.SuggestionProvider.Should().NotBeNull();
+        vm.FilteredSuggestions.Should().BeEmpty("SetCandidates must not auto-open the overlay");
+    }
+
+    [Fact]
+    public void ClearCandidates_ResetsEverything()
+    {
+        var vm = new AutocompleteViewModel();
+        vm.SetCandidates(Sample, new GlobSuggestionProvider(Sample));
+        vm.ShowAll("");
+
+        vm.ClearCandidates();
+
+        vm.Suggestions.Should().BeEmpty();
+        vm.FilteredSuggestions.Should().BeEmpty();
+        vm.SuggestionProvider.Should().BeNull();
+    }
+
+    [Fact]
+    public void ApplyFilter_EmptyPool_ProducesEmpty()
+    {
+        var vm = new AutocompleteViewModel();
+        vm.ApplyFilter("anything");
+
+        vm.FilteredSuggestions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ApplyFilter_EmptyText_HidesOverlay()
+    {
+        var vm = new AutocompleteViewModel();
+        vm.SetCandidates(Sample, null);
+
+        vm.ApplyFilter("");
+
+        vm.FilteredSuggestions.Should().BeEmpty("empty text closes the overlay rather than showing all");
+    }
+
+    [Fact]
+    public void ApplyFilter_AllTermsMustMatchSomewhere()
+    {
+        var vm = new AutocompleteViewModel();
+        vm.SetCandidates(Sample, null);
+
+        vm.ApplyFilter("speed min");
+
+        vm.FilteredSuggestions.Should().ContainSingle(s => s.Value == "100");
+    }
+
+    [Fact]
+    public void ApplyFilter_MatchesCommentField()
+    {
+        var vm = new AutocompleteViewModel();
+        vm.SetCandidates(Sample, null);
+
+        vm.ApplyFilter("bar");
+
+        vm.FilteredSuggestions.Should().ContainSingle(s => s.Value == "50");
+    }
+
+    [Fact]
+    public void ApplyFilter_IsCaseInsensitive()
+    {
+        var vm = new AutocompleteViewModel();
+        vm.SetCandidates(Sample, null);
+
+        vm.ApplyFilter("SPEED");
+
+        vm.FilteredSuggestions.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void ApplyFilter_Suppressed_AlwaysEmpty()
+    {
+        var vm = new AutocompleteViewModel();
+        vm.SetCandidates(Sample, null);
+        vm.SuppressSuggestions = true;
+
+        vm.ApplyFilter("speed");
+
+        vm.FilteredSuggestions.Should().BeEmpty("suppression must hard-close the overlay");
+    }
+
+    [Fact]
+    public void ShowAll_EmptyFilter_RendersAll()
+    {
+        var vm = new AutocompleteViewModel();
+        vm.SetCandidates(Sample, null);
+
+        vm.ShowAll("");
+
+        vm.FilteredSuggestions.Should().HaveCount(3);
+        vm.HasFilteredSuggestions.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShowAll_WithFilter_RendersMatchesOnly()
+    {
+        var vm = new AutocompleteViewModel();
+        vm.SetCandidates(Sample, null);
+
+        vm.ShowAll("max");
+
+        vm.FilteredSuggestions.Should().ContainSingle(s => s.Value == "200");
+    }
+
+    [Fact]
+    public void Toggle_OpensWhenClosed_ClosesWhenOpen()
+    {
+        var vm = new AutocompleteViewModel();
+        vm.SetCandidates(Sample, null);
+
+        vm.Toggle("");
+        vm.HasFilteredSuggestions.Should().BeTrue("first toggle opens");
+
+        vm.Toggle("");
+        vm.HasFilteredSuggestions.Should().BeFalse("second toggle closes");
+    }
+
+    [Fact]
+    public void ClearFiltered_HidesOverlay_KeepsPool()
+    {
+        var vm = new AutocompleteViewModel();
+        vm.SetCandidates(Sample, null);
+        vm.ShowAll("");
+
+        vm.ClearFiltered();
+
+        vm.FilteredSuggestions.Should().BeEmpty();
+        vm.Suggestions.Should().HaveCount(3, "ClearFiltered must not touch the candidate pool");
+    }
+
+    [Fact]
+    public void HasFilteredSuggestions_RaisesOnFilterChange()
+    {
+        var vm = new AutocompleteViewModel();
+        vm.SetCandidates(Sample, null);
+
+        var raised = new List<string?>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        vm.ShowAll("");
+
+        raised.Should().Contain(nameof(AutocompleteViewModel.HasFilteredSuggestions));
+    }
+
+    [Fact]
+    public void Match_Static_SameLogicAsInstance()
+    {
+        var instanceResult = new AutocompleteViewModel();
+        instanceResult.SetCandidates(Sample, null);
+        instanceResult.ShowAll("speed");
+
+        var staticResult = AutocompleteViewModel.Match(Sample, "speed");
+
+        staticResult.Select(s => s.Value).Should().BeEquivalentTo(
+            instanceResult.FilteredSuggestions.Select(s => s.Value));
+    }
+}

--- a/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
@@ -848,7 +848,7 @@ public class BulkChangeViewModelInvariantTests
         var reachableNodes = vm.RootMembers
             .SelectMany(r => new[] { r }.Concat(r.AllDescendants()))
             .ToHashSet();
-        var orphanedPaths = vm.PendingEdits
+        var orphanedPaths = vm.Pending.PendingEdits
             .Where(e => !reachableNodes.Contains(e.Node))
             .Select(e => e.Path)
             .ToList();

--- a/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
@@ -862,7 +862,7 @@ public class BulkChangeViewModelInvariantTests
         // a transition path forgets to call it, the stale rows survive.
         if (!vm.HasScope && !vm.IsManualMode)
         {
-            vm.BulkPreview.Should().BeEmpty(
+            vm.BulkPreview.Entries.Should().BeEmpty(
                 "invariant 7: BulkPreview must be empty when no scope is " +
                 "selected and not in manual mode");
         }
@@ -871,7 +871,7 @@ public class BulkChangeViewModelInvariantTests
         // from the live tree — same shape as invariant 6 for PendingEdits.
         // Removing a DB from the active set must vacate any preview rows or
         // manual-selection paths that pointed at its leaves (§H3).
-        var orphanedPreview = vm.BulkPreview
+        var orphanedPreview = vm.BulkPreview.Entries
             .Where(e => !reachableNodes.Contains(e.Node))
             .Select(e => e.Path)
             .ToList();

--- a/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
@@ -499,7 +499,7 @@ public class BulkChangeViewModelInvariantTests
         env.Vm.HasStashedDbs.Should().BeTrue("Keep moves pending edits into the stash");
         env.Vm.StashedDbs.Should().ContainSingle(s => s.DbName == "FlatDB",
             "anchor's pending edit must land in the stash dictionary, not be silently dropped");
-        env.Vm.PendingEdits.Should().BeEmpty(
+        env.Vm.Pending.PendingEdits.Should().BeEmpty(
             "removed DB's pending leaves must vacate the bound PendingEdits list");
         AssertInvariants(env.Vm);
     }

--- a/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
@@ -909,7 +909,7 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         vm.SearchQuery = "Speed";    // schedules _searchDebounceTimer
         vm.NewValue = "42";          // schedules _valueDebounceTimer
 
-        var usageTextBefore = vm.UsageStatusText;
+        var usageTextBefore = vm.Subscription.UsageStatusText;
 
         // First Dispose
         var ex1 = Record.Exception(() => vm.Dispose());

--- a/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
@@ -645,12 +645,12 @@ public class BulkChangeViewModelRegressionTests : IDisposable
 
         // Confirm starting state: ShowConstants=false → Suggestions empty
         vm.ShowConstants.Should().BeFalse("no rule forces ShowConstants on");
-        vm.Suggestions.Should().BeEmpty("ShowConstants is off — no suggestions loaded yet");
+        vm.Autocomplete.Suggestions.Should().BeEmpty("ShowConstants is off — no suggestions loaded yet");
 
         // Toggle on → Suggestions must populate from the tag-table cache
         vm.ShowConstants = true;
 
-        vm.Suggestions.Should().NotBeEmpty(
+        vm.Autocomplete.Suggestions.Should().NotBeEmpty(
             "ShowConstants=true must load suggestions from the tag-table cache");
     }
 
@@ -700,22 +700,22 @@ public class BulkChangeViewModelRegressionTests : IDisposable
 
         // Force ShowConstants on to populate _suggestions
         vm.ShowConstants = true;
-        vm.Suggestions.Should().HaveCount(10, "all 10 entries loaded");
-        vm.FilteredSuggestions.Should().BeEmpty("not yet toggled open");
+        vm.Autocomplete.Suggestions.Should().HaveCount(10, "all 10 entries loaded");
+        vm.Autocomplete.FilteredSuggestions.Should().BeEmpty("not yet toggled open");
 
         // Set NewValue without flushing the debounce — FilteredSuggestions stays empty
         // (we want to test the toggle path, not the auto-filter path)
         vm.NewValue = "ON";
         // Don't flush: we want to test ToggleAllSuggestions when the list starts empty.
 
-        vm.FilteredSuggestions.Should().BeEmpty("debounce not yet flushed — list still empty");
+        vm.Autocomplete.FilteredSuggestions.Should().BeEmpty("debounce not yet flushed — list still empty");
 
         // First toggle: closed → open (FilteredSuggestions filtered by NewValue="ON")
         vm.ToggleAllSuggestions();
 
-        vm.FilteredSuggestions.Should().NotBeEmpty("toggle-open must populate FilteredSuggestions");
+        vm.Autocomplete.FilteredSuggestions.Should().NotBeEmpty("toggle-open must populate FilteredSuggestions");
         // Only VAL_ON_1 and VAL_ON_2 have "ON" in name — rest do not
-        vm.FilteredSuggestions.Should().AllSatisfy(s =>
+        vm.Autocomplete.FilteredSuggestions.Should().AllSatisfy(s =>
             (s.DisplayName.IndexOf("ON", StringComparison.OrdinalIgnoreCase) >= 0
              || s.Value.IndexOf("ON", StringComparison.OrdinalIgnoreCase) >= 0
              || (s.Comment?.IndexOf("ON", StringComparison.OrdinalIgnoreCase) ?? -1) >= 0)
@@ -724,7 +724,7 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         // Second toggle: close → FilteredSuggestions clears
         vm.ToggleAllSuggestions();
 
-        vm.FilteredSuggestions.Should().BeEmpty("second toggle-call must close the list");
+        vm.Autocomplete.FilteredSuggestions.Should().BeEmpty("second toggle-call must close the list");
     }
 
     // ─────────────────────────────────────────────────────────────────────

--- a/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
@@ -251,7 +251,7 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         vm.NewValue = "";
         vm.FlushPendingHighlighting();
 
-        vm.BulkPreview.Should().BeEmpty(
+        vm.BulkPreview.Entries.Should().BeEmpty(
             "empty NewValue must produce no BulkPreview entries (hasInput guard at ComputeBulkPreview)");
     }
 
@@ -281,14 +281,14 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         vm.NewValue = "42";
         vm.FlushPendingHighlighting();
 
-        vm.BulkPreview.Count.Should().Be(0,
+        vm.BulkPreview.Entries.Count.Should().Be(0,
             "all 4 leaves already hold the target value — skip-already-matching must produce 0 entries");
 
         // Now a different value — all 4 differ
         vm.NewValue = "99";
         vm.FlushPendingHighlighting();
 
-        vm.BulkPreview.Count.Should().Be(4,
+        vm.BulkPreview.Entries.Count.Should().Be(4,
             "all 4 leaves differ from target '99' — all must appear in BulkPreview");
     }
 
@@ -324,10 +324,10 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         vm.NewValue = "99";
         vm.FlushPendingHighlighting();
 
-        vm.BulkPreviewConflictCount.Should().Be(1,
+        vm.BulkPreview.ConflictCount.Should().Be(1,
             "one leaf has a pending inline edit that the bulk Set would overwrite");
-        vm.HasBulkPreviewConflict.Should().BeTrue();
-        vm.BulkPreviewConflictWarning.Should().Contain("1 overlap",
+        vm.BulkPreview.HasConflict.Should().BeTrue();
+        vm.BulkPreview.ConflictWarning.Should().Contain("1 overlap",
             "warning must mention the count of overlapping edits");
     }
 
@@ -354,8 +354,8 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         vm.NewValue = "85";
         vm.FlushPendingHighlighting();
 
-        vm.BulkPreview.Should().HaveCount(4, "all 4 differ from 85");
-        vm.BulkPreviewSummary.Should().Be("42 ⇢ 85",
+        vm.BulkPreview.Entries.Should().HaveCount(4, "all 4 differ from 85");
+        vm.BulkPreview.Summary.Should().Be("42 ⇢ 85",
             "homogeneous originals should produce 'orig ⇢ new' format");
 
         // Make one leaf heterogeneous by staging a pending edit
@@ -391,7 +391,7 @@ public class BulkChangeViewModelRegressionTests : IDisposable
 
         // Speed.StartValue="1500", Enable.StartValue="true" — different originals
         vm2.BulkPreview.Count.Should().BeGreaterThan(0, "both differ from 'ON'");
-        vm2.BulkPreviewSummary.Should().MatchRegex(@"^\d+ targets$",
+        vm2.BulkPreview.Summary.Should().MatchRegex(@"^\d+ targets$",
             "heterogeneous originals (Speed='1500' vs Enable='true') must use '{N} targets' format");
 
         vm2.Dispose();

--- a/src/BlockParam.Tests/BulkChangeViewModelTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelTests.cs
@@ -106,11 +106,11 @@ public class BulkChangeViewModelTests : IDisposable
             ""constraints"": { ""min"": 0, ""max"": 1000 } }] }";
         var vm = CreateViewModelWithRule("flat-db.xml", rule);
 
-        vm.HasExistingIssues.Should().BeTrue("Speed=1500 violates max=1000");
-        vm.ExistingIssuesCount.Should().Be(1);
-        vm.ExistingIssues.Single().Node.Name.Should().Be("Speed");
-        vm.ExistingIssues.Single().CurrentValue.Should().Be("1500");
-        vm.ExistingIssues.Single().Node.HasExistingViolation.Should().BeTrue();
+        vm.Pending.HasExistingIssues.Should().BeTrue("Speed=1500 violates max=1000");
+        vm.Pending.ExistingIssuesCount.Should().Be(1);
+        vm.Pending.ExistingIssues.Single().Node.Name.Should().Be("Speed");
+        vm.Pending.ExistingIssues.Single().CurrentValue.Should().Be("1500");
+        vm.Pending.ExistingIssues.Single().Node.HasExistingViolation.Should().BeTrue();
     }
 
     /// <summary>
@@ -121,8 +121,8 @@ public class BulkChangeViewModelTests : IDisposable
     public void ExistingIssues_Empty_WhenNoRules()
     {
         var vm = CreateViewModel(); // no rules configured
-        vm.HasExistingIssues.Should().BeFalse();
-        vm.ExistingIssuesCount.Should().Be(0);
+        vm.Pending.HasExistingIssues.Should().BeFalse();
+        vm.Pending.ExistingIssuesCount.Should().Be(0);
     }
 
     /// <summary>
@@ -137,7 +137,7 @@ public class BulkChangeViewModelTests : IDisposable
         var vm = CreateViewModelWithRule("flat-db.xml", rule);
 
         // Pre-existing violation present
-        vm.HasExistingIssues.Should().BeTrue();
+        vm.Pending.HasExistingIssues.Should().BeTrue();
         // No pending edits, no inline errors
         vm.HasInlineErrors.Should().BeFalse(
             "existing violations must not flip HasInlineError — that's the Apply blocker");
@@ -238,7 +238,7 @@ public class BulkChangeViewModelTests : IDisposable
         vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
         vm.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
 
-        vm.PendingInlineEditCount.Should().Be(2);
+        vm.Pending.PendingInlineEditCount.Should().Be(2);
         vm.ApplyCommand.CanExecute(null).Should().BeFalse(
             "Apply must be blocked when pending count > remaining quota — no partial-apply state");
     }
@@ -319,7 +319,7 @@ public class BulkChangeViewModelTests : IDisposable
     public void ApplyTooltip_NoPending_OmitsCostLine()
     {
         var vm = CreateViewModelWithUsage(new UsageStatus(0, 200));
-        vm.PendingInlineEditCount.Should().Be(0);
+        vm.Pending.PendingInlineEditCount.Should().Be(0);
         vm.ApplyTooltip.Should().NotContain("remaining today");
     }
 
@@ -333,7 +333,7 @@ public class BulkChangeViewModelTests : IDisposable
         var vm = CreateViewModelWithUsage(new UsageStatus(0, 200)); // 200 remaining
         vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
 
-        vm.PendingInlineEditCount.Should().Be(1);
+        vm.Pending.PendingInlineEditCount.Should().Be(1);
         vm.ApplyTooltip.Should().NotContain("remaining today",
             "1 change with 200 left is the unsurprising case — keep the tooltip quiet");
     }
@@ -371,7 +371,7 @@ public class BulkChangeViewModelTests : IDisposable
             vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
             vm.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
 
-            vm.PendingInlineEditCount.Should().Be(2);
+            vm.Pending.PendingInlineEditCount.Should().Be(2);
             vm.ApplyTooltip.Should()
                 .Contain("free changes remaining today",
                     "the cost line — not just any '2 of 200' substring — must be present")
@@ -392,7 +392,7 @@ public class BulkChangeViewModelTests : IDisposable
             var vm = CreateViewModelWithUsage(new UsageStatus(170, 200)); // 30 remaining
             vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
 
-            vm.PendingInlineEditCount.Should().Be(1);
+            vm.Pending.PendingInlineEditCount.Should().Be(1);
             vm.ApplyTooltip.Should()
                 .Contain("free changes remaining today",
                     "tight remaining quota deserves the cost line even for a single change")

--- a/src/BlockParam.Tests/BulkPreviewViewModelTests.cs
+++ b/src/BlockParam.Tests/BulkPreviewViewModelTests.cs
@@ -1,0 +1,160 @@
+using BlockParam.Models;
+using BlockParam.UI;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Focused tests for the bulk-preview slice (#80 slice 5).
+/// </summary>
+public class BulkPreviewViewModelTests
+{
+    [Fact]
+    public void Defaults_AreEmpty()
+    {
+        var vm = new BulkPreviewViewModel(() => "");
+
+        vm.Entries.Should().BeEmpty();
+        vm.HasEntries.Should().BeFalse();
+        vm.Count.Should().Be(0);
+        vm.ConflictCount.Should().Be(0);
+        vm.HasConflict.Should().BeFalse();
+        vm.ConflictWarning.Should().BeEmpty();
+        vm.Summary.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Add_PopulatesEntriesAndCount()
+    {
+        var vm = new BulkPreviewViewModel(() => "999");
+        vm.Add(MakeEntry("Speed1", "100", "999", conflict: false));
+        vm.Add(MakeEntry("Speed2", "100", "999", conflict: false));
+
+        vm.Count.Should().Be(2);
+        vm.HasEntries.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Clear_EmptiesEntries()
+    {
+        var vm = new BulkPreviewViewModel(() => "999");
+        vm.Add(MakeEntry("Speed1", "100", "999", conflict: false));
+
+        vm.Clear();
+
+        vm.Entries.Should().BeEmpty();
+        vm.HasEntries.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ConflictCount_CountsRowsWithPendingConflictFlag()
+    {
+        var vm = new BulkPreviewViewModel(() => "999");
+        vm.Add(MakeEntry("A", "100", "999", conflict: false));
+        vm.Add(MakeEntry("B", "100", "999", conflict: true));
+        vm.Add(MakeEntry("C", "100", "999", conflict: true));
+
+        vm.ConflictCount.Should().Be(2);
+        vm.HasConflict.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ConflictWarning_NoConflicts_IsEmpty()
+    {
+        var vm = new BulkPreviewViewModel(() => "");
+        vm.Add(MakeEntry("A", "0", "1", conflict: false));
+
+        vm.ConflictWarning.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ConflictWarning_SingularAndPlural()
+    {
+        var vm = new BulkPreviewViewModel(() => "");
+        vm.Add(MakeEntry("A", "0", "1", conflict: true));
+        vm.ConflictWarning.Should().Contain("1 overlap");
+
+        vm.Add(MakeEntry("B", "0", "1", conflict: true));
+        vm.ConflictWarning.Should().Contain("2 overlap");
+    }
+
+    [Fact]
+    public void Summary_Empty_IsEmpty()
+    {
+        var vm = new BulkPreviewViewModel(() => "999");
+        vm.Summary.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Summary_HomogeneousOriginals_RendersOrigToNew()
+    {
+        var vm = new BulkPreviewViewModel(() => "85");
+        vm.Add(MakeEntry("A", "42", "85", conflict: false));
+        vm.Add(MakeEntry("B", "42", "85", conflict: false));
+
+        vm.Summary.Should().Be("42 ⇢ 85");
+    }
+
+    [Fact]
+    public void Summary_HeterogeneousOriginals_RendersCountTargets()
+    {
+        var vm = new BulkPreviewViewModel(() => "85");
+        vm.Add(MakeEntry("A", "42", "85", conflict: false));
+        vm.Add(MakeEntry("B", "50", "85", conflict: false));
+        vm.Add(MakeEntry("C", "60", "85", conflict: false));
+
+        vm.Summary.Should().Be("3 targets");
+    }
+
+    [Fact]
+    public void Summary_HomogeneousButEmptyOriginal_FallsBackToCountTargets()
+    {
+        var vm = new BulkPreviewViewModel(() => "85");
+        vm.Add(MakeEntry("A", "", "85", conflict: false));
+        vm.Add(MakeEntry("B", "", "85", conflict: false));
+
+        vm.Summary.Should().Be("2 targets");
+    }
+
+    [Fact]
+    public void Summary_UsesCurrentTargetValueViaCallback()
+    {
+        string target = "85";
+        var vm = new BulkPreviewViewModel(() => target);
+        vm.Add(MakeEntry("A", "42", "85", conflict: false));
+
+        vm.Summary.Should().EndWith("85");
+
+        target = "99";
+        vm.Summary.Should().EndWith("99");
+    }
+
+    [Fact]
+    public void RaiseDerivedChanged_NotifiesAllDerivedProperties()
+    {
+        var vm = new BulkPreviewViewModel(() => "");
+        var raised = new System.Collections.Generic.List<string?>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        vm.RaiseDerivedChanged();
+
+        raised.Should().Contain(nameof(BulkPreviewViewModel.HasEntries));
+        raised.Should().Contain(nameof(BulkPreviewViewModel.Count));
+        raised.Should().Contain(nameof(BulkPreviewViewModel.Summary));
+        raised.Should().Contain(nameof(BulkPreviewViewModel.ConflictCount));
+        raised.Should().Contain(nameof(BulkPreviewViewModel.HasConflict));
+        raised.Should().Contain(nameof(BulkPreviewViewModel.ConflictWarning));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Fixtures
+    // ─────────────────────────────────────────────────────────────────────
+
+    private static BulkPreviewEntry MakeEntry(string name, string original, string preview, bool conflict)
+    {
+        var leaf = new MemberNode(name, "Int", original, $"DB.{name}", null, Array.Empty<MemberNode>());
+        var leafVm = new MemberNodeViewModel(leaf, null);
+        return new BulkPreviewEntry(leafVm, original, preview, conflict);
+    }
+}

--- a/src/BlockParam.Tests/InspectorPanelsViewModelTests.cs
+++ b/src/BlockParam.Tests/InspectorPanelsViewModelTests.cs
@@ -1,0 +1,149 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using BlockParam.UI;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Focused tests for the inspector-panel slice (#80 slice 1).
+/// </summary>
+public class InspectorPanelsViewModelTests
+{
+    [Fact]
+    public void Defaults_InspectorExpanded_AllSectionsExpanded()
+    {
+        var vm = new InspectorPanelsViewModel();
+
+        vm.IsInspectorCollapsed.Should().BeFalse();
+        vm.IsInspectorExpanded.Should().BeTrue();
+        vm.IsBulkEditExpanded.Should().BeTrue();
+        vm.IsBulkPreviewExpanded.Should().BeTrue();
+        vm.IsPendingExpanded.Should().BeTrue();
+        vm.IsIssuesExpanded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ToggleInspector_FlipsBothCollapsedAndExpanded()
+    {
+        var vm = new InspectorPanelsViewModel();
+        var raised = CapturePropertyChanges(vm);
+
+        vm.ToggleInspectorCommand.Execute(null);
+
+        vm.IsInspectorCollapsed.Should().BeTrue();
+        vm.IsInspectorExpanded.Should().BeFalse();
+        raised.Should().Contain(nameof(InspectorPanelsViewModel.IsInspectorCollapsed));
+        raised.Should().Contain(nameof(InspectorPanelsViewModel.IsInspectorExpanded));
+    }
+
+    [Fact]
+    public void ToggleInspector_TwicePerToggle_ReturnsToOriginal()
+    {
+        var vm = new InspectorPanelsViewModel();
+
+        vm.ToggleInspectorCommand.Execute(null);
+        vm.ToggleInspectorCommand.Execute(null);
+
+        vm.IsInspectorCollapsed.Should().BeFalse();
+        vm.IsInspectorExpanded.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(nameof(InspectorPanelsViewModel.IsBulkEditExpanded))]
+    [InlineData(nameof(InspectorPanelsViewModel.IsBulkPreviewExpanded))]
+    [InlineData(nameof(InspectorPanelsViewModel.IsPendingExpanded))]
+    [InlineData(nameof(InspectorPanelsViewModel.IsIssuesExpanded))]
+    public void SectionFlag_SettingSameValue_DoesNotRaisePropertyChanged(string name)
+    {
+        var vm = new InspectorPanelsViewModel();
+        var raised = CapturePropertyChanges(vm);
+
+        // Defaults are true; setting true again must be a no-op.
+        SetSectionFlag(vm, name, true);
+
+        raised.Should().NotContain(name);
+    }
+
+    [Fact]
+    public void ToggleBulkEdit_FlipsAndRaisesProperty()
+    {
+        var vm = new InspectorPanelsViewModel();
+        var raised = CapturePropertyChanges(vm);
+
+        vm.ToggleBulkEditCommand.Execute(null);
+
+        vm.IsBulkEditExpanded.Should().BeFalse();
+        raised.Should().Contain(nameof(InspectorPanelsViewModel.IsBulkEditExpanded));
+    }
+
+    [Fact]
+    public void ToggleBulkPreview_FlipsAndRaisesProperty()
+    {
+        var vm = new InspectorPanelsViewModel();
+        var raised = CapturePropertyChanges(vm);
+
+        vm.ToggleBulkPreviewCommand.Execute(null);
+
+        vm.IsBulkPreviewExpanded.Should().BeFalse();
+        raised.Should().Contain(nameof(InspectorPanelsViewModel.IsBulkPreviewExpanded));
+    }
+
+    [Fact]
+    public void TogglePending_FlipsAndRaisesProperty()
+    {
+        var vm = new InspectorPanelsViewModel();
+        var raised = CapturePropertyChanges(vm);
+
+        vm.TogglePendingCommand.Execute(null);
+
+        vm.IsPendingExpanded.Should().BeFalse();
+        raised.Should().Contain(nameof(InspectorPanelsViewModel.IsPendingExpanded));
+    }
+
+    [Fact]
+    public void ToggleIssues_FlipsAndRaisesProperty()
+    {
+        var vm = new InspectorPanelsViewModel();
+        var raised = CapturePropertyChanges(vm);
+
+        vm.ToggleIssuesCommand.Execute(null);
+
+        vm.IsIssuesExpanded.Should().BeFalse();
+        raised.Should().Contain(nameof(InspectorPanelsViewModel.IsIssuesExpanded));
+    }
+
+    [Fact]
+    public void IsInspectorCollapsed_SettingSameValue_DoesNotRaise()
+    {
+        var vm = new InspectorPanelsViewModel();
+        var raised = CapturePropertyChanges(vm);
+
+        vm.IsInspectorCollapsed = false; // already the default
+
+        raised.Should().BeEmpty();
+    }
+
+    private static List<string?> CapturePropertyChanges(INotifyPropertyChanged vm)
+    {
+        var raised = new List<string?>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        return raised;
+    }
+
+    private static void SetSectionFlag(InspectorPanelsViewModel vm, string name, bool value)
+    {
+        switch (name)
+        {
+            case nameof(InspectorPanelsViewModel.IsBulkEditExpanded):
+                vm.IsBulkEditExpanded = value; break;
+            case nameof(InspectorPanelsViewModel.IsBulkPreviewExpanded):
+                vm.IsBulkPreviewExpanded = value; break;
+            case nameof(InspectorPanelsViewModel.IsPendingExpanded):
+                vm.IsPendingExpanded = value; break;
+            case nameof(InspectorPanelsViewModel.IsIssuesExpanded):
+                vm.IsIssuesExpanded = value; break;
+        }
+    }
+}

--- a/src/BlockParam.Tests/PendingEditsViewModelTests.cs
+++ b/src/BlockParam.Tests/PendingEditsViewModelTests.cs
@@ -208,14 +208,18 @@ public class PendingEditsViewModelTests
         return new MemberValidator(config, null);
     }
 
-    private static MemberNodeViewModel FindLeaf(MemberNodeViewModel node, string name)
+    private static MemberNodeViewModel FindLeaf(MemberNodeViewModel node, string name) =>
+        TryFindLeaf(node, name)
+            ?? throw new InvalidOperationException($"Leaf '{name}' not found");
+
+    private static MemberNodeViewModel? TryFindLeaf(MemberNodeViewModel node, string name)
     {
         if (node.Name == name && node.IsLeaf) return node;
         foreach (var c in node.Children)
         {
-            var found = FindLeaf(c, name);
+            var found = TryFindLeaf(c, name);
             if (found != null) return found;
         }
-        throw new InvalidOperationException($"Leaf '{name}' not found");
+        return null;
     }
 }

--- a/src/BlockParam.Tests/PendingEditsViewModelTests.cs
+++ b/src/BlockParam.Tests/PendingEditsViewModelTests.cs
@@ -1,0 +1,221 @@
+using System.Linq;
+using BlockParam.Config;
+using BlockParam.Models;
+using BlockParam.Services;
+using BlockParam.UI;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Focused tests for the pending-edits slice (#80 slice 4).
+/// </summary>
+public class PendingEditsViewModelTests
+{
+    [Fact]
+    public void Defaults_AreEmpty()
+    {
+        var vm = new PendingEditsViewModel(() => 0);
+
+        vm.PendingEdits.Should().BeEmpty();
+        vm.ExistingIssues.Should().BeEmpty();
+        vm.HasPendingEdits.Should().BeFalse();
+        vm.HasExistingIssues.Should().BeFalse();
+        vm.PendingInlineEditCount.Should().Be(0);
+        vm.PendingStatusText.Should().BeNull();
+        vm.InvalidPendingCount.Should().Be(0);
+        vm.HasInvalidPending.Should().BeFalse();
+        vm.InvalidPendingBadge.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void PendingInlineEditCount_DelegatesToCallback()
+    {
+        int count = 7;
+        var vm = new PendingEditsViewModel(() => count);
+
+        vm.PendingInlineEditCount.Should().Be(7);
+
+        count = 3;
+        vm.PendingInlineEditCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void PendingStatusText_FormatsWithCount()
+    {
+        int count = 0;
+        var vm = new PendingEditsViewModel(() => count);
+
+        count = 1;
+        vm.PendingStatusText.Should().Be("1 pending inline edit");
+
+        count = 5;
+        vm.PendingStatusText.Should().Be("5 pending inline edits");
+    }
+
+    [Fact]
+    public void Rebuild_CollectsPendingNodesFromTree()
+    {
+        var root = BuildTree();
+        // Stage two pending edits.
+        var speed = FindLeaf(root, "Speed");
+        var pressure = FindLeaf(root, "Pressure");
+        speed.EditableStartValue = "999";
+        pressure.EditableStartValue = "42";
+
+        var vm = new PendingEditsViewModel(() => 2);
+        vm.Rebuild(new[] { root }, bulkPaths: null);
+
+        vm.PendingEdits.Should().HaveCount(2);
+        vm.HasPendingEdits.Should().BeTrue();
+        vm.PendingEdits.Select(e => e.Node.Path).Should().Contain(speed.Path, pressure.Path);
+    }
+
+    [Fact]
+    public void Rebuild_MarksOverwrittenByBulkWhenPathInBulkSet()
+    {
+        var root = BuildTree();
+        var speed = FindLeaf(root, "Speed");
+        speed.EditableStartValue = "999";
+
+        var vm = new PendingEditsViewModel(() => 1);
+        vm.Rebuild(new[] { root }, bulkPaths: new System.Collections.Generic.HashSet<string> { speed.Path });
+
+        vm.PendingEdits.Should().ContainSingle()
+            .Which.WillBeOverwrittenByBulk.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Rebuild_ClearsBeforeRepopulating()
+    {
+        var root = BuildTree();
+        var speed = FindLeaf(root, "Speed");
+        speed.EditableStartValue = "999";
+
+        var vm = new PendingEditsViewModel(() => 1);
+        vm.Rebuild(new[] { root }, null);
+        vm.PendingEdits.Should().HaveCount(1);
+
+        // Drop the pending edit and rebuild — collection must reflect it.
+        speed.ClearPending();
+        vm.Rebuild(new[] { root }, null);
+
+        vm.PendingEdits.Should().BeEmpty();
+        vm.HasPendingEdits.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RebuildExistingIssues_FlagsLeavesViolatingValidator()
+    {
+        var root = BuildTreeForValidation();
+        var validator = BuildValidatorWithSpeedMax();
+
+        var vm = new PendingEditsViewModel(() => 0);
+        vm.RebuildExistingIssues(new[] { root }, validator);
+
+        vm.ExistingIssues.Should().HaveCount(1);
+        vm.HasExistingIssues.Should().BeTrue();
+        vm.ExistingIssuesCount.Should().Be(1);
+        vm.ExistingIssues.Single().Node.Name.Should().Be("Speed");
+        vm.ExistingIssues.Single().Node.HasExistingViolation.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RebuildExistingIssues_ClearsPriorViolationsWhenValueNowValid()
+    {
+        var root = BuildTreeForValidation();
+        var leaf = FindLeaf(root, "Speed");
+
+        // Initial scan with strict validator: Speed=1500 violates max=1000.
+        var strict = BuildValidatorWithSpeedMax();
+        var vm = new PendingEditsViewModel(() => 0);
+        vm.RebuildExistingIssues(new[] { root }, strict);
+        leaf.HasExistingViolation.Should().BeTrue();
+
+        // Permissive validator: no rule → no violation.
+        var lenient = new MemberValidator(null, null);
+        vm.RebuildExistingIssues(new[] { root }, lenient);
+
+        leaf.HasExistingViolation.Should().BeFalse();
+        vm.ExistingIssues.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RaisePendingCountChanged_NotifiesCountAndStatus()
+    {
+        int count = 0;
+        var vm = new PendingEditsViewModel(() => count);
+        var raised = new System.Collections.Generic.List<string?>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        count = 4;
+        vm.RaisePendingCountChanged();
+
+        raised.Should().Contain(nameof(PendingEditsViewModel.PendingInlineEditCount));
+        raised.Should().Contain(nameof(PendingEditsViewModel.PendingStatusText));
+    }
+
+    [Fact]
+    public void RaiseInvalidPendingChanged_NotifiesBadgeAndCount()
+    {
+        var vm = new PendingEditsViewModel(() => 0);
+        var raised = new System.Collections.Generic.List<string?>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        vm.RaiseInvalidPendingChanged();
+
+        raised.Should().Contain(nameof(PendingEditsViewModel.InvalidPendingCount));
+        raised.Should().Contain(nameof(PendingEditsViewModel.HasInvalidPending));
+        raised.Should().Contain(nameof(PendingEditsViewModel.InvalidPendingBadge));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Fixtures
+    // ─────────────────────────────────────────────────────────────────────
+
+    private static MemberNodeViewModel BuildTree()
+    {
+        var speed = new MemberNode("Speed", "Int", "100", "Root.Speed", null, Array.Empty<MemberNode>());
+        var pressure = new MemberNode("Pressure", "Int", "10", "Root.Pressure", null, Array.Empty<MemberNode>());
+        var root = new MemberNode("Root", "Struct", null, "Root", null, new[] { speed, pressure });
+        return new MemberNodeViewModel(root, null);
+    }
+
+    private static MemberNodeViewModel BuildTreeForValidation()
+    {
+        // Speed exceeds the rule's max (see BuildValidatorWithSpeedMax).
+        var speed = new MemberNode("Speed", "Int", "1500", "Root.Speed", null, Array.Empty<MemberNode>());
+        var ok = new MemberNode("Within", "Int", "50", "Root.Within", null, Array.Empty<MemberNode>());
+        var root = new MemberNode("Root", "Struct", null, "Root", null, new[] { speed, ok });
+        return new MemberNodeViewModel(root, null);
+    }
+
+    private static MemberValidator BuildValidatorWithSpeedMax()
+    {
+        // Build a config with a rule capping Speed to 1000.
+        var config = new BulkChangeConfig
+        {
+            Rules = new System.Collections.Generic.List<MemberRule>
+            {
+                new MemberRule
+                {
+                    PathPattern = @".*\.Speed$",
+                    Constraints = new ValueConstraint { Min = 0, Max = 1000 },
+                }
+            }
+        };
+        return new MemberValidator(config, null);
+    }
+
+    private static MemberNodeViewModel FindLeaf(MemberNodeViewModel node, string name)
+    {
+        if (node.Name == name && node.IsLeaf) return node;
+        foreach (var c in node.Children)
+        {
+            var found = FindLeaf(c, name);
+            if (found != null) return found;
+        }
+        throw new InvalidOperationException($"Leaf '{name}' not found");
+    }
+}

--- a/src/BlockParam.Tests/SubscriptionViewModelTests.cs
+++ b/src/BlockParam.Tests/SubscriptionViewModelTests.cs
@@ -1,0 +1,253 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Threading;
+using BlockParam.Config;
+using BlockParam.Licensing;
+using BlockParam.UI;
+using BlockParam.Updates;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Focused tests for the subscription slice (#80 slice 2).
+/// </summary>
+public class SubscriptionViewModelTests
+{
+    [Fact]
+    public void UpdateUsageStatus_FreeTier_ShowsRemainingQuota()
+    {
+        var (vm, _, _, _, _) = CreateVm(used: 30, limit: 200, isPro: false);
+
+        vm.UpdateUsageStatus();
+
+        vm.UsageStatusText.Should().Contain("170");
+        vm.UsageStatusText.Should().Contain("200");
+        vm.LicenseTierText.Should().NotBeEmpty();
+        vm.IsLimitReached.Should().BeFalse();
+    }
+
+    [Fact]
+    public void UpdateUsageStatus_Pro_ShowsProBranding()
+    {
+        var (vm, _, _, _, _) = CreateVm(used: 0, limit: 200, isPro: true);
+
+        vm.UpdateUsageStatus();
+
+        vm.IsProActive.Should().BeTrue();
+        vm.LicenseTierText.Should().NotBeEmpty();
+        // Pro should not show a remaining-quota string with the daily-limit number.
+        vm.UsageStatusText.Should().NotContain("/200");
+    }
+
+    [Fact]
+    public void UpdateUsageStatus_FiresStateChanged()
+    {
+        var (vm, _, _, _, _) = CreateVm(used: 0, limit: 200, isPro: false);
+
+        int stateChangedCount = 0;
+        vm.StateChanged += () => stateChangedCount++;
+
+        vm.UpdateUsageStatus();
+
+        stateChangedCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void MaybeWarnLimitReachedOnce_BelowLimit_DoesNothing()
+    {
+        var (vm, _, _, _, msg) = CreateVm(used: 100, limit: 200, isPro: false);
+
+        vm.MaybeWarnLimitReachedOnce();
+
+        msg.InfoShownCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void MaybeWarnLimitReachedOnce_AtLimit_ShowsOncePerInstance()
+    {
+        var (vm, _, _, _, msg) = CreateVm(used: 200, limit: 200, isPro: false);
+
+        vm.MaybeWarnLimitReachedOnce();
+        vm.MaybeWarnLimitReachedOnce();
+        vm.MaybeWarnLimitReachedOnce();
+
+        msg.InfoShownCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void RecordUsage_Delegates_ToTracker()
+    {
+        var (vm, _, tracker, _, _) = CreateVm(used: 0, limit: 200, isPro: false);
+
+        var ok = vm.RecordUsage(5);
+
+        ok.Should().BeTrue();
+        tracker.RecordedTotal.Should().Be(5);
+    }
+
+    [Fact]
+    public void RecordUsage_OverLimit_ReturnsFalseAndDoesNotIncrement()
+    {
+        var (vm, _, tracker, _, _) = CreateVm(used: 198, limit: 200, isPro: false);
+
+        var ok = vm.RecordUsage(5);
+
+        ok.Should().BeFalse();
+        tracker.RecordedTotal.Should().Be(0);
+    }
+
+    [Fact]
+    public void InitializeUpdateCheck_NoService_NoBadge()
+    {
+        var (vm, _, _, _, _) = CreateVm(used: 0, limit: 200, isPro: false, updateService: null);
+
+        vm.InitializeUpdateCheck(forceRefresh: false);
+
+        vm.HasUpdateAvailable.Should().BeFalse();
+        vm.AvailableUpdate.Should().BeNull();
+        vm.UpdateBadgeText.Should().BeEmpty();
+        vm.UpdateBadgeTooltip.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void InitializeUpdateCheck_WithCachedRelease_PopulatesBadge()
+    {
+        var info = new UpdateInfo { TagName = "v9.9.9", Name = "Great release" };
+        var update = new StubUpdateService(cached: info);
+        var (vm, _, _, _, _) = CreateVm(used: 0, limit: 200, isPro: false, updateService: update);
+
+        vm.InitializeUpdateCheck(forceRefresh: false);
+
+        vm.HasUpdateAvailable.Should().BeTrue();
+        vm.AvailableUpdate.Should().Be(info);
+        vm.UpdateBadgeText.Should().Contain("9.9.9");
+        vm.UpdateBadgeTooltip.Should().Contain("Great release");
+    }
+
+    [Fact]
+    public void Dispose_UnsubscribesFromLicenseStateChanged()
+    {
+        var license = new RecordingLicenseService();
+        var (vm, _, _, _, _) = CreateVm(used: 0, limit: 200, isPro: false, license: license);
+
+        license.SubscriberCount.Should().Be(1, "ctor subscribes the handler");
+
+        vm.Dispose();
+        vm.Dispose(); // idempotent
+
+        license.SubscriberCount.Should().Be(0);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Fixtures
+    // ─────────────────────────────────────────────────────────────────────
+
+    private static (SubscriptionViewModel vm,
+        StubLicenseService license,
+        StubUsageTracker tracker,
+        StubUpdateService? update,
+        SpyMessageBox msg) CreateVm(
+        int used,
+        int limit,
+        bool isPro,
+        IUpdateCheckService? updateService = null,
+        ILicenseService? license = null)
+    {
+        var lic = license ?? new StubLicenseService(isPro);
+        var tracker = new StubUsageTracker(used, limit);
+        var upd = updateService;
+        var msg = new SpyMessageBox();
+        var vm = new SubscriptionViewModel(
+            tracker, lic, upd,
+            new ConfigLoader(null), msg, Dispatcher.CurrentDispatcher);
+        return (vm,
+            lic as StubLicenseService ?? new StubLicenseService(isPro),
+            tracker,
+            upd as StubUpdateService,
+            msg);
+    }
+
+    private sealed class StubLicenseService : ILicenseService
+    {
+        public StubLicenseService(bool isPro) { IsProActive = isPro; }
+        public LicenseInfo GetLicenseInfo() => new LicenseInfo { Tier = LicenseTier.Free };
+        public LicenseTier CurrentTier => IsProActive ? LicenseTier.Pro : LicenseTier.Free;
+        public bool IsProActive { get; }
+        public Task<LicenseActivationResult> ActivateKeyAsync(string licenseKey)
+            => Task.FromResult(LicenseActivationResult.InvalidKey("stub"));
+        public void DeactivateKey() { }
+        public void StartHeartbeat() { }
+        public void StopHeartbeat() { }
+        public event EventHandler? LicenseStateChanged;
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// Stub that exposes a subscriber-count so Dispose tests can verify the
+    /// VM unsubscribes from <see cref="ILicenseService.LicenseStateChanged"/>.
+    /// </summary>
+    private sealed class RecordingLicenseService : ILicenseService
+    {
+        public int SubscriberCount { get; private set; }
+        public event EventHandler? LicenseStateChanged
+        {
+            add { SubscriberCount++; }
+            remove { SubscriberCount--; }
+        }
+        public LicenseInfo GetLicenseInfo() => new LicenseInfo { Tier = LicenseTier.Free };
+        public LicenseTier CurrentTier => LicenseTier.Free;
+        public bool IsProActive => false;
+        public Task<LicenseActivationResult> ActivateKeyAsync(string licenseKey)
+            => Task.FromResult(LicenseActivationResult.InvalidKey("stub"));
+        public void DeactivateKey() { }
+        public void StartHeartbeat() { }
+        public void StopHeartbeat() { }
+        public void Dispose() { }
+    }
+
+    private sealed class StubUsageTracker : IUsageTracker
+    {
+        private int _used;
+        public StubUsageTracker(int used, int limit)
+        {
+            _used = used;
+            DailyLimit = limit;
+        }
+        public int DailyLimit { get; }
+        public int RecordedTotal { get; private set; }
+        public UsageStatus GetStatus() => new UsageStatus(_used, DailyLimit);
+        public bool RecordUsage(int count)
+        {
+            if (_used + count > DailyLimit) return false;
+            _used += count;
+            RecordedTotal += count;
+            return true;
+        }
+    }
+
+    private sealed class StubUpdateService : IUpdateCheckService
+    {
+        private readonly UpdateInfo? _cached;
+        public StubUpdateService(UpdateInfo? cached) { _cached = cached; }
+        public UpdateInfo? GetCached() => _cached;
+        public Task<UpdateInfo?> CheckAsync(CancellationToken ct = default)
+            => Task.FromResult<UpdateInfo?>(_cached);
+    }
+
+    private sealed class SpyMessageBox : IMessageBoxService
+    {
+        public int InfoShownCount { get; private set; }
+        public bool AskYesNo(string message, string title) => false;
+        public void ShowError(string message, string title) { }
+        public void ShowInfo(string message, string title) { InfoShownCount++; }
+        public ApplyStashCancelResult AskApplyStashCancel(string message, string title)
+            => ApplyStashCancelResult.Cancel;
+        public AddOrReplaceResult AskAddOrReplace(string message, string title)
+            => AddOrReplaceResult.Cancel;
+        public CloseWithStashResult AskCloseWithStash(string message, string title)
+            => CloseWithStashResult.Cancel;
+    }
+}

--- a/src/BlockParam.Tests/SubscriptionViewModelTests.cs
+++ b/src/BlockParam.Tests/SubscriptionViewModelTests.cs
@@ -181,7 +181,9 @@ public class SubscriptionViewModelTests
         public void DeactivateKey() { }
         public void StartHeartbeat() { }
         public void StopHeartbeat() { }
-        public event EventHandler? LicenseStateChanged;
+        // Manual add/remove avoids CS0067 ("event never used") — the SUT
+        // subscribes via `+=` but never invokes; auto-impl flags as unused.
+        public event EventHandler? LicenseStateChanged { add { } remove { } }
         public void Dispose() { }
     }
 

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -697,6 +697,21 @@ Examples: en-US, de-DE. Leave empty for the default language.</value>
   <data name="Pending_InvalidBadgeTooltip" xml:space="preserve">
     <value>Fix or undo invalid entries before applying.</value>
   </data>
+  <data name="Pending_StatusText_Singular" xml:space="preserve">
+    <value>{0} pending inline edit</value>
+    <comment>{0} = count (always 1)</comment>
+  </data>
+  <data name="Pending_StatusText_Plural" xml:space="preserve">
+    <value>{0} pending inline edits</value>
+    <comment>{0} = count (&gt; 1)</comment>
+  </data>
+  <data name="BulkPreview_ConflictWarning_Singular" xml:space="preserve">
+    <value>⚠ 1 overlap with pending edits — will be overwritten.</value>
+  </data>
+  <data name="BulkPreview_ConflictWarning_Plural" xml:space="preserve">
+    <value>⚠ {0} overlap with pending edits — will be overwritten.</value>
+    <comment>{0} = overlap count (&gt; 1). Wording preserved verbatim from inline string (#80 slice 5).</comment>
+  </data>
   <!-- Existing-value validator findings (#26) -->
   <data name="Issues_Header" xml:space="preserve">
     <value>ISSUES</value>

--- a/src/BlockParam/UI/AutocompleteViewModel.cs
+++ b/src/BlockParam/UI/AutocompleteViewModel.cs
@@ -1,0 +1,160 @@
+using System.Collections.Generic;
+using System.Linq;
+using BlockParam.Services;
+
+namespace BlockParam.UI;
+
+/// <summary>
+/// Autocomplete suggestion slice (#80 slice 3).
+///
+/// <para>
+/// Data holder for the inline-autocomplete overlay: the full candidate
+/// pool, the currently-displayed filtered subset, and the glob provider
+/// used by per-row inline matching. Owns the term-matching logic
+/// (previously duplicated across four host-VM methods).
+/// </para>
+///
+/// <para>
+/// The host VM keeps the public methods that compose with non-slice
+/// state (<c>AcceptSuggestion</c> mutates <c>NewValue</c>;
+/// <c>GetSuggestionsForMember</c> reads tag-table cache + config rules;
+/// <c>ReloadSuggestions</c> reads the selected member). Those methods
+/// drive the slice via <see cref="SetCandidates"/> /
+/// <see cref="ClearFiltered"/> / <see cref="ApplyFilter"/> /
+/// <see cref="ShowAll"/> / <see cref="Toggle"/>.
+/// </para>
+/// </summary>
+public class AutocompleteViewModel : ViewModelBase
+{
+    private GlobSuggestionProvider? _suggestionProvider;
+    private IReadOnlyList<AutocompleteSuggestion> _suggestions = Array.Empty<AutocompleteSuggestion>();
+    private IReadOnlyList<AutocompleteSuggestion> _filteredSuggestions = Array.Empty<AutocompleteSuggestion>();
+    private bool _suppressSuggestions;
+
+    /// <summary>Suggestion provider for glob-based per-row matching (null = no suggestions).</summary>
+    public GlobSuggestionProvider? SuggestionProvider
+    {
+        get => _suggestionProvider;
+        private set => SetProperty(ref _suggestionProvider, value);
+    }
+
+    /// <summary>Full candidate pool for the currently-selected member.</summary>
+    public IReadOnlyList<AutocompleteSuggestion> Suggestions
+    {
+        get => _suggestions;
+        private set => SetProperty(ref _suggestions, value);
+    }
+
+    /// <summary>Filtered subset currently rendered in the overlay.</summary>
+    public IReadOnlyList<AutocompleteSuggestion> FilteredSuggestions
+    {
+        get => _filteredSuggestions;
+        private set
+        {
+            if (SetProperty(ref _filteredSuggestions, value))
+                OnPropertyChanged(nameof(HasFilteredSuggestions));
+        }
+    }
+
+    public bool HasFilteredSuggestions => _filteredSuggestions.Count > 0;
+
+    /// <summary>
+    /// When true, <see cref="ApplyFilter"/> short-circuits to empty —
+    /// host sets this around bulk-edit operations that would otherwise
+    /// re-open the overlay.
+    /// </summary>
+    public bool SuppressSuggestions
+    {
+        get => _suppressSuggestions;
+        set => _suppressSuggestions = value;
+    }
+
+    /// <summary>
+    /// Replace the candidate pool. Clears the visible filtered list as a
+    /// side effect — callers that want the overlay re-rendered should
+    /// follow with <see cref="ApplyFilter"/> / <see cref="ShowAll"/>.
+    /// </summary>
+    public void SetCandidates(
+        IReadOnlyList<AutocompleteSuggestion> suggestions,
+        GlobSuggestionProvider? provider)
+    {
+        Suggestions = suggestions;
+        SuggestionProvider = provider;
+        FilteredSuggestions = Array.Empty<AutocompleteSuggestion>();
+    }
+
+    /// <summary>Clear the candidate pool and any rendered filter.</summary>
+    public void ClearCandidates()
+    {
+        Suggestions = Array.Empty<AutocompleteSuggestion>();
+        SuggestionProvider = null;
+        FilteredSuggestions = Array.Empty<AutocompleteSuggestion>();
+    }
+
+    /// <summary>Hide the overlay without touching the candidate pool.</summary>
+    public void ClearFiltered() =>
+        FilteredSuggestions = Array.Empty<AutocompleteSuggestion>();
+
+    /// <summary>
+    /// Re-render the filtered overlay from the current candidate pool +
+    /// the given filter text. Empty filter when the user clears the
+    /// textbox keeps the overlay open if it was already open; an empty
+    /// pool or <see cref="SuppressSuggestions"/> hides the overlay.
+    /// </summary>
+    public void ApplyFilter(string filter)
+    {
+        if (_suggestions.Count == 0 || _suppressSuggestions)
+        {
+            FilteredSuggestions = Array.Empty<AutocompleteSuggestion>();
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(filter))
+        {
+            FilteredSuggestions = Array.Empty<AutocompleteSuggestion>();
+            return;
+        }
+
+        FilteredSuggestions = Match(_suggestions, filter);
+    }
+
+    /// <summary>Open the overlay (showing all when filter is empty).</summary>
+    public void ShowAll(string filter)
+    {
+        if (_suggestions.Count == 0) return;
+        FilteredSuggestions = string.IsNullOrEmpty(filter)
+            ? _suggestions.ToList()
+            : Match(_suggestions, filter);
+    }
+
+    /// <summary>Toggle the overlay: hide if open, open with filter otherwise.</summary>
+    public void Toggle(string filter)
+    {
+        if (_filteredSuggestions.Count > 0)
+        {
+            FilteredSuggestions = Array.Empty<AutocompleteSuggestion>();
+            return;
+        }
+        ShowAll(filter);
+    }
+
+    /// <summary>
+    /// Term-matching shared by overlay filters and per-row inline lookup
+    /// (<c>BulkChangeViewModel.GetSuggestionsForMember</c>). All space-
+    /// separated terms must match somewhere in DisplayName / Value /
+    /// Comment, case-insensitive.
+    /// </summary>
+    public static IReadOnlyList<AutocompleteSuggestion> Match(
+        IEnumerable<AutocompleteSuggestion> source, string filter)
+    {
+        if (string.IsNullOrWhiteSpace(filter))
+            return source as IReadOnlyList<AutocompleteSuggestion> ?? source.ToList();
+
+        var terms = filter.Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+        return source.Where(s => terms.All(term =>
+            s.DisplayName.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0 ||
+            s.Value.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0 ||
+            (s.Comment != null && s.Comment.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0)))
+            .ToList();
+    }
+}

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -151,7 +151,7 @@
                         VerticalAlignment="Center" FontWeight="SemiBold"/>
                 <Button Content="{loc:Loc Dialog_Discard}" Command="{Binding DiscardPendingCommand}"
                         MinWidth="60" Height="26" Margin="0,0,4,0" Padding="8,0"
-                        Visibility="{Binding PendingStatusText, Converter={StaticResource NullToVis}}"/>
+                        Visibility="{Binding Pending.PendingStatusText, Converter={StaticResource NullToVis}}"/>
                 <Button x:Name="ApplyButton"
                         Content="{loc:Loc Dialog_Apply}" Command="{Binding ApplyCommand}"
                         MinWidth="70" Height="26" Margin="0,0,4,0" Padding="8,0"
@@ -165,9 +165,9 @@
                 <Button Content="{loc:Loc Dialog_Close}" Click="OnClose"
                         MinWidth="60" Height="26" Padding="8,0"/>
             </StackPanel>
-            <TextBlock Text="{Binding PendingStatusText}" FontSize="10"
+            <TextBlock Text="{Binding Pending.PendingStatusText}" FontSize="10"
                        Foreground="#B8860B" VerticalAlignment="Center"
-                       Visibility="{Binding PendingStatusText, Converter={StaticResource NullToVis}}"
+                       Visibility="{Binding Pending.PendingStatusText, Converter={StaticResource NullToVis}}"
                        Margin="0,0,8,0"/>
             <TextBlock Text="{Binding StatusText}" VerticalAlignment="Center"
                        Foreground="#333"/>
@@ -668,8 +668,8 @@
                                     HorizontalAlignment="Right" VerticalAlignment="Top"
                                     Padding="3,0" Margin="0,-2,-2,0"
                                     IsHitTestVisible="False"
-                                    Visibility="{Binding HasPendingEdits, Converter={StaticResource BoolToVis}}">
-                                <TextBlock Text="{Binding PendingInlineEditCount}" FontSize="8"
+                                    Visibility="{Binding Pending.HasPendingEdits, Converter={StaticResource BoolToVis}}">
+                                <TextBlock Text="{Binding Pending.PendingInlineEditCount}" FontSize="8"
                                            FontWeight="Bold" Foreground="White"
                                            HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Border>
@@ -688,8 +688,8 @@
                                     HorizontalAlignment="Right" VerticalAlignment="Top"
                                     Padding="3,0" Margin="0,-2,-2,0"
                                     IsHitTestVisible="False"
-                                    Visibility="{Binding HasExistingIssues, Converter={StaticResource BoolToVis}}">
-                                <TextBlock Text="{Binding ExistingIssuesCount}" FontSize="8"
+                                    Visibility="{Binding Pending.HasExistingIssues, Converter={StaticResource BoolToVis}}">
+                                <TextBlock Text="{Binding Pending.ExistingIssuesCount}" FontSize="8"
                                            FontWeight="Bold" Foreground="White"
                                            HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Border>
@@ -1120,8 +1120,8 @@
                                     <Border DockPanel.Dock="Left" Margin="6,0,0,0" Padding="5,0"
                                             Background="#e0a93a" CornerRadius="8"
                                             VerticalAlignment="Center"
-                                            Visibility="{Binding HasPendingEdits, Converter={StaticResource BoolToVis}}">
-                                        <TextBlock Text="{Binding PendingInlineEditCount}"
+                                            Visibility="{Binding Pending.HasPendingEdits, Converter={StaticResource BoolToVis}}">
+                                        <TextBlock Text="{Binding Pending.PendingInlineEditCount}"
                                                    FontSize="10" FontWeight="Bold" Foreground="White"/>
                                     </Border>
                                     <!-- Invalid-count badge (#11): appears when any pending entry fails validation. -->
@@ -1129,8 +1129,8 @@
                                             Background="#D32F2F" CornerRadius="8"
                                             VerticalAlignment="Center"
                                             ToolTip="{loc:Loc Pending_InvalidBadgeTooltip}"
-                                            Visibility="{Binding HasInvalidPending, Converter={StaticResource BoolToVis}}">
-                                        <TextBlock Text="{Binding InvalidPendingBadge}"
+                                            Visibility="{Binding Pending.HasInvalidPending, Converter={StaticResource BoolToVis}}">
+                                        <TextBlock Text="{Binding Pending.InvalidPendingBadge}"
                                                    FontSize="10" FontWeight="Bold" Foreground="White"/>
                                     </Border>
                                     <Button DockPanel.Dock="Right" HorizontalAlignment="Right"
@@ -1140,7 +1140,7 @@
                                             Foreground="#0b4fbf" Cursor="Hand"
                                             FontSize="10" FontWeight="SemiBold"
                                             Padding="4,0" Margin="0,0,8,0"
-                                            Visibility="{Binding HasPendingEdits, Converter={StaticResource BoolToVis}}"/>
+                                            Visibility="{Binding Pending.HasPendingEdits, Converter={StaticResource BoolToVis}}"/>
                                 </DockPanel>
                             </Border>
                             <!-- Empty state -->
@@ -1152,7 +1152,7 @@
                                             <MultiDataTrigger>
                                                 <MultiDataTrigger.Conditions>
                                                     <Condition Binding="{Binding Inspector.IsPendingExpanded}" Value="True"/>
-                                                    <Condition Binding="{Binding HasPendingEdits}" Value="False"/>
+                                                    <Condition Binding="{Binding Pending.HasPendingEdits}" Value="False"/>
                                                 </MultiDataTrigger.Conditions>
                                                 <Setter Property="Visibility" Value="Visible"/>
                                             </MultiDataTrigger>
@@ -1165,7 +1165,7 @@
                             </Border>
                             <!-- List -->
                             <ItemsControl x:Name="PendingEditsList"
-                                          ItemsSource="{Binding PendingEdits}"
+                                          ItemsSource="{Binding Pending.PendingEdits}"
                                           Background="White">
                                 <ItemsControl.Style>
                                     <Style TargetType="ItemsControl">
@@ -1174,7 +1174,7 @@
                                             <MultiDataTrigger>
                                                 <MultiDataTrigger.Conditions>
                                                     <Condition Binding="{Binding Inspector.IsPendingExpanded}" Value="True"/>
-                                                    <Condition Binding="{Binding HasPendingEdits}" Value="True"/>
+                                                    <Condition Binding="{Binding Pending.HasPendingEdits}" Value="True"/>
                                                 </MultiDataTrigger.Conditions>
                                                 <Setter Property="Visibility" Value="Visible"/>
                                             </MultiDataTrigger>
@@ -1450,8 +1450,8 @@
                                     <Border DockPanel.Dock="Left" Margin="6,0,0,0" Padding="5,0"
                                             Background="#9C27B0" CornerRadius="8"
                                             VerticalAlignment="Center"
-                                            Visibility="{Binding HasExistingIssues, Converter={StaticResource BoolToVis}}">
-                                        <TextBlock Text="{Binding ExistingIssuesCount}"
+                                            Visibility="{Binding Pending.HasExistingIssues, Converter={StaticResource BoolToVis}}">
+                                        <TextBlock Text="{Binding Pending.ExistingIssuesCount}"
                                                    FontSize="10" FontWeight="Bold" Foreground="White"/>
                                     </Border>
                                     <!-- Filler to consume remaining space (avoids the icon's tooltip
@@ -1468,7 +1468,7 @@
                                             <MultiDataTrigger>
                                                 <MultiDataTrigger.Conditions>
                                                     <Condition Binding="{Binding Inspector.IsIssuesExpanded}" Value="True"/>
-                                                    <Condition Binding="{Binding HasExistingIssues}" Value="False"/>
+                                                    <Condition Binding="{Binding Pending.HasExistingIssues}" Value="False"/>
                                                 </MultiDataTrigger.Conditions>
                                                 <Setter Property="Visibility" Value="Visible"/>
                                             </MultiDataTrigger>
@@ -1481,7 +1481,7 @@
                             </Border>
                             <!-- List -->
                             <ItemsControl x:Name="ExistingIssuesList"
-                                          ItemsSource="{Binding ExistingIssues}"
+                                          ItemsSource="{Binding Pending.ExistingIssues}"
                                           Background="White">
                                 <ItemsControl.Style>
                                     <Style TargetType="ItemsControl">
@@ -1490,7 +1490,7 @@
                                             <MultiDataTrigger>
                                                 <MultiDataTrigger.Conditions>
                                                     <Condition Binding="{Binding Inspector.IsIssuesExpanded}" Value="True"/>
-                                                    <Condition Binding="{Binding HasExistingIssues}" Value="True"/>
+                                                    <Condition Binding="{Binding Pending.HasExistingIssues}" Value="True"/>
                                                 </MultiDataTrigger.Conditions>
                                                 <Setter Property="Visibility" Value="Visible"/>
                                             </MultiDataTrigger>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -847,8 +847,8 @@
                                                  below the TextBox inside the sidebar column. -->
                                             <Border Background="White" BorderBrush="#CCC" BorderThickness="1"
                                                     MaxHeight="250" Margin="0,-1,0,0"
-                                                    Visibility="{Binding HasFilteredSuggestions, Converter={StaticResource BoolToVis}}">
-                                                <ListBox ItemsSource="{Binding FilteredSuggestions}"
+                                                    Visibility="{Binding Autocomplete.HasFilteredSuggestions, Converter={StaticResource BoolToVis}}">
+                                                <ListBox ItemsSource="{Binding Autocomplete.FilteredSuggestions}"
                                                          MaxHeight="250" BorderThickness="0"
                                                          VirtualizingStackPanel.IsVirtualizing="True"
                                                          ItemContainerStyle="{StaticResource SuggestionItemStyle}"

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -128,24 +128,24 @@
                 <!-- Update-available badge (#61). Hidden until the async
                      check resolves with a newer release; clicking opens the
                      details popup with changelog + "Open download page". -->
-                <Button Content="{Binding UpdateBadgeText}" FontSize="10"
-                        Command="{Binding ShowUpdateDetailsCommand}"
-                        Visibility="{Binding HasUpdateAvailable, Converter={StaticResource BoolToVis}}"
+                <Button Content="{Binding Subscription.UpdateBadgeText}" FontSize="10"
+                        Command="{Binding Subscription.ShowUpdateDetailsCommand}"
+                        Visibility="{Binding Subscription.HasUpdateAvailable, Converter={StaticResource BoolToVis}}"
                         Background="#FFF4DA" BorderBrush="#E0A030" BorderThickness="1"
                         Foreground="#7A5200" Cursor="Hand" Padding="6,2"
                         VerticalAlignment="Center" Margin="0,0,12,0" FontWeight="SemiBold"
-                        ToolTip="{Binding UpdateBadgeTooltip}"/>
+                        ToolTip="{Binding Subscription.UpdateBadgeTooltip}"/>
                 <!-- License / usage summary — clickable to open the license dialog.
                      Single control replaces the old tier badge + separate Manage link. -->
-                <Button Content="{Binding UsageStatusText}" FontSize="10"
-                        Command="{Binding EnterLicenseKeyCommand}"
-                        Visibility="{Binding ShowLicenseKeyButton, Converter={StaticResource BoolToVis}}"
+                <Button Content="{Binding Subscription.UsageStatusText}" FontSize="10"
+                        Command="{Binding Subscription.EnterLicenseKeyCommand}"
+                        Visibility="{Binding Subscription.ShowLicenseKeyButton, Converter={StaticResource BoolToVis}}"
                         Background="Transparent" BorderThickness="0" Foreground="#666"
                         Cursor="Hand" Padding="0" VerticalAlignment="Center" Margin="0,0,12,0"
-                        ToolTip="{Binding LicenseKeyButtonText}"/>
+                        ToolTip="{Binding Subscription.LicenseKeyButtonText}"/>
                 <Button Content="{loc:Loc License_UpgradeToPro}" FontSize="10"
-                        Command="{Binding UpgradeToProCommand}"
-                        Visibility="{Binding IsLimitReached, Converter={StaticResource BoolToVis}}"
+                        Command="{Binding Subscription.UpgradeToProCommand}"
+                        Visibility="{Binding Subscription.IsLimitReached, Converter={StaticResource BoolToVis}}"
                         Background="#0078D7" Foreground="White" BorderThickness="0"
                         Cursor="Hand" Padding="8,3" Margin="0,0,12,0"
                         VerticalAlignment="Center" FontWeight="SemiBold"/>
@@ -918,7 +918,7 @@
 
                                 <!-- Limit-reached overlay over Section 1 only -->
                                 <Border Background="#E6FFFFFF"
-                                        Visibility="{Binding IsLimitReached, Converter={StaticResource BoolToVis}}">
+                                        Visibility="{Binding Subscription.IsLimitReached, Converter={StaticResource BoolToVis}}">
                                     <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center"
                                                 Margin="14,10">
                                         <TextBlock Text="{loc:Loc Dialog_LimitReachedOverlay_Title}"
@@ -929,13 +929,13 @@
                                                    HorizontalAlignment="Center" TextWrapping="Wrap"
                                                    TextAlignment="Center"/>
                                         <Button Content="{loc:Loc License_UpgradeToPro}" FontSize="11"
-                                                Command="{Binding UpgradeToProCommand}"
+                                                Command="{Binding Subscription.UpgradeToProCommand}"
                                                 Background="#0078D7" Foreground="White" BorderThickness="0"
                                                 Cursor="Hand" Padding="14,6" FontWeight="SemiBold"
                                                 Margin="0,0,0,6"/>
-                                        <Button Content="{Binding LicenseKeyButtonText}" FontSize="11"
-                                                Command="{Binding EnterLicenseKeyCommand}"
-                                                Visibility="{Binding ShowLicenseKeyButton, Converter={StaticResource BoolToVis}}"
+                                        <Button Content="{Binding Subscription.LicenseKeyButtonText}" FontSize="11"
+                                                Command="{Binding Subscription.EnterLicenseKeyCommand}"
+                                                Visibility="{Binding Subscription.ShowLicenseKeyButton, Converter={StaticResource BoolToVis}}"
                                                 Background="Transparent" BorderThickness="1"
                                                 BorderBrush="#0078D7" Foreground="#0078D7"
                                                 Cursor="Hand" Padding="14,5"/>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -649,8 +649,8 @@
                                     HorizontalAlignment="Right" VerticalAlignment="Top"
                                     Padding="3,0" Margin="0,-2,-2,0"
                                     IsHitTestVisible="False"
-                                    Visibility="{Binding HasBulkPreview, Converter={StaticResource BoolToVis}}">
-                                <TextBlock Text="{Binding BulkPreviewCount}" FontSize="8"
+                                    Visibility="{Binding BulkPreview.HasEntries, Converter={StaticResource BoolToVis}}">
+                                <TextBlock Text="{Binding BulkPreview.Count}" FontSize="8"
                                            FontWeight="Bold" Foreground="White"
                                            HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Border>
@@ -908,8 +908,8 @@
                                         <!-- Overlap warning: bulk will overwrite existing pending edits -->
                                         <Border Margin="12,0,12,12" Padding="6,4"
                                                 Background="#fffbef" BorderBrush="#e0a93a" BorderThickness="1"
-                                                Visibility="{Binding HasBulkPreviewConflict, Converter={StaticResource BoolToVis}}">
-                                            <TextBlock Text="{Binding BulkPreviewConflictWarning}"
+                                                Visibility="{Binding BulkPreview.HasConflict, Converter={StaticResource BoolToVis}}">
+                                            <TextBlock Text="{Binding BulkPreview.ConflictWarning}"
                                                        FontSize="10.5" Foreground="#6b4a0a"
                                                        TextWrapping="Wrap"/>
                                         </Border>
@@ -980,12 +980,12 @@
                                     <Border DockPanel.Dock="Left" Margin="6,0,0,0" Padding="5,0"
                                             Background="#1f6feb" CornerRadius="8"
                                             VerticalAlignment="Center"
-                                            Visibility="{Binding HasBulkPreview, Converter={StaticResource BoolToVis}}">
-                                        <TextBlock Text="{Binding BulkPreviewCount}"
+                                            Visibility="{Binding BulkPreview.HasEntries, Converter={StaticResource BoolToVis}}">
+                                        <TextBlock Text="{Binding BulkPreview.Count}"
                                                    FontSize="10" FontWeight="Bold" Foreground="White"/>
                                     </Border>
                                     <TextBlock DockPanel.Dock="Right" HorizontalAlignment="Right"
-                                               Text="{Binding BulkPreviewSummary}"
+                                               Text="{Binding BulkPreview.Summary}"
                                                FontSize="10" Foreground="#5b6471"
                                                FontFamily="Consolas,Courier New"
                                                VerticalAlignment="Center" Margin="0,0,10,0"/>
@@ -1000,7 +1000,7 @@
                                             <MultiDataTrigger>
                                                 <MultiDataTrigger.Conditions>
                                                     <Condition Binding="{Binding Inspector.IsBulkPreviewExpanded}" Value="True"/>
-                                                    <Condition Binding="{Binding HasBulkPreview}" Value="False"/>
+                                                    <Condition Binding="{Binding BulkPreview.HasEntries}" Value="False"/>
                                                 </MultiDataTrigger.Conditions>
                                                 <Setter Property="Visibility" Value="Visible"/>
                                             </MultiDataTrigger>
@@ -1012,7 +1012,7 @@
                                            TextWrapping="Wrap"/>
                             </Border>
                             <!-- List -->
-                            <ItemsControl ItemsSource="{Binding BulkPreview}"
+                            <ItemsControl ItemsSource="{Binding BulkPreview.Entries}"
                                           Background="White">
                                 <ItemsControl.Style>
                                     <Style TargetType="ItemsControl">
@@ -1021,7 +1021,7 @@
                                             <MultiDataTrigger>
                                                 <MultiDataTrigger.Conditions>
                                                     <Condition Binding="{Binding Inspector.IsBulkPreviewExpanded}" Value="True"/>
-                                                    <Condition Binding="{Binding HasBulkPreview}" Value="True"/>
+                                                    <Condition Binding="{Binding BulkPreview.HasEntries}" Value="True"/>
                                                 </MultiDataTrigger.Conditions>
                                                 <Setter Property="Visibility" Value="Visible"/>
                                             </MultiDataTrigger>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -589,7 +589,7 @@
             <GridSplitter Grid.Column="1"
                           HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                           Background="#D6D9DE" ShowsPreview="False"
-                          Visibility="{Binding IsInspectorExpanded, Converter={StaticResource BoolToVis}}"/>
+                          Visibility="{Binding Inspector.IsInspectorExpanded, Converter={StaticResource BoolToVis}}"/>
 
             <!-- Right: Inspector sidebar -->
             <Border Grid.Column="2" BorderBrush="#B9BEC6" BorderThickness="1,1,0,1"
@@ -600,7 +600,7 @@
                             BorderBrush="#B9BEC6" BorderThickness="0,0,0,1" Height="26">
                         <DockPanel LastChildFill="True">
                             <Button DockPanel.Dock="Left"
-                                    Command="{Binding ToggleInspectorCommand}"
+                                    Command="{Binding Inspector.ToggleInspectorCommand}"
                                     Width="22" Height="24" Background="Transparent" BorderThickness="0"
                                     Cursor="Hand" Focusable="False"
                                     ToolTip="Collapse / expand inspector">
@@ -609,26 +609,26 @@
                                     <Path HorizontalAlignment="Center" VerticalAlignment="Center"
                                           Fill="#5b6471" Stretch="Uniform" Width="8" Height="8"
                                           Data="M 0,0 L 6,4 L 0,8 Z"
-                                          Visibility="{Binding IsInspectorExpanded, Converter={StaticResource BoolToVis}}"/>
+                                          Visibility="{Binding Inspector.IsInspectorExpanded, Converter={StaticResource BoolToVis}}"/>
                                     <!-- Collapsed: chevron points left (click to pull sidebar back / expand) -->
                                     <Path HorizontalAlignment="Center" VerticalAlignment="Center"
                                           Fill="#5b6471" Stretch="Uniform" Width="8" Height="8"
                                           Data="M 6,0 L 0,4 L 6,8 Z"
-                                          Visibility="{Binding IsInspectorExpanded, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"/>
+                                          Visibility="{Binding Inspector.IsInspectorExpanded, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"/>
                                 </Grid>
                             </Button>
                             <TextBlock Text="INSPECTOR" VerticalAlignment="Center"
                                        Margin="4,0,0,0" FontSize="10" FontWeight="Bold"
                                        Foreground="#1e2227"
-                                       Visibility="{Binding IsInspectorExpanded, Converter={StaticResource BoolToVis}}"/>
+                                       Visibility="{Binding Inspector.IsInspectorExpanded, Converter={StaticResource BoolToVis}}"/>
                         </DockPanel>
                     </Border>
 
                     <!-- Collapsed rail: vertical icon stack, clicking any icon expands inspector -->
                     <StackPanel DockPanel.Dock="Top" HorizontalAlignment="Center"
-                                Visibility="{Binding IsInspectorCollapsed, Converter={StaticResource BoolToVis}}">
+                                Visibility="{Binding Inspector.IsInspectorCollapsed, Converter={StaticResource BoolToVis}}">
                         <!-- Bulk edit -->
-                        <Button Command="{Binding ToggleInspectorCommand}"
+                        <Button Command="{Binding Inspector.ToggleInspectorCommand}"
                                 Width="26" Height="26" Margin="0,6,0,2"
                                 Background="Transparent" BorderThickness="0" Cursor="Hand"
                                 ToolTip="{loc:Loc Dialog_BulkEdit}">
@@ -638,7 +638,7 @@
                         </Button>
                         <!-- Bulk preview + count badge -->
                         <Grid Width="26" Height="26" Margin="0,2">
-                            <Button Command="{Binding ToggleInspectorCommand}"
+                            <Button Command="{Binding Inspector.ToggleInspectorCommand}"
                                     Background="Transparent" BorderThickness="0" Cursor="Hand"
                                     ToolTip="Bulk preview">
                                 <Viewbox Width="16" Height="16">
@@ -657,7 +657,7 @@
                         </Grid>
                         <!-- Pending edits + count badge -->
                         <Grid Width="26" Height="26" Margin="0,2">
-                            <Button Command="{Binding ToggleInspectorCommand}"
+                            <Button Command="{Binding Inspector.ToggleInspectorCommand}"
                                     Background="Transparent" BorderThickness="0" Cursor="Hand"
                                     ToolTip="Pending edits">
                                 <Viewbox Width="16" Height="16">
@@ -676,7 +676,7 @@
                         </Grid>
                         <!-- Issues + count badge (#26) -->
                         <Grid Width="26" Height="26" Margin="0,2,0,6">
-                            <Button Command="{Binding ToggleInspectorCommand}"
+                            <Button Command="{Binding Inspector.ToggleInspectorCommand}"
                                     Background="Transparent" BorderThickness="0" Cursor="Hand"
                                     ToolTip="{loc:Loc Issues_Tooltip}">
                                 <Viewbox Width="16" Height="16">
@@ -705,7 +705,7 @@
                          scroll position. See OnInspectorScrollChanged in the .xaml.cs. -->
                     <ScrollViewer x:Name="InspectorScroll"
                                   VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled"
-                                  Visibility="{Binding IsInspectorExpanded, Converter={StaticResource BoolToVis}}">
+                                  Visibility="{Binding Inspector.IsInspectorExpanded, Converter={StaticResource BoolToVis}}">
                         <StackPanel x:Name="InspectorContent">
                             <!-- =========================================================
                                  Section 1 — BULK EDIT (input)
@@ -735,16 +735,16 @@
                                         </Border.RenderTransform>
                                         <DockPanel Margin="0,0,0,0">
                                             <Button DockPanel.Dock="Left"
-                                                    Command="{Binding ToggleBulkEditCommand}"
+                                                    Command="{Binding Inspector.ToggleBulkEditCommand}"
                                                     Background="Transparent" BorderThickness="0"
                                                     Width="18" Height="24" Cursor="Hand" Focusable="False">
                                                 <Grid Width="10" Height="10">
                                                     <TextBlock Text="&#x25BC;" FontSize="9" Foreground="#5b6471"
                                                                HorizontalAlignment="Center" VerticalAlignment="Center"
-                                                               Visibility="{Binding IsBulkEditExpanded, Converter={StaticResource BoolToVis}}"/>
+                                                               Visibility="{Binding Inspector.IsBulkEditExpanded, Converter={StaticResource BoolToVis}}"/>
                                                     <TextBlock Text="&#x25B6;" FontSize="9" Foreground="#5b6471"
                                                                HorizontalAlignment="Center" VerticalAlignment="Center"
-                                                               Visibility="{Binding IsBulkEditExpanded, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"/>
+                                                               Visibility="{Binding Inspector.IsBulkEditExpanded, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"/>
                                                 </Grid>
                                             </Button>
                                             <!-- Section icon: pencil = edit input -->
@@ -760,7 +760,7 @@
 
                                     <!-- Body -->
                                     <StackPanel Background="White" Margin="0"
-                                                Visibility="{Binding IsBulkEditExpanded, Converter={StaticResource BoolToVis}}">
+                                                Visibility="{Binding Inspector.IsBulkEditExpanded, Converter={StaticResource BoolToVis}}">
                                         <!-- Target field (readonly display) -->
                                         <StackPanel Margin="12,10,12,0">
                                             <TextBlock Text="TARGET FIELD" FontSize="9.5" FontWeight="Bold"
@@ -956,16 +956,16 @@
                                 </Border.RenderTransform>
                                 <DockPanel>
                                     <Button DockPanel.Dock="Left"
-                                            Command="{Binding ToggleBulkPreviewCommand}"
+                                            Command="{Binding Inspector.ToggleBulkPreviewCommand}"
                                             Background="Transparent" BorderThickness="0"
                                             Width="18" Height="24" Cursor="Hand" Focusable="False">
                                         <Grid Width="10" Height="10">
                                             <TextBlock Text="&#x25BC;" FontSize="9" Foreground="#5b6471"
                                                        HorizontalAlignment="Center" VerticalAlignment="Center"
-                                                       Visibility="{Binding IsBulkPreviewExpanded, Converter={StaticResource BoolToVis}}"/>
+                                                       Visibility="{Binding Inspector.IsBulkPreviewExpanded, Converter={StaticResource BoolToVis}}"/>
                                             <TextBlock Text="&#x25B6;" FontSize="9" Foreground="#5b6471"
                                                        HorizontalAlignment="Center" VerticalAlignment="Center"
-                                                       Visibility="{Binding IsBulkPreviewExpanded, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"/>
+                                                       Visibility="{Binding Inspector.IsBulkPreviewExpanded, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"/>
                                         </Grid>
                                     </Button>
                                     <!-- Section icon: eye = preview -->
@@ -999,7 +999,7 @@
                                         <Style.Triggers>
                                             <MultiDataTrigger>
                                                 <MultiDataTrigger.Conditions>
-                                                    <Condition Binding="{Binding IsBulkPreviewExpanded}" Value="True"/>
+                                                    <Condition Binding="{Binding Inspector.IsBulkPreviewExpanded}" Value="True"/>
                                                     <Condition Binding="{Binding HasBulkPreview}" Value="False"/>
                                                 </MultiDataTrigger.Conditions>
                                                 <Setter Property="Visibility" Value="Visible"/>
@@ -1020,7 +1020,7 @@
                                         <Style.Triggers>
                                             <MultiDataTrigger>
                                                 <MultiDataTrigger.Conditions>
-                                                    <Condition Binding="{Binding IsBulkPreviewExpanded}" Value="True"/>
+                                                    <Condition Binding="{Binding Inspector.IsBulkPreviewExpanded}" Value="True"/>
                                                     <Condition Binding="{Binding HasBulkPreview}" Value="True"/>
                                                 </MultiDataTrigger.Conditions>
                                                 <Setter Property="Visibility" Value="Visible"/>
@@ -1096,16 +1096,16 @@
                                 </Border.RenderTransform>
                                 <DockPanel>
                                     <Button DockPanel.Dock="Left"
-                                            Command="{Binding TogglePendingCommand}"
+                                            Command="{Binding Inspector.TogglePendingCommand}"
                                             Background="Transparent" BorderThickness="0"
                                             Width="18" Height="24" Cursor="Hand" Focusable="False">
                                         <Grid Width="10" Height="10">
                                             <TextBlock Text="&#x25BC;" FontSize="9" Foreground="#5b6471"
                                                        HorizontalAlignment="Center" VerticalAlignment="Center"
-                                                       Visibility="{Binding IsPendingExpanded, Converter={StaticResource BoolToVis}}"/>
+                                                       Visibility="{Binding Inspector.IsPendingExpanded, Converter={StaticResource BoolToVis}}"/>
                                             <TextBlock Text="&#x25B6;" FontSize="9" Foreground="#5b6471"
                                                        HorizontalAlignment="Center" VerticalAlignment="Center"
-                                                       Visibility="{Binding IsPendingExpanded, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"/>
+                                                       Visibility="{Binding Inspector.IsPendingExpanded, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"/>
                                         </Grid>
                                     </Button>
                                     <!-- Section icon: clock = pending/waiting -->
@@ -1151,7 +1151,7 @@
                                         <Style.Triggers>
                                             <MultiDataTrigger>
                                                 <MultiDataTrigger.Conditions>
-                                                    <Condition Binding="{Binding IsPendingExpanded}" Value="True"/>
+                                                    <Condition Binding="{Binding Inspector.IsPendingExpanded}" Value="True"/>
                                                     <Condition Binding="{Binding HasPendingEdits}" Value="False"/>
                                                 </MultiDataTrigger.Conditions>
                                                 <Setter Property="Visibility" Value="Visible"/>
@@ -1173,7 +1173,7 @@
                                         <Style.Triggers>
                                             <MultiDataTrigger>
                                                 <MultiDataTrigger.Conditions>
-                                                    <Condition Binding="{Binding IsPendingExpanded}" Value="True"/>
+                                                    <Condition Binding="{Binding Inspector.IsPendingExpanded}" Value="True"/>
                                                     <Condition Binding="{Binding HasPendingEdits}" Value="True"/>
                                                 </MultiDataTrigger.Conditions>
                                                 <Setter Property="Visibility" Value="Visible"/>
@@ -1425,16 +1425,16 @@
                                 </Border.RenderTransform>
                                 <DockPanel ToolTip="{loc:Loc Issues_Tooltip}">
                                     <Button DockPanel.Dock="Left"
-                                            Command="{Binding ToggleIssuesCommand}"
+                                            Command="{Binding Inspector.ToggleIssuesCommand}"
                                             Background="Transparent" BorderThickness="0"
                                             Width="18" Height="24" Cursor="Hand" Focusable="False">
                                         <Grid Width="10" Height="10">
                                             <TextBlock Text="&#x25BC;" FontSize="9" Foreground="#5b6471"
                                                        HorizontalAlignment="Center" VerticalAlignment="Center"
-                                                       Visibility="{Binding IsIssuesExpanded, Converter={StaticResource BoolToVis}}"/>
+                                                       Visibility="{Binding Inspector.IsIssuesExpanded, Converter={StaticResource BoolToVis}}"/>
                                             <TextBlock Text="&#x25B6;" FontSize="9" Foreground="#5b6471"
                                                        HorizontalAlignment="Center" VerticalAlignment="Center"
-                                                       Visibility="{Binding IsIssuesExpanded, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"/>
+                                                       Visibility="{Binding Inspector.IsIssuesExpanded, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"/>
                                         </Grid>
                                     </Button>
                                     <!-- Section icon: triangle/exclamation = warning finding -->
@@ -1467,7 +1467,7 @@
                                         <Style.Triggers>
                                             <MultiDataTrigger>
                                                 <MultiDataTrigger.Conditions>
-                                                    <Condition Binding="{Binding IsIssuesExpanded}" Value="True"/>
+                                                    <Condition Binding="{Binding Inspector.IsIssuesExpanded}" Value="True"/>
                                                     <Condition Binding="{Binding HasExistingIssues}" Value="False"/>
                                                 </MultiDataTrigger.Conditions>
                                                 <Setter Property="Visibility" Value="Visible"/>
@@ -1489,7 +1489,7 @@
                                         <Style.Triggers>
                                             <MultiDataTrigger>
                                                 <MultiDataTrigger.Conditions>
-                                                    <Condition Binding="{Binding IsIssuesExpanded}" Value="True"/>
+                                                    <Condition Binding="{Binding Inspector.IsIssuesExpanded}" Value="True"/>
                                                     <Condition Binding="{Binding HasExistingIssues}" Value="True"/>
                                                 </MultiDataTrigger.Conditions>
                                                 <Setter Property="Visibility" Value="Visible"/>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml.cs
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml.cs
@@ -40,7 +40,7 @@ public partial class BulkChangeDialog : Window
         DataContext = viewModel;
         viewModel.RequestClose += () => Close();
         viewModel.FlatListRefreshed += RehydrateManualSelection;
-        viewModel.PropertyChanged += OnViewModelPropertyChanged;
+        viewModel.Inspector.PropertyChanged += OnInspectorPropertyChanged;
         Closed += (_, _) => viewModel.Dispose();
 
         // Briefly set Topmost to appear above TIA Portal, then release
@@ -53,12 +53,12 @@ public partial class BulkChangeDialog : Window
         };
     }
 
-    private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    private void OnInspectorPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        if (e.PropertyName != nameof(BulkChangeViewModel.IsInspectorCollapsed)) return;
+        if (e.PropertyName != nameof(InspectorPanelsViewModel.IsInspectorCollapsed)) return;
         if (DataContext is not BulkChangeViewModel vm) return;
 
-        if (vm.IsInspectorCollapsed)
+        if (vm.Inspector.IsInspectorCollapsed)
         {
             // Save the user's last expanded width before collapsing.
             if (SidebarColumn.Width.IsAbsolute && SidebarColumn.Width.Value > CollapsedSidebarWidth)
@@ -1054,10 +1054,10 @@ public partial class BulkChangeDialog : Window
         // ExtentHeight — otherwise ScrollToVerticalOffset clamps short.
         switch (idx)
         {
-            case 0: vm.IsBulkEditExpanded = true; break;
-            case 1: vm.IsBulkPreviewExpanded = true; break;
-            case 2: vm.IsPendingExpanded = true; break;
-            case 3: vm.IsIssuesExpanded = true; break;
+            case 0: vm.Inspector.IsBulkEditExpanded = true; break;
+            case 1: vm.Inspector.IsBulkPreviewExpanded = true; break;
+            case 2: vm.Inspector.IsPendingExpanded = true; break;
+            case 3: vm.Inspector.IsIssuesExpanded = true; break;
         }
         UpdateLayout();
 

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -270,7 +270,10 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         InlineRuleExtractor.ApplyTo(configLoader.GetConfig(), dataBlockInfo);
 
-        BulkPreview = new ObservableCollection<BulkPreviewEntry>();
+        // Bulk-preview collection slice (#80 slice 5). NewValue is host-owned;
+        // pass it via callback so the slice's Summary stays in sync without
+        // pulling NewValue into the slice's surface.
+        BulkPreview = new BulkPreviewViewModel(() => _newValue);
         // Pending-edits + existing-issues collections slice (#80 slice 4).
         // The underlying PendingEditStore stays on the host VM — too many
         // call sites mutate it directly to make moving it worth the churn
@@ -415,12 +418,11 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     public ObservableCollection<ScopeLevel> AvailableScopes { get; }
 
     /// <summary>
-    /// Live preview of the rows that would be staged if the user clicked "Set".
-    /// Rebuilt reactively whenever target / scope / value changes — it does
-    /// NOT itself mutate any node. On Set, entries are transferred to
-    /// pending and the collection is cleared.
+    /// Bulk-preview collection slice (#80 slice 5). Owns the live preview
+    /// rows plus the section-header summary / conflict-overlap readouts.
+    /// XAML binds via <c>{Binding BulkPreview.Entries}</c> etc.
     /// </summary>
-    public ObservableCollection<BulkPreviewEntry> BulkPreview { get; }
+    public BulkPreviewViewModel BulkPreview { get; }
 
     /// <summary>
     /// Pending-edits + existing-issues slice (#80 slice 4). Owns the
@@ -438,44 +440,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     public ObservableCollection<StashedDbState> StashedDbs { get; }
 
     public bool HasStashedDbs => StashedDbs.Count > 0;
-
-    public bool HasBulkPreview => BulkPreview.Count > 0;
-    public int BulkPreviewCount => BulkPreview.Count;
-
-    /// <summary>Preview rows whose node already has a pending edit — they'd overwrite it on Set.</summary>
-    public int BulkPreviewConflictCount => BulkPreview.Count(e => e.HasPendingConflict);
-
-    public bool HasBulkPreviewConflict => BulkPreviewConflictCount > 0;
-
-    public string BulkPreviewConflictWarning
-    {
-        get
-        {
-            int n = BulkPreviewConflictCount;
-            if (n == 0) return "";
-            return n == 1
-                ? "\u26A0 1 overlap with pending edits \u2014 will be overwritten."
-                : $"\u26A0 {n} overlap with pending edits \u2014 will be overwritten.";
-        }
-    }
-
-    /// <summary>
-    /// Summary shown in the section header, e.g. "90 ⇢ 85" when all rows share
-    /// the same original value, or "{count} targets" otherwise.
-    /// </summary>
-    public string BulkPreviewSummary
-    {
-        get
-        {
-            if (BulkPreview.Count == 0) return "";
-            var firstOrig = BulkPreview[0].OriginalValue;
-            bool homogeneous = BulkPreview.All(e =>
-                string.Equals(e.OriginalValue, firstOrig, StringComparison.Ordinal));
-            if (homogeneous && !string.IsNullOrEmpty(firstOrig))
-                return $"{firstOrig} \u21E2 {_newValue}";
-            return $"{BulkPreview.Count} targets";
-        }
-    }
 
     /// <summary>Flat list for the ListView (proper column alignment).</summary>
     public ObservableCollection<MemberNodeViewModel> FlatMembers => _flatTreeManager.FlatList;
@@ -2667,14 +2631,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         // Only raise bindings when the result might actually have changed.
         if (wasNonEmpty || BulkPreview.Count > 0)
-        {
-            OnPropertyChanged(nameof(HasBulkPreview));
-            OnPropertyChanged(nameof(BulkPreviewCount));
-            OnPropertyChanged(nameof(BulkPreviewSummary));
-            OnPropertyChanged(nameof(BulkPreviewConflictCount));
-            OnPropertyChanged(nameof(HasBulkPreviewConflict));
-            OnPropertyChanged(nameof(BulkPreviewConflictWarning));
-        }
+            BulkPreview.RaiseDerivedChanged();
     }
 
     private void TryAddPreviewEntry(MemberNodeViewModel node)
@@ -2715,7 +2672,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private void RebuildPendingEdits()
     {
         var bulkPaths = BulkPreview.Count > 0
-            ? new HashSet<string>(BulkPreview.Select(e => e.Path), StringComparer.Ordinal)
+            ? new HashSet<string>(BulkPreview.Entries.Select(e => e.Path), StringComparer.Ordinal)
             : null;
         Pending.Rebuild(RootMembers, bulkPaths);
     }

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -1,6 +1,5 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -59,12 +58,10 @@ namespace BlockParam.UI;
 /// </summary>
 public class BulkChangeViewModel : ViewModelBase, IDisposable
 {
-    private EventHandler? _licenseStateChangedHandler;
     private bool _disposed;
 
     private readonly HierarchyAnalyzer _analyzer;
     private readonly BulkChangeService _bulkChangeService;
-    private readonly IUsageTracker _usageTracker;
     private readonly ConfigLoader _configLoader;
     private readonly Func<string>? _onBackup;   // callback to create backup, returns backup path
     private readonly Action<string>? _onRestore; // callback to restore from backup path
@@ -183,13 +180,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private bool _suppressSuggestions;
     private bool _lastApplySucceeded;
     private bool _hasPendingChanges;
-    private bool _limitWarningShown;
     private readonly IReadOnlyList<string> _projectLanguages;
     private readonly CommentLanguagePolicy _commentLanguagePolicy;
     private readonly Dispatcher _dispatcher;
-    private readonly ILicenseService? _licenseService;
-    private readonly IUpdateCheckService? _updateCheckService;
-    private UpdateInfo? _availableUpdate;
 
     public BulkChangeViewModel(
         DataBlockInfo dataBlockInfo,
@@ -228,7 +221,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             _activeDbs.AddRange(additionalActiveDbs);
         _analyzer = analyzer;
         _bulkChangeService = bulkChangeService;
-        _usageTracker = usageTracker;
         _configLoader = configLoader;
         _onBackup = onBackup;
         _onRestore = onRestore;
@@ -240,8 +232,12 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         _udtDir = udtDir;
         _udtResolver = udtResolver;
         _commentResolver = commentResolver;
-        _licenseService = licenseService;
-        _updateCheckService = updateCheckService;
+        Subscription = new SubscriptionViewModel(
+            usageTracker, licenseService, updateCheckService,
+            configLoader, _messageBox, _dispatcher);
+        // ApplyTooltip composes license + remaining-quota state, so re-raise
+        // it whenever Subscription publishes a tier / quota change.
+        Subscription.StateChanged += () => OnPropertyChanged(nameof(ApplyTooltip));
         _enumerateDataBlocks = enumerateDataBlocks;
         _switchToDataBlock = switchToDataBlock;
         _buildActiveDbForSummary = buildActiveDbForSummary;
@@ -302,9 +298,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         EditConfigCommand = new RelayCommand(ExecuteEditConfig);
         RefreshConstantsCommand = new RelayCommand(ExecuteRefreshConstants);
-        EnterLicenseKeyCommand = new RelayCommand(ExecuteEnterLicenseKey);
-        ShowUpdateDetailsCommand = new RelayCommand(ExecuteShowUpdateDetails, () => HasUpdateAvailable);
-        UpgradeToProCommand = new RelayCommand(ExecuteUpgradeToPro);
         ExpandAllCommand = new RelayCommand(ExecuteExpandAll);
         CollapseAllCommand = new RelayCommand(ExecuteCollapseAll);
         // Inspector-panel expand/collapse state lives on its own slice VM
@@ -334,18 +327,11 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             if (parameter is StashedDbState stash) ReactivateStashedDb(stash);
         });
 
-        if (_licenseService != null)
-        {
-            _licenseStateChangedHandler = (_, __) =>
-                _dispatcher.BeginInvoke(new Action(() => UpdateUsageStatus()));
-            _licenseService.LicenseStateChanged += _licenseStateChangedHandler;
-        }
-
         // Apply initial filter and build flat list
         ApplyAllFilters();
         RefreshFlatList();
-        UpdateUsageStatus();
-        InitializeUpdateCheck();
+        Subscription.UpdateUsageStatus();
+        Subscription.InitializeUpdateCheck();
 
         // #26: Surface pre-existing rule violations on dialog load. Runs after
         // RefreshRuleHints so RuleHint is available for the issue tooltip.
@@ -751,8 +737,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         set => SetProperty(ref _constraintInfo, value);
     }
 
-    public string UsageStatusText { get; private set; } = "";
-
     public bool HasSelection => _selectedFlatMember is { IsLeaf: true };
     public bool HasScope => _selectedScope != null && !IsManualMode;
     public bool HasValidationError => !string.IsNullOrEmpty(_validationError);
@@ -863,9 +847,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     public ICommand DiscardPendingCommand { get; }
 
     public ICommand EditConfigCommand { get; }
-    public ICommand EnterLicenseKeyCommand { get; }
-    public ICommand UpgradeToProCommand { get; }
-    public ICommand ShowUpdateDetailsCommand { get; }
     public ICommand ExpandAllCommand { get; }
     public ICommand CollapseAllCommand { get; }
     public ICommand ClearManualSelectionCommand { get; }
@@ -2061,7 +2042,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         var pendingEdits = _pendingEditStore.GetForDb(db, _modelToDb).ToList();
         if (pendingEdits.Count == 0) return true;
 
-        var status = _usageTracker.GetStatus();
+        var status = Subscription.GetUsageStatus();
         if (pendingEdits.Count > status.RemainingToday)
         {
             StatusText = Res.Format("Status_WouldExceedLimit",
@@ -2082,7 +2063,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                 }
             }
             db.OnApply.Invoke(db.Xml);
-            if (totalChanged > 0) _usageTracker.RecordUsage(totalChanged);
+            if (totalChanged > 0) Subscription.RecordUsage(totalChanged);
             // The edits are now committed to TIA — evict the DB's store entries
             // so a subsequent tree rebuild doesn't re-populate committed values.
             _pendingEditStore.ClearForDb(db, _modelToDb);
@@ -2267,20 +2248,13 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// </summary>
     public event Action? FlatListRefreshed;
 
-    public string LicenseTierText { get; private set; } = "";
-
     /// <summary>
-    /// Show the license dialog opener whenever a license service is available — users need
-    /// access even when Pro (to view status, remove / re-activate on a new machine, etc.).
+    /// Subscription / usage / update slice (#80 slice 2). Owns license-tier
+    /// display, usage status, license-key dialog opener, upgrade prompt,
+    /// update-available badge. The host VM keeps <see cref="ApplyTooltip"/>
+    /// because it composes Apply-pipeline state with subscription state.
     /// </summary>
-    public bool ShowLicenseKeyButton => _licenseService != null;
-
-    /// <summary>Label on the license dialog opener — adapts to tier.</summary>
-    public string LicenseKeyButtonText =>
-        _licenseService?.IsProActive == true
-            ? Res.Get("License_ManageKey")
-            : Res.Get("License_EnterKey");
-    public bool IsLimitReached => _usageTracker.GetStatus().IsLimitReached;
+    public SubscriptionViewModel Subscription { get; }
 
     /// <summary>
     /// Picked so a few back-to-back bulk applies on a normal day stay quiet, but
@@ -2300,12 +2274,12 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         get
         {
             var baseText = Res.Get("Dialog_ApplyTooltip");
-            if (_licenseService?.IsProActive == true) return baseText;
+            if (Subscription.IsProActive) return baseText;
 
             var cost = PendingInlineEditCount;
             if (cost == 0) return baseText;
 
-            var remaining = _usageTracker.GetStatus().RemainingToday;
+            var remaining = Subscription.GetUsageStatus().RemainingToday;
             if (cost <= 1 && remaining >= TightHeadroomThreshold) return baseText;
 
             return baseText + Environment.NewLine + Environment.NewLine +
@@ -3604,7 +3578,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         if (_selectedScope == null) return;
 
-        MaybeWarnLimitReachedOnce();
+        Subscription.MaybeWarnLimitReachedOnce();
 
         // Multi-DB safe (#58 review must-fix #2): resolve scope members to
         // their owning DB's tree VMs by reference. Path-string staging used
@@ -3638,7 +3612,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// </summary>
     private void ExecuteSetPendingManual()
     {
-        MaybeWarnLimitReachedOnce();
+        Subscription.MaybeWarnLimitReachedOnce();
 
         int count = 0;
         foreach (var node in _manualSelectedPaths)
@@ -3746,7 +3720,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         // Free-tier cap: block Apply when the pending batch would push past
         // the daily quota. The user has to drop some edits or upgrade.
-        var status = _usageTracker.GetStatus();
+        var status = Subscription.GetUsageStatus();
         if (PendingInlineEditCount > status.RemainingToday) return false;
 
         return true;
@@ -3813,12 +3787,12 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // would push past the limit — partial Apply leaves the user in a
         // confusing half-applied state. Pro tier always passes (DailyLimit
         // is int.MaxValue via LicensedUsageTracker).
-        var status = _usageTracker.GetStatus();
+        var status = Subscription.GetUsageStatus();
         if (pendingEdits.Count > status.RemainingToday)
         {
             StatusText = Res.Format("Status_WouldExceedLimit",
                 pendingEdits.Count, status.RemainingToday);
-            UpdateUsageStatus();
+            Subscription.UpdateUsageStatus();
             return;
         }
 
@@ -3876,7 +3850,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                 // Preserve pending edits in the tree so they can retry — skip RefreshTree
                 // because TIA still holds the pre-Apply state.
                 _lastApplySucceeded = false;
-                UpdateUsageStatus();
+                Subscription.UpdateUsageStatus();
                 return;
             }
 
@@ -3887,10 +3861,10 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             // already committed at this point, so we can't roll back — but we
             // CAN consume whatever quota remains so the next Apply is blocked
             // by CanExecuteApply, and warn the user that they're over-cap.
-            if (totalChanged > 0 && !_usageTracker.RecordUsage(totalChanged))
+            if (totalChanged > 0 && !Subscription.RecordUsage(totalChanged))
             {
-                var remaining = _usageTracker.GetStatus().RemainingToday;
-                if (remaining > 0 && !_usageTracker.RecordUsage(remaining))
+                var remaining = Subscription.GetUsageStatus().RemainingToday;
+                if (remaining > 0 && !Subscription.RecordUsage(remaining))
                 {
                     Log.Warning(
                         "ExecuteApply: second RecordUsage({Remaining}) also failed — " +
@@ -3917,7 +3891,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             HandleErrorWithRollback(ex, backupPath);
         }
 
-        UpdateUsageStatus();
+        Subscription.UpdateUsageStatus();
     }
 
     private void ExecuteApplyAndClose()
@@ -3962,12 +3936,12 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         // Pre-check the daily cap against the SUM across all DBs (#58:
         // unified counter, no per-DB quota).
-        var status = _usageTracker.GetStatus();
+        var status = Subscription.GetUsageStatus();
         if (totalChanges > status.RemainingToday)
         {
             StatusText = Res.Format("Status_WouldExceedLimit",
                 totalChanges, status.RemainingToday);
-            UpdateUsageStatus();
+            Subscription.UpdateUsageStatus();
             return;
         }
 
@@ -4050,10 +4024,10 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                 // Charge the partial committed sum so the user can't
                 // accidentally double-spend on the next click. Counter
                 // race handling mirrors the all-success path.
-                if (committedChanges > 0 && !_usageTracker.RecordUsage(committedChanges))
+                if (committedChanges > 0 && !Subscription.RecordUsage(committedChanges))
                 {
-                    var remaining = _usageTracker.GetStatus().RemainingToday;
-                    if (remaining > 0 && !_usageTracker.RecordUsage(remaining))
+                    var remaining = Subscription.GetUsageStatus().RemainingToday;
+                    if (remaining > 0 && !Subscription.RecordUsage(remaining))
                     {
                         Log.Warning(
                             "ExecuteApplyMultiDb partial-commit: second RecordUsage({Remaining}) " +
@@ -4081,7 +4055,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                 }
                 _lastApplySucceeded = false;
                 HasPendingChanges = false;
-                UpdateUsageStatus();
+                Subscription.UpdateUsageStatus();
                 return;
             }
 
@@ -4090,10 +4064,10 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             // Phase 3: charge the unified daily counter once for the sum
             // (#58 decision: no separate multi-DB counter). Race handling
             // mirrors the single-DB path.
-            if (totalChanged > 0 && !_usageTracker.RecordUsage(totalChanged))
+            if (totalChanged > 0 && !Subscription.RecordUsage(totalChanged))
             {
-                var remaining = _usageTracker.GetStatus().RemainingToday;
-                if (remaining > 0 && !_usageTracker.RecordUsage(remaining))
+                var remaining = Subscription.GetUsageStatus().RemainingToday;
+                if (remaining > 0 && !Subscription.RecordUsage(remaining))
                 {
                     Log.Warning(
                         "ExecuteApplyMultiDb full-commit: second RecordUsage({Remaining}) " +
@@ -4134,7 +4108,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             HandleErrorWithRollback(ex, backupPath);
         }
 
-        UpdateUsageStatus();
+        Subscription.UpdateUsageStatus();
     }
 
 
@@ -4207,7 +4181,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             StatusText = Res.Format("Status_ErrorComments", ex.Message);
         }
 
-        UpdateUsageStatus();
+        Subscription.UpdateUsageStatus();
     }
 
     private bool CanExecuteUpdateComments()
@@ -4353,7 +4327,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // per dialog open if the user starts editing while already at 0 left,
         // so they aren't blindsided when Apply is disabled.
         if (!memberVm.IsPendingInlineEdit)
-            MaybeWarnLimitReachedOnce();
+            Subscription.MaybeWarnLimitReachedOnce();
 
         // Shared validator → same rule language as the bulk inspector (#7).
         var error = BuildValidator().Validate(memberVm.Model, newValue);
@@ -4568,138 +4542,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             RestoreExpandStates(child, states);
     }
 
-    private void UpdateUsageStatus()
-    {
-        if (_licenseService != null && _licenseService.IsProActive)
-        {
-            UsageStatusText = Res.Get("Status_Pro");
-            LicenseTierText = Res.Get("License_Tier_Pro");
-        }
-        else
-        {
-            var status = _usageTracker.GetStatus();
-            UsageStatusText = Res.Format("Status_Remaining",
-                status.RemainingToday, status.DailyLimit);
-            LicenseTierText = Res.Get("License_Tier_Free");
-        }
-
-        OnPropertyChanged(nameof(UsageStatusText));
-        OnPropertyChanged(nameof(LicenseTierText));
-        OnPropertyChanged(nameof(ShowLicenseKeyButton));
-        OnPropertyChanged(nameof(LicenseKeyButtonText));
-        OnPropertyChanged(nameof(IsLimitReached));
-        OnPropertyChanged(nameof(ApplyTooltip));
-    }
-
-    /// <summary>
-    /// Shows the daily-cap-reached modal once per dialog open, when the user
-    /// first attempts to stage or edit a change while at 0 remaining quota.
-    /// Staging itself isn't blocked — Apply is the choke point — but a single
-    /// proactive heads-up beats discovering it via a disabled Apply button.
-    /// </summary>
-    private void MaybeWarnLimitReachedOnce()
-    {
-        if (_limitWarningShown) return;
-        if (!_usageTracker.GetStatus().IsLimitReached) return;
-
-        _limitWarningShown = true;
-        _messageBox.ShowInfo(
-            Res.Get("LimitReached_Modal_Message"),
-            Res.Get("LimitReached_Modal_Title"));
-    }
-
-    private void ExecuteEnterLicenseKey()
-    {
-        if (_licenseService == null) return;
-
-        var dialog = new LicenseKeyDialog(_licenseService, _updateCheckService, _configLoader);
-        dialog.Owner = Application.Current?.Windows.OfType<Window>().FirstOrDefault(w => w.IsActive);
-        dialog.ShowDialog();
-        UpdateUsageStatus();
-        // The user may have toggled "Check for updates" — re-evaluate the badge.
-        InitializeUpdateCheck(forceRefresh: false);
-    }
-
-    /// <summary>
-    /// Update available (#61). Null when no newer version is on offer
-    /// (offline / opted out / already on latest / skipped).
-    /// </summary>
-    public UpdateInfo? AvailableUpdate
-    {
-        get => _availableUpdate;
-        private set
-        {
-            if (ReferenceEquals(_availableUpdate, value)) return;
-            _availableUpdate = value;
-            OnPropertyChanged(nameof(AvailableUpdate));
-            OnPropertyChanged(nameof(HasUpdateAvailable));
-            OnPropertyChanged(nameof(UpdateBadgeText));
-            OnPropertyChanged(nameof(UpdateBadgeTooltip));
-            (ShowUpdateDetailsCommand as RelayCommand)?.RaiseCanExecuteChanged();
-        }
-    }
-
-    public bool HasUpdateAvailable => _availableUpdate != null;
-
-    public string UpdateBadgeText
-    {
-        get
-        {
-            if (_availableUpdate == null) return "";
-            var current = typeof(BulkChangeViewModel).Assembly.GetName().Version;
-            var currentText = current != null
-                ? $"v{current.Major}.{Math.Max(0, current.Minor)}.{Math.Max(0, current.Build)}"
-                : "v?";
-            var latest = _availableUpdate.TagName;
-            if (latest.Length > 0 && latest[0] != 'v' && latest[0] != 'V') latest = "v" + latest;
-            return Res.Format("Update_BadgeText", currentText, latest);
-        }
-    }
-
-    public string UpdateBadgeTooltip => _availableUpdate == null
-        ? ""
-        : Res.Format("Update_BadgeTooltip",
-            string.IsNullOrEmpty(_availableUpdate.Name)
-                ? _availableUpdate.TagName
-                : _availableUpdate.Name);
-
-    private void InitializeUpdateCheck(bool forceRefresh = true)
-    {
-        if (_updateCheckService == null) return;
-
-        // Synchronous cached read so the badge shows up the moment the
-        // dialog opens — no flash where it appears half a second later.
-        try { AvailableUpdate = _updateCheckService.GetCached(); }
-        catch (Exception ex) { Log.Warning(ex, "UpdateCheck: GetCached threw"); }
-
-        if (!forceRefresh) return;
-
-        // Fire-and-forget refresh — never blocks the UI thread, never
-        // surfaces an error. Cache TTL gates the actual network hit.
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                var info = await _updateCheckService.CheckAsync().ConfigureAwait(false);
-                _ = _dispatcher.BeginInvoke(new Action(() => AvailableUpdate = info));
-            }
-            catch (Exception ex)
-            {
-                Log.Warning(ex, "UpdateCheck: background CheckAsync threw");
-            }
-        });
-    }
-
-    private void ExecuteShowUpdateDetails()
-    {
-        var info = _availableUpdate;
-        if (info == null || _updateCheckService == null) return;
-
-        var dialog = new UpdateAvailableDialog(info);
-        dialog.Owner = Application.Current?.Windows.OfType<Window>().FirstOrDefault(w => w.IsActive);
-        dialog.ShowDialog();
-    }
-
     /// <summary>
     /// Called by the view when the user's Ctrl+Click selection changes.
     /// Only leaf members are tracked. <paramref name="isFilterRehydration"/> is true
@@ -4855,18 +4697,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         return types;
     }
 
-    private void ExecuteUpgradeToPro()
-    {
-        try
-        {
-            Process.Start(new ProcessStartInfo(ShopUrls.CheckoutUrl) { UseShellExecute = true });
-        }
-        catch
-        {
-            // Fallback: silently ignore if browser cannot be opened
-        }
-    }
-
     public void Dispose()
     {
         if (_disposed) return;
@@ -4877,12 +4707,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         _searchDebounceTimer?.Dispose();
         _searchDebounceTimer = null;
 
-        // Unsubscribe so the lambda's `this` capture stops keeping the VM alive.
-        // We do NOT dispose _licenseService — the caller that constructed it owns it.
-        if (_licenseService != null && _licenseStateChangedHandler != null)
-        {
-            _licenseService.LicenseStateChanged -= _licenseStateChangedHandler;
-            _licenseStateChangedHandler = null;
-        }
+        // Subscription owns the LicenseStateChanged subscription (#80 slice 2).
+        Subscription.Dispose();
     }
 }

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -161,9 +161,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     // current selection are skipped while this is true, so user-entered input
     // isn't clobbered by selection changes.
     private bool _newValueTouched;
-    private GlobSuggestionProvider? _suggestionProvider;
-    private IReadOnlyList<AutocompleteSuggestion> _suggestions = Array.Empty<AutocompleteSuggestion>();
-    private IReadOnlyList<AutocompleteSuggestion> _filteredSuggestions = Array.Empty<AutocompleteSuggestion>();
     private string _statusText = "";
     private string _validationError = "";
     private string _constraintInfo = "";
@@ -177,7 +174,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private bool _constantsForced;
     private string _tagTableAge = "";
     private bool _isRefreshing;
-    private bool _suppressSuggestions;
     private bool _lastApplySucceeded;
     private bool _hasPendingChanges;
     private readonly IReadOnlyList<string> _projectLanguages;
@@ -255,6 +251,8 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         _autocompleteProvider = tagTableCache != null
             ? new AutocompleteProvider(configLoader, tagTableCache)
             : null;
+        // Autocomplete suggestion slice (#80 slice 3).
+        Autocomplete = new AutocompleteViewModel();
 
         UpdateTagTableAge();
 
@@ -2300,32 +2298,12 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         }
     }
 
-    /// <summary>Suggestion provider for autocomplete (null = no suggestions).</summary>
-    public GlobSuggestionProvider? SuggestionProvider
-    {
-        get => _suggestionProvider;
-        private set => SetProperty(ref _suggestionProvider, value);
-    }
-
-    /// <summary>All autocomplete suggestions for the current member.</summary>
-    public IReadOnlyList<AutocompleteSuggestion> Suggestions
-    {
-        get => _suggestions;
-        private set => SetProperty(ref _suggestions, value);
-    }
-
-    /// <summary>Filtered suggestions based on current text input.</summary>
-    public IReadOnlyList<AutocompleteSuggestion> FilteredSuggestions
-    {
-        get => _filteredSuggestions;
-        private set
-        {
-            if (SetProperty(ref _filteredSuggestions, value))
-                OnPropertyChanged(nameof(HasFilteredSuggestions));
-        }
-    }
-
-    public bool HasFilteredSuggestions => _filteredSuggestions.Count > 0;
+    /// <summary>
+    /// Autocomplete suggestion slice (#80 slice 3). Owns the candidate
+    /// pool, the filtered subset, and the glob provider. XAML binds via
+    /// <c>{Binding Autocomplete.FilteredSuggestions}</c> etc.
+    /// </summary>
+    public AutocompleteViewModel Autocomplete { get; }
 
     /// <summary>Returns filtered suggestions for a specific member (used by inline autocomplete).</summary>
     public IReadOnlyList<AutocompleteSuggestion> GetSuggestionsForMember(MemberNodeViewModel memberVm, string filter)
@@ -2349,15 +2327,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         else
             return Array.Empty<AutocompleteSuggestion>();
 
-        if (string.IsNullOrWhiteSpace(filter))
-            return all;
-
-        var terms = filter.Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-        return all.Where(s => terms.All(term =>
-            s.DisplayName.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0 ||
-            s.Value.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0 ||
-            (s.Comment != null && s.Comment.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0)))
-            .ToList();
+        return AutocompleteViewModel.Match(all, filter);
     }
 
     /// <summary>
@@ -2379,57 +2349,15 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         _newValue = value; // Set backing field to avoid re-triggering filter
         OnPropertyChanged(nameof(NewValue));
         ValidateValue();
-        FilteredSuggestions = Array.Empty<AutocompleteSuggestion>();
+        Autocomplete.ClearFiltered();
         UpdateHighlighting();
     }
 
     /// <summary>Show suggestions filtered by current text (always opens).</summary>
-    public void ShowAllSuggestions()
-    {
-        if (_suggestions.Count == 0) return;
-
-        var filter = _newValue?.Trim() ?? "";
-        if (string.IsNullOrEmpty(filter))
-        {
-            FilteredSuggestions = _suggestions.ToList();
-            return;
-        }
-
-        var terms = filter.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-        FilteredSuggestions = _suggestions
-            .Where(s => terms.All(term =>
-                s.DisplayName.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0 ||
-                s.Value.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0 ||
-                (s.Comment != null && s.Comment.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0)))
-            .ToList();
-    }
+    public void ShowAllSuggestions() => Autocomplete.ShowAll(_newValue?.Trim() ?? "");
 
     /// <summary>Toggle: show filtered suggestions or hide them.</summary>
-    public void ToggleAllSuggestions()
-    {
-        if (_filteredSuggestions.Count > 0)
-        {
-            FilteredSuggestions = Array.Empty<AutocompleteSuggestion>();
-        }
-        else
-        {
-            // Apply current text as filter (empty = show all)
-            var filter = _newValue?.Trim() ?? "";
-            if (string.IsNullOrEmpty(filter))
-            {
-                FilteredSuggestions = _suggestions.ToList();
-                return;
-            }
-
-            var terms = filter.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            FilteredSuggestions = _suggestions
-                .Where(s => terms.All(term =>
-                    s.DisplayName.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0 ||
-                    s.Value.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0 ||
-                    (s.Comment != null && s.Comment.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0)))
-                .ToList();
-        }
-    }
+    public void ToggleAllSuggestions() => Autocomplete.Toggle(_newValue?.Trim() ?? "");
 
     /// <summary>Whether to show constant suggestions. Forced on when a rule with tagTableReference matches.</summary>
     public bool ShowConstants
@@ -2565,9 +2493,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         OnPropertyChanged(nameof(CanEdit));
         ValidationError = "";
         ConstraintInfo = "";
-        SuggestionProvider = null;
-        Suggestions = Array.Empty<AutocompleteSuggestion>();
-        FilteredSuggestions = Array.Empty<AutocompleteSuggestion>();
+        Autocomplete.ClearCandidates();
 
         // In manual multi-select mode, scope analysis does not apply.
         if (IsManualMode)
@@ -3305,32 +3231,8 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             ScanExistingViolations(child, validator);
     }
 
-    private void UpdateFilteredSuggestions()
-    {
-        if (_suggestions.Count == 0 || _suppressSuggestions)
-        {
-            FilteredSuggestions = Array.Empty<AutocompleteSuggestion>();
-            return;
-        }
-
-        var filter = _newValue?.Trim() ?? "";
-        if (string.IsNullOrEmpty(filter))
-        {
-            // Don't show list when input is empty
-            FilteredSuggestions = Array.Empty<AutocompleteSuggestion>();
-            return;
-        }
-
-        // Split by whitespace → AND: all terms must match somewhere
-        var terms = filter.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-
-        FilteredSuggestions = _suggestions
-            .Where(s => terms.All(term =>
-                s.DisplayName.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0 ||
-                s.Value.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0 ||
-                (s.Comment != null && s.Comment.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0)))
-            .ToList();
-    }
+    private void UpdateFilteredSuggestions() =>
+        Autocomplete.ApplyFilter(_newValue?.Trim() ?? "");
 
     /// <summary>
     /// Ensures tag tables are exported and cached. Called lazily on first need.
@@ -3359,9 +3261,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// </summary>
     private void ReloadSuggestions()
     {
-        Suggestions = Array.Empty<AutocompleteSuggestion>();
-        FilteredSuggestions = Array.Empty<AutocompleteSuggestion>();
-        SuggestionProvider = null;
+        Autocomplete.ClearCandidates();
 
         if (_selectedFlatMember == null || !_selectedFlatMember.IsLeaf) return;
         if (!_showConstants) return;
@@ -3390,10 +3290,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         }
 
         if (suggestions.Count > 0)
-        {
-            SuggestionProvider = new GlobSuggestionProvider(suggestions);
-            Suggestions = suggestions;
-        }
+            Autocomplete.SetCandidates(suggestions, new GlobSuggestionProvider(suggestions));
     }
 
     /// <summary>
@@ -4514,11 +4411,11 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                 // Value is reset after Apply: the just-committed value would
                 // misrepresent the current state (#8). Clear touched so the
                 // next selection can prefill cleanly.
-                _suppressSuggestions = true;
+                Autocomplete.SuppressSuggestions = true;
                 _newValueTouched = false;
                 _newValue = "";
                 OnPropertyChanged(nameof(NewValue));
-                _suppressSuggestions = false;
+                Autocomplete.SuppressSuggestions = false;
             }
         }
     }

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -184,11 +184,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private bool _lastApplySucceeded;
     private bool _hasPendingChanges;
     private bool _limitWarningShown;
-    private bool _isInspectorCollapsed;
-    private bool _isBulkEditExpanded = true;
-    private bool _isBulkPreviewExpanded = true;
-    private bool _isPendingExpanded = true;
-    private bool _isIssuesExpanded = true;
     private readonly IReadOnlyList<string> _projectLanguages;
     private readonly CommentLanguagePolicy _commentLanguagePolicy;
     private readonly Dispatcher _dispatcher;
@@ -312,11 +307,11 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         UpgradeToProCommand = new RelayCommand(ExecuteUpgradeToPro);
         ExpandAllCommand = new RelayCommand(ExecuteExpandAll);
         CollapseAllCommand = new RelayCommand(ExecuteCollapseAll);
-        ToggleInspectorCommand = new RelayCommand(() => IsInspectorCollapsed = !IsInspectorCollapsed);
-        ToggleBulkEditCommand = new RelayCommand(() => IsBulkEditExpanded = !IsBulkEditExpanded);
-        ToggleBulkPreviewCommand = new RelayCommand(() => IsBulkPreviewExpanded = !IsBulkPreviewExpanded);
-        TogglePendingCommand = new RelayCommand(() => IsPendingExpanded = !IsPendingExpanded);
-        ToggleIssuesCommand = new RelayCommand(() => IsIssuesExpanded = !IsIssuesExpanded);
+        // Inspector-panel expand/collapse state lives on its own slice VM
+        // (#80 slice 1). The dialog code-behind subscribes to
+        // `Inspector.PropertyChanged` directly for the splitter-column
+        // animation — no host-side relay needed.
+        Inspector = new InspectorPanelsViewModel();
         ClearManualSelectionCommand = new RelayCommand(ExecuteClearManualSelection,
             () => _manualSelectedPaths.Count > 0);
 
@@ -874,7 +869,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     public ICommand ExpandAllCommand { get; }
     public ICommand CollapseAllCommand { get; }
     public ICommand ClearManualSelectionCommand { get; }
-    public ICommand ToggleInspectorCommand { get; }
 
     // --- DB-switcher dropdown (#59) ---
 
@@ -2261,48 +2255,11 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         OnPropertyChanged(nameof(HasStashedDbs));
     }
 
-    public bool IsInspectorCollapsed
-    {
-        get => _isInspectorCollapsed;
-        set
-        {
-            if (_isInspectorCollapsed == value) return;
-            _isInspectorCollapsed = value;
-            OnPropertyChanged(nameof(IsInspectorCollapsed));
-            OnPropertyChanged(nameof(IsInspectorExpanded));
-        }
-    }
-
-    public bool IsInspectorExpanded => !_isInspectorCollapsed;
-
-    public bool IsBulkEditExpanded
-    {
-        get => _isBulkEditExpanded;
-        set { if (_isBulkEditExpanded != value) { _isBulkEditExpanded = value; OnPropertyChanged(nameof(IsBulkEditExpanded)); } }
-    }
-
-    public bool IsBulkPreviewExpanded
-    {
-        get => _isBulkPreviewExpanded;
-        set { if (_isBulkPreviewExpanded != value) { _isBulkPreviewExpanded = value; OnPropertyChanged(nameof(IsBulkPreviewExpanded)); } }
-    }
-
-    public bool IsPendingExpanded
-    {
-        get => _isPendingExpanded;
-        set { if (_isPendingExpanded != value) { _isPendingExpanded = value; OnPropertyChanged(nameof(IsPendingExpanded)); } }
-    }
-
-    public bool IsIssuesExpanded
-    {
-        get => _isIssuesExpanded;
-        set { if (_isIssuesExpanded != value) { _isIssuesExpanded = value; OnPropertyChanged(nameof(IsIssuesExpanded)); } }
-    }
-
-    public ICommand ToggleBulkEditCommand { get; }
-    public ICommand ToggleBulkPreviewCommand { get; }
-    public ICommand TogglePendingCommand { get; }
-    public ICommand ToggleIssuesCommand { get; }
+    /// <summary>
+    /// Inspector-panel expand/collapse state (#80 slice 1).
+    /// XAML binds via <c>{Binding Inspector.IsBulkEditExpanded}</c> etc.
+    /// </summary>
+    public InspectorPanelsViewModel Inspector { get; }
 
     /// <summary>
     /// Raised after the flat list has been refreshed so the view can rehydrate

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -1676,6 +1676,12 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // owns the cleanup of every collection that holds VM references.
         RebuildPendingEdits();
         BulkPreview.Clear();
+        // Clear() raises the underlying CollectionChanged event, but the
+        // slice's derived properties (Count, HasEntries, Summary, Conflict*)
+        // are separate INotifyPropertyChanged signals — without this, the
+        // inspector header badge/summary stays stale until the next
+        // ComputeBulkPreview cycle.
+        BulkPreview.RaiseDerivedChanged();
         OnPropertyChanged(nameof(HasMultipleActiveDbs));
         OnPropertyChanged(nameof(SelectedFlatMember));
         OnPropertyChanged(nameof(SelectedScope));
@@ -3810,6 +3816,10 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                 }
                 _lastApplySucceeded = false;
                 HasPendingChanges = false;
+                // Pending list + count + ApplyTooltip would otherwise stay
+                // showing the pre-clear total — both happy paths below call
+                // RefreshPendingAndPreview, this early-return branch must too.
+                RefreshPendingAndPreview();
                 Subscription.UpdateUsageStatus();
                 return;
             }

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -271,8 +271,11 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         InlineRuleExtractor.ApplyTo(configLoader.GetConfig(), dataBlockInfo);
 
         BulkPreview = new ObservableCollection<BulkPreviewEntry>();
-        PendingEdits = new ObservableCollection<PendingEditEntry>();
-        ExistingIssues = new ObservableCollection<ExistingIssueEntry>();
+        // Pending-edits + existing-issues collections slice (#80 slice 4).
+        // The underlying PendingEditStore stays on the host VM — too many
+        // call sites mutate it directly to make moving it worth the churn
+        // in this PR. The slice owns only the visible collections + badges.
+        Pending = new PendingEditsViewModel(() => _pendingEditStore.Count);
         StashedDbs = new ObservableCollection<StashedDbState>();
 
         // Build tree view models. Multi-DB workflow (#58): when more than
@@ -420,18 +423,11 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     public ObservableCollection<BulkPreviewEntry> BulkPreview { get; }
 
     /// <summary>
-    /// Aggregated view of every node that currently has a pending inline edit.
-    /// Rebuilt whenever <c>PendingInlineEditCount</c> changes.
+    /// Pending-edits + existing-issues slice (#80 slice 4). Owns the
+    /// PendingEdits / ExistingIssues collections + badge properties.
+    /// XAML binds via <c>{Binding Pending.PendingEdits}</c> etc.
     /// </summary>
-    public ObservableCollection<PendingEditEntry> PendingEdits { get; }
-
-    /// <summary>
-    /// Findings produced by running the validator over the *existing* StartValues
-    /// when the dialog opens (and after every tree refresh / inline edit). Read-only —
-    /// these are pre-existing rule violations the user can fix manually, not pending
-    /// edits. They never block Apply (#26).
-    /// </summary>
-    public ObservableCollection<ExistingIssueEntry> ExistingIssues { get; }
+    public PendingEditsViewModel Pending { get; }
 
     /// <summary>
     /// One entry per DB the user has switched away from with un-applied
@@ -445,9 +441,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
     public bool HasBulkPreview => BulkPreview.Count > 0;
     public int BulkPreviewCount => BulkPreview.Count;
-    public bool HasPendingEdits => PendingEdits.Count > 0;
-    public bool HasExistingIssues => ExistingIssues.Count > 0;
-    public int ExistingIssuesCount => ExistingIssues.Count;
 
     /// <summary>Preview rows whose node already has a pending edit — they'd overwrite it on Set.</summary>
     public int BulkPreviewConflictCount => BulkPreview.Count(e => e.HasPendingConflict);
@@ -1277,7 +1270,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// </summary>
     private string SnapshotState() =>
         $"active=[{string.Join(",", _activeDbs.Select(d => d.Info.Name))}] " +
-        $"pending={PendingEdits.Count} stashed={StashedDbs.Count} " +
+        $"pending={Pending.PendingEdits.Count} stashed={StashedDbs.Count} " +
         $"treeShape={(_activeDbs.Count == 1 ? "single" : "multi")}";
 
     /// <summary>
@@ -2214,7 +2207,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         {
             RefreshPendingAndPreview();
             OnPropertyChanged(nameof(HasInlineErrors));
-            RaiseInvalidPendingChanged();
+            Pending.RaiseInvalidPendingChanged();
         }
         Log.Information("Restored {Restored} stashed edit(s) for {Db} ({Dropped} dropped)",
             restored, state.Summary.Name, dropped);
@@ -2286,17 +2279,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     }
 
     /// <summary>Number of individual inline edits waiting to be applied.</summary>
-    public int PendingInlineEditCount => _pendingEditStore.Count;
-
-    /// <summary>Status text showing pending inline edits count.</summary>
-    public string? PendingStatusText
-    {
-        get
-        {
-            var count = PendingInlineEditCount;
-            return count > 0 ? $"{count} pending inline edit{(count == 1 ? "" : "s")}" : null;
-        }
-    }
+    public int PendingInlineEditCount => Pending.PendingInlineEditCount;
 
     /// <summary>
     /// Autocomplete suggestion slice (#80 slice 3). Owns the candidate
@@ -2714,60 +2697,27 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// that could shift which nodes are pending OR which rows the preview
     /// would overwrite — the two sides are coupled (preview conflict flags
     /// depend on pending state, pending overwrite flags depend on preview).
-    /// Call order matters: preview first so <c>RebuildPendingEdits</c> can
-    /// read the just-built BulkPreview paths.
+    /// Call order matters: preview first so the rebuild can read the
+    /// just-built BulkPreview paths.
     /// </summary>
     private void RefreshPendingAndPreview()
     {
+        Pending.RaisePendingCountChanged();
         OnPropertyChanged(nameof(PendingInlineEditCount));
-        OnPropertyChanged(nameof(PendingStatusText));
         OnPropertyChanged(nameof(ApplyTooltip));
         ComputeBulkPreview();
         RebuildPendingEdits();
     }
 
     /// <summary>
-    /// Rebuilds <see cref="PendingEdits"/> from the current tree state.
-    /// Call whenever <c>PendingInlineEditCount</c> is expected to have changed.
+    /// Rebuilds the pending-edits side panel from the current tree state.
     /// </summary>
     private void RebuildPendingEdits()
     {
-        PendingEdits.Clear();
         var bulkPaths = BulkPreview.Count > 0
             ? new HashSet<string>(BulkPreview.Select(e => e.Path), StringComparer.Ordinal)
             : null;
-        CollectPendingEntries(RootMembers, bulkPaths);
-        OnPropertyChanged(nameof(HasPendingEdits));
-        RaiseInvalidPendingChanged();
-    }
-
-    /// <summary>
-    /// Nudges bindings attached to <see cref="InvalidPendingCount"/> and friends.
-    /// Call after any mutation that could flip a pending entry's error state.
-    /// </summary>
-    private void RaiseInvalidPendingChanged()
-    {
-        OnPropertyChanged(nameof(InvalidPendingCount));
-        OnPropertyChanged(nameof(HasInvalidPending));
-        OnPropertyChanged(nameof(InvalidPendingBadge));
-    }
-
-    private void CollectPendingEntries(IEnumerable<MemberNodeViewModel> nodes,
-        HashSet<string>? bulkPaths)
-    {
-        foreach (var node in nodes)
-        {
-            if (node.IsPendingInlineEdit)
-            {
-                bool overwritten = bulkPaths != null && bulkPaths.Contains(node.Path);
-                PendingEdits.Add(new PendingEditEntry(
-                    node,
-                    node.StartValue ?? "",
-                    node.PendingValue ?? "",
-                    willBeOverwrittenByBulk: overwritten));
-            }
-            CollectPendingEntries(node.Children, bulkPaths);
-        }
+        Pending.Rebuild(RootMembers, bulkPaths);
     }
 
     /// <summary>
@@ -3197,39 +3147,8 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// validator already short-circuits cleanly when the cache is missing
     /// (no false positives for tag-table rules with no cache yet).
     /// </remarks>
-    private void RebuildExistingIssues()
-    {
-        ExistingIssues.Clear();
-        var validator = BuildValidator();
-
-        foreach (var root in RootMembers)
-            ScanExistingViolations(root, validator);
-
-        OnPropertyChanged(nameof(HasExistingIssues));
-        OnPropertyChanged(nameof(ExistingIssuesCount));
-    }
-
-    private void ScanExistingViolations(MemberNodeViewModel node, MemberValidator validator)
-    {
-        if (node.IsLeaf && !string.IsNullOrEmpty(node.StartValue))
-        {
-            var error = validator.Validate(node.Model, node.StartValue);
-            if (error != null)
-            {
-                node.HasExistingViolation = true;
-                node.ExistingViolationMessage = error;
-                ExistingIssues.Add(new ExistingIssueEntry(
-                    node, node.StartValue ?? "", error, node.RuleHint));
-            }
-            else if (node.HasExistingViolation)
-            {
-                node.HasExistingViolation = false;
-                node.ExistingViolationMessage = null;
-            }
-        }
-        foreach (var child in node.Children)
-            ScanExistingViolations(child, validator);
-    }
+    private void RebuildExistingIssues() =>
+        Pending.RebuildExistingIssues(RootMembers, BuildValidator());
 
     private void UpdateFilteredSuggestions() =>
         Autocomplete.ApplyFilter(_newValue?.Trim() ?? "");
@@ -3635,24 +3554,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         return false;
     }
 
-    /// <summary>
-    /// Count of pending entries whose staged value fails validation (#11).
-    /// Derived from the tree so it stays in sync with inline-edit validation.
-    /// </summary>
-    public int InvalidPendingCount => PendingEdits.Count(e => e.Node.HasInlineError);
-
-    public bool HasInvalidPending => InvalidPendingCount > 0;
-
-    /// <summary>"N of M invalid" summary shown on the sidebar header badge.</summary>
-    public string InvalidPendingBadge
-    {
-        get
-        {
-            var total = PendingEdits.Count;
-            var invalid = InvalidPendingCount;
-            return invalid == 0 ? "" : Res.Format("Pending_InvalidBadge", invalid, total);
-        }
-    }
 
     /// <summary>
     /// Applies ALL pending changes (bulk-staged + inline edits) to XML.
@@ -4246,7 +4147,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         RefreshPendingAndPreview();
         OnPropertyChanged(nameof(HasInlineErrors));
-        RaiseInvalidPendingChanged();
+        Pending.RaiseInvalidPendingChanged();
     }
 
     /// <summary>

--- a/src/BlockParam/UI/BulkPreviewViewModel.cs
+++ b/src/BlockParam/UI/BulkPreviewViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Linq;
+using BlockParam.Localization;
 
 namespace BlockParam.UI;
 
@@ -52,8 +53,8 @@ public class BulkPreviewViewModel : ViewModelBase
             int n = ConflictCount;
             if (n == 0) return "";
             return n == 1
-                ? "⚠ 1 overlap with pending edits — will be overwritten."
-                : $"⚠ {n} overlap with pending edits — will be overwritten.";
+                ? Res.Get("BulkPreview_ConflictWarning_Singular")
+                : Res.Format("BulkPreview_ConflictWarning_Plural", n);
         }
     }
 

--- a/src/BlockParam/UI/BulkPreviewViewModel.cs
+++ b/src/BlockParam/UI/BulkPreviewViewModel.cs
@@ -1,0 +1,98 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace BlockParam.UI;
+
+/// <summary>
+/// Bulk-preview collection slice (#80 slice 5).
+///
+/// <para>
+/// Owns the live preview of rows that would be staged when the user
+/// clicks Set, plus the section-header summary / conflict-overlap
+/// readouts derived from it. The preview itself never mutates any tree
+/// node — entries are computed by the host VM from the current scope ×
+/// NewValue state, and the slice just renders them.
+/// </para>
+///
+/// <para>
+/// The summary string composes with the current NewValue (host-owned),
+/// so the slice accepts it via a constructor callback rather than
+/// pulling NewValue into its surface.
+/// </para>
+/// </summary>
+public class BulkPreviewViewModel : ViewModelBase
+{
+    private readonly Func<string> _getTargetValue;
+
+    public BulkPreviewViewModel(Func<string> getTargetValue)
+    {
+        _getTargetValue = getTargetValue;
+        Entries = new ObservableCollection<BulkPreviewEntry>();
+    }
+
+    /// <summary>
+    /// Live preview rows. Cleared and rebuilt by the host whenever
+    /// target / scope / value changes. On Set, entries are transferred to
+    /// pending and the collection is cleared.
+    /// </summary>
+    public ObservableCollection<BulkPreviewEntry> Entries { get; }
+
+    public bool HasEntries => Entries.Count > 0;
+    public int Count => Entries.Count;
+
+    /// <summary>Preview rows whose node already has a pending edit — they'd overwrite it on Set.</summary>
+    public int ConflictCount => Entries.Count(e => e.HasPendingConflict);
+
+    public bool HasConflict => ConflictCount > 0;
+
+    public string ConflictWarning
+    {
+        get
+        {
+            int n = ConflictCount;
+            if (n == 0) return "";
+            return n == 1
+                ? "⚠ 1 overlap with pending edits — will be overwritten."
+                : $"⚠ {n} overlap with pending edits — will be overwritten.";
+        }
+    }
+
+    /// <summary>
+    /// Summary shown in the section header, e.g. "90 ⇢ 85" when all rows share
+    /// the same original value, or "{count} targets" otherwise.
+    /// </summary>
+    public string Summary
+    {
+        get
+        {
+            if (Entries.Count == 0) return "";
+            var firstOrig = Entries[0].OriginalValue;
+            bool homogeneous = Entries.All(e =>
+                string.Equals(e.OriginalValue, firstOrig, StringComparison.Ordinal));
+            if (homogeneous && !string.IsNullOrEmpty(firstOrig))
+                return $"{firstOrig} ⇢ {_getTargetValue()}";
+            return $"{Entries.Count} targets";
+        }
+    }
+
+    /// <summary>Remove every preview row.</summary>
+    public void Clear() => Entries.Clear();
+
+    /// <summary>Append a single preview row.</summary>
+    public void Add(BulkPreviewEntry entry) => Entries.Add(entry);
+
+    /// <summary>
+    /// Nudge all derived bindings (count / conflict / summary). Called by
+    /// the host after a Clear-then-Add(...) batch so the inspector header
+    /// updates in one render pass.
+    /// </summary>
+    public void RaiseDerivedChanged()
+    {
+        OnPropertyChanged(nameof(HasEntries));
+        OnPropertyChanged(nameof(Count));
+        OnPropertyChanged(nameof(Summary));
+        OnPropertyChanged(nameof(ConflictCount));
+        OnPropertyChanged(nameof(HasConflict));
+        OnPropertyChanged(nameof(ConflictWarning));
+    }
+}

--- a/src/BlockParam/UI/InspectorPanelsViewModel.cs
+++ b/src/BlockParam/UI/InspectorPanelsViewModel.cs
@@ -1,0 +1,79 @@
+using System.Windows.Input;
+
+namespace BlockParam.UI;
+
+/// <summary>
+/// Inspector-panel expand/collapse state (#80 slice 1).
+///
+/// <para>
+/// Owns the four inspector section expanders (Bulk Edit, Bulk Preview,
+/// Pending, Issues) plus the overall inspector sidebar collapse flag.
+/// Pure UI state — no business logic, no cross-slice dependencies — so
+/// this is the pattern-setter slice for the wider #80 split: the host
+/// VM exposes one child VM property (<c>Inspector</c>), XAML rebinds
+/// from <c>{Binding IsBulkEditExpanded}</c> to
+/// <c>{Binding Inspector.IsBulkEditExpanded}</c>, and the slice gets
+/// its own focused test class.
+/// </para>
+/// </summary>
+public class InspectorPanelsViewModel : ViewModelBase
+{
+    private bool _isInspectorCollapsed;
+    private bool _isBulkEditExpanded = true;
+    private bool _isBulkPreviewExpanded = true;
+    private bool _isPendingExpanded = true;
+    private bool _isIssuesExpanded = true;
+
+    public InspectorPanelsViewModel()
+    {
+        ToggleInspectorCommand = new RelayCommand(() => IsInspectorCollapsed = !IsInspectorCollapsed);
+        ToggleBulkEditCommand = new RelayCommand(() => IsBulkEditExpanded = !IsBulkEditExpanded);
+        ToggleBulkPreviewCommand = new RelayCommand(() => IsBulkPreviewExpanded = !IsBulkPreviewExpanded);
+        TogglePendingCommand = new RelayCommand(() => IsPendingExpanded = !IsPendingExpanded);
+        ToggleIssuesCommand = new RelayCommand(() => IsIssuesExpanded = !IsIssuesExpanded);
+    }
+
+    public bool IsInspectorCollapsed
+    {
+        get => _isInspectorCollapsed;
+        set
+        {
+            if (_isInspectorCollapsed == value) return;
+            _isInspectorCollapsed = value;
+            OnPropertyChanged(nameof(IsInspectorCollapsed));
+            OnPropertyChanged(nameof(IsInspectorExpanded));
+        }
+    }
+
+    public bool IsInspectorExpanded => !_isInspectorCollapsed;
+
+    public bool IsBulkEditExpanded
+    {
+        get => _isBulkEditExpanded;
+        set => SetProperty(ref _isBulkEditExpanded, value);
+    }
+
+    public bool IsBulkPreviewExpanded
+    {
+        get => _isBulkPreviewExpanded;
+        set => SetProperty(ref _isBulkPreviewExpanded, value);
+    }
+
+    public bool IsPendingExpanded
+    {
+        get => _isPendingExpanded;
+        set => SetProperty(ref _isPendingExpanded, value);
+    }
+
+    public bool IsIssuesExpanded
+    {
+        get => _isIssuesExpanded;
+        set => SetProperty(ref _isIssuesExpanded, value);
+    }
+
+    public ICommand ToggleInspectorCommand { get; }
+    public ICommand ToggleBulkEditCommand { get; }
+    public ICommand ToggleBulkPreviewCommand { get; }
+    public ICommand TogglePendingCommand { get; }
+    public ICommand ToggleIssuesCommand { get; }
+}

--- a/src/BlockParam/UI/PendingEditsViewModel.cs
+++ b/src/BlockParam/UI/PendingEditsViewModel.cs
@@ -63,7 +63,10 @@ public class PendingEditsViewModel : ViewModelBase
         get
         {
             var count = PendingInlineEditCount;
-            return count > 0 ? $"{count} pending inline edit{(count == 1 ? "" : "s")}" : null;
+            if (count == 0) return null;
+            return count == 1
+                ? Res.Format("Pending_StatusText_Singular", count)
+                : Res.Format("Pending_StatusText_Plural", count);
         }
     }
 

--- a/src/BlockParam/UI/PendingEditsViewModel.cs
+++ b/src/BlockParam/UI/PendingEditsViewModel.cs
@@ -1,0 +1,178 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using BlockParam.Localization;
+using BlockParam.Services;
+
+namespace BlockParam.UI;
+
+/// <summary>
+/// Pending-edits + existing-issues collections slice (#80 slice 4).
+///
+/// <para>
+/// Owns the two side-panel collections (<see cref="PendingEdits"/> +
+/// <see cref="ExistingIssues"/>), their badge / count properties, and
+/// the rebuild routines that repopulate them from the tree.
+/// </para>
+///
+/// <para>
+/// The underlying <c>PendingEditStore</c> stays on the host VM because
+/// 20+ Apply-pipeline / value-edit / manual-selection sites mutate it
+/// directly. The slice exposes <see cref="RaisePendingCountChanged"/>
+/// so the host can notify after store mutations, and accepts the
+/// pending-count via a constructor callback so
+/// <see cref="PendingInlineEditCount"/> stays in sync without the
+/// slice taking a reference to the store.
+/// </para>
+/// </summary>
+public class PendingEditsViewModel : ViewModelBase
+{
+    private readonly Func<int> _getPendingCount;
+
+    public PendingEditsViewModel(Func<int> getPendingCount)
+    {
+        _getPendingCount = getPendingCount;
+        PendingEdits = new ObservableCollection<PendingEditEntry>();
+        ExistingIssues = new ObservableCollection<ExistingIssueEntry>();
+    }
+
+    /// <summary>
+    /// Aggregated view of every node that currently has a pending inline edit.
+    /// Rebuilt whenever <see cref="PendingInlineEditCount"/> changes.
+    /// </summary>
+    public ObservableCollection<PendingEditEntry> PendingEdits { get; }
+
+    /// <summary>
+    /// Findings produced by running the validator over the *existing* StartValues
+    /// when the dialog opens (and after every tree refresh / inline edit). Read-only —
+    /// these are pre-existing rule violations the user can fix manually, not pending
+    /// edits. They never block Apply (#26).
+    /// </summary>
+    public ObservableCollection<ExistingIssueEntry> ExistingIssues { get; }
+
+    public bool HasPendingEdits => PendingEdits.Count > 0;
+    public bool HasExistingIssues => ExistingIssues.Count > 0;
+    public int ExistingIssuesCount => ExistingIssues.Count;
+
+    /// <summary>Number of individual inline edits waiting to be applied.</summary>
+    public int PendingInlineEditCount => _getPendingCount();
+
+    /// <summary>Status text showing pending inline edits count.</summary>
+    public string? PendingStatusText
+    {
+        get
+        {
+            var count = PendingInlineEditCount;
+            return count > 0 ? $"{count} pending inline edit{(count == 1 ? "" : "s")}" : null;
+        }
+    }
+
+    /// <summary>
+    /// Count of pending entries whose staged value fails validation (#11).
+    /// Derived from the tree so it stays in sync with inline-edit validation.
+    /// </summary>
+    public int InvalidPendingCount => PendingEdits.Count(e => e.Node.HasInlineError);
+
+    public bool HasInvalidPending => InvalidPendingCount > 0;
+
+    /// <summary>"N of M invalid" summary shown on the sidebar header badge.</summary>
+    public string InvalidPendingBadge
+    {
+        get
+        {
+            var total = PendingEdits.Count;
+            var invalid = InvalidPendingCount;
+            return invalid == 0 ? "" : Res.Format("Pending_InvalidBadge", invalid, total);
+        }
+    }
+
+    /// <summary>
+    /// Rebuild <see cref="PendingEdits"/> from the current tree state.
+    /// Caller passes the pre-built BulkPreview paths so overwritten flags can
+    /// be set on each entry without the slice scanning the preview itself.
+    /// </summary>
+    public void Rebuild(IEnumerable<MemberNodeViewModel> roots, HashSet<string>? bulkPaths)
+    {
+        PendingEdits.Clear();
+        CollectPendingEntries(roots, bulkPaths);
+        OnPropertyChanged(nameof(HasPendingEdits));
+        RaiseInvalidPendingChanged();
+    }
+
+    /// <summary>
+    /// Rebuild <see cref="ExistingIssues"/> by running the validator over
+    /// every leaf's existing StartValue. Mutates the leaf VMs'
+    /// <c>HasExistingViolation</c> / <c>ExistingViolationMessage</c> so the
+    /// tree's row decorations stay in sync (#26).
+    /// </summary>
+    public void RebuildExistingIssues(IEnumerable<MemberNodeViewModel> roots, MemberValidator validator)
+    {
+        ExistingIssues.Clear();
+        foreach (var root in roots)
+            ScanExistingViolations(root, validator);
+        OnPropertyChanged(nameof(HasExistingIssues));
+        OnPropertyChanged(nameof(ExistingIssuesCount));
+    }
+
+    /// <summary>
+    /// Nudge bindings on <see cref="PendingInlineEditCount"/> /
+    /// <see cref="PendingStatusText"/>. The host calls this after store
+    /// mutations that don't fall under <see cref="Rebuild"/>.
+    /// </summary>
+    public void RaisePendingCountChanged()
+    {
+        OnPropertyChanged(nameof(PendingInlineEditCount));
+        OnPropertyChanged(nameof(PendingStatusText));
+    }
+
+    /// <summary>
+    /// Nudge bindings on the invalid-pending badge after a single inline-edit
+    /// state flip (host call site: <c>OnSingleValueEdited</c>).
+    /// </summary>
+    public void RaiseInvalidPendingChanged()
+    {
+        OnPropertyChanged(nameof(InvalidPendingCount));
+        OnPropertyChanged(nameof(HasInvalidPending));
+        OnPropertyChanged(nameof(InvalidPendingBadge));
+    }
+
+    private void CollectPendingEntries(IEnumerable<MemberNodeViewModel> nodes,
+        HashSet<string>? bulkPaths)
+    {
+        foreach (var node in nodes)
+        {
+            if (node.IsPendingInlineEdit)
+            {
+                bool overwritten = bulkPaths != null && bulkPaths.Contains(node.Path);
+                PendingEdits.Add(new PendingEditEntry(
+                    node,
+                    node.StartValue ?? "",
+                    node.PendingValue ?? "",
+                    willBeOverwrittenByBulk: overwritten));
+            }
+            CollectPendingEntries(node.Children, bulkPaths);
+        }
+    }
+
+    private void ScanExistingViolations(MemberNodeViewModel node, MemberValidator validator)
+    {
+        if (node.IsLeaf && !string.IsNullOrEmpty(node.StartValue))
+        {
+            var error = validator.Validate(node.Model, node.StartValue);
+            if (error != null)
+            {
+                node.HasExistingViolation = true;
+                node.ExistingViolationMessage = error;
+                ExistingIssues.Add(new ExistingIssueEntry(
+                    node, node.StartValue ?? "", error, node.RuleHint));
+            }
+            else if (node.HasExistingViolation)
+            {
+                node.HasExistingViolation = false;
+                node.ExistingViolationMessage = null;
+            }
+        }
+        foreach (var child in node.Children)
+            ScanExistingViolations(child, validator);
+    }
+}

--- a/src/BlockParam/UI/SubscriptionViewModel.cs
+++ b/src/BlockParam/UI/SubscriptionViewModel.cs
@@ -1,0 +1,286 @@
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Threading;
+using BlockParam.Config;
+using BlockParam.Diagnostics;
+using BlockParam.Licensing;
+using BlockParam.Localization;
+using BlockParam.Updates;
+
+namespace BlockParam.UI;
+
+/// <summary>
+/// Subscription / usage / update slice (#80 slice 2).
+///
+/// <para>
+/// Owns the daily-cap usage display, license-tier label, license-key
+/// dialog opener, upgrade prompt, and the update-available badge.
+/// Holds the three service references (<see cref="ILicenseService"/>,
+/// <see cref="IUsageTracker"/>, <see cref="IUpdateCheckService"/>) so
+/// the host VM doesn't need to know about them — Apply pipeline calls
+/// go through <see cref="RecordUsage"/>, <see cref="GetUsageStatus"/>,
+/// <see cref="UpdateUsageStatus"/> and <see cref="MaybeWarnLimitReachedOnce"/>.
+/// </para>
+///
+/// <para>
+/// Emits <see cref="StateChanged"/> after usage / license / update
+/// changes so the host can re-raise tooltip + Apply-related
+/// properties that compose with subscription state (e.g.
+/// <c>BulkChangeViewModel.ApplyTooltip</c>).
+/// </para>
+/// </summary>
+public class SubscriptionViewModel : ViewModelBase, IDisposable
+{
+    private readonly ILicenseService? _licenseService;
+    private readonly IUsageTracker _usageTracker;
+    private readonly IUpdateCheckService? _updateCheckService;
+    private readonly ConfigLoader _configLoader;
+    private readonly IMessageBoxService _messageBox;
+    private readonly Dispatcher _dispatcher;
+    private EventHandler? _licenseStateChangedHandler;
+
+    private bool _limitWarningShown;
+    private UpdateInfo? _availableUpdate;
+    private string _usageStatusText = "";
+    private string _licenseTierText = "";
+    private bool _disposed;
+
+    /// <summary>
+    /// Raised after any subscription-side state changes that the host
+    /// composes with (license tier, remaining quota, limit-reached). Used
+    /// by the host to re-raise <c>ApplyTooltip</c> on tier / quota shifts.
+    /// </summary>
+    public event Action? StateChanged;
+
+    public SubscriptionViewModel(
+        IUsageTracker usageTracker,
+        ILicenseService? licenseService,
+        IUpdateCheckService? updateCheckService,
+        ConfigLoader configLoader,
+        IMessageBoxService messageBox,
+        Dispatcher dispatcher)
+    {
+        _usageTracker = usageTracker;
+        _licenseService = licenseService;
+        _updateCheckService = updateCheckService;
+        _configLoader = configLoader;
+        _messageBox = messageBox;
+        _dispatcher = dispatcher;
+
+        EnterLicenseKeyCommand = new RelayCommand(ExecuteEnterLicenseKey);
+        UpgradeToProCommand = new RelayCommand(ExecuteUpgradeToPro);
+        ShowUpdateDetailsCommand = new RelayCommand(ExecuteShowUpdateDetails, () => HasUpdateAvailable);
+
+        if (_licenseService != null)
+        {
+            _licenseStateChangedHandler = (_, __) =>
+                _dispatcher.BeginInvoke(new Action(UpdateUsageStatus));
+            _licenseService.LicenseStateChanged += _licenseStateChangedHandler;
+        }
+    }
+
+    // --- VM-facing properties ---
+
+    public string UsageStatusText
+    {
+        get => _usageStatusText;
+        private set => SetProperty(ref _usageStatusText, value);
+    }
+
+    public string LicenseTierText
+    {
+        get => _licenseTierText;
+        private set => SetProperty(ref _licenseTierText, value);
+    }
+
+    /// <summary>
+    /// Show the license dialog opener whenever a license service is available — users need
+    /// access even when Pro (to view status, remove / re-activate on a new machine, etc.).
+    /// </summary>
+    public bool ShowLicenseKeyButton => _licenseService != null;
+
+    /// <summary>Label on the license dialog opener — adapts to tier.</summary>
+    public string LicenseKeyButtonText =>
+        _licenseService?.IsProActive == true
+            ? Res.Get("License_ManageKey")
+            : Res.Get("License_EnterKey");
+
+    public bool IsLimitReached => _usageTracker.GetStatus().IsLimitReached;
+
+    /// <summary>
+    /// Update available (#61). Null when no newer version is on offer
+    /// (offline / opted out / already on latest / skipped).
+    /// </summary>
+    public UpdateInfo? AvailableUpdate
+    {
+        get => _availableUpdate;
+        private set
+        {
+            if (ReferenceEquals(_availableUpdate, value)) return;
+            _availableUpdate = value;
+            OnPropertyChanged(nameof(AvailableUpdate));
+            OnPropertyChanged(nameof(HasUpdateAvailable));
+            OnPropertyChanged(nameof(UpdateBadgeText));
+            OnPropertyChanged(nameof(UpdateBadgeTooltip));
+            (ShowUpdateDetailsCommand as RelayCommand)?.RaiseCanExecuteChanged();
+        }
+    }
+
+    public bool HasUpdateAvailable => _availableUpdate != null;
+
+    public string UpdateBadgeText
+    {
+        get
+        {
+            if (_availableUpdate == null) return "";
+            var current = typeof(SubscriptionViewModel).Assembly.GetName().Version;
+            var currentText = current != null
+                ? $"v{current.Major}.{Math.Max(0, current.Minor)}.{Math.Max(0, current.Build)}"
+                : "v?";
+            var latest = _availableUpdate.TagName;
+            if (latest.Length > 0 && latest[0] != 'v' && latest[0] != 'V') latest = "v" + latest;
+            return Res.Format("Update_BadgeText", currentText, latest);
+        }
+    }
+
+    public string UpdateBadgeTooltip => _availableUpdate == null
+        ? ""
+        : Res.Format("Update_BadgeTooltip",
+            string.IsNullOrEmpty(_availableUpdate.Name)
+                ? _availableUpdate.TagName
+                : _availableUpdate.Name);
+
+    public ICommand EnterLicenseKeyCommand { get; }
+    public ICommand UpgradeToProCommand { get; }
+    public ICommand ShowUpdateDetailsCommand { get; }
+
+    // --- Host-facing passthroughs (composed into ApplyTooltip etc.) ---
+
+    public bool IsProActive => _licenseService?.IsProActive == true;
+
+    public UsageStatus GetUsageStatus() => _usageTracker.GetStatus();
+
+    public bool RecordUsage(int count) => _usageTracker.RecordUsage(count);
+
+    // --- Operations ---
+
+    /// <summary>
+    /// Refresh the visible usage / tier strings and broadcast
+    /// <see cref="StateChanged"/> so composers (Apply tooltip) re-render.
+    /// </summary>
+    public void UpdateUsageStatus()
+    {
+        if (_licenseService != null && _licenseService.IsProActive)
+        {
+            UsageStatusText = Res.Get("Status_Pro");
+            LicenseTierText = Res.Get("License_Tier_Pro");
+        }
+        else
+        {
+            var status = _usageTracker.GetStatus();
+            UsageStatusText = Res.Format("Status_Remaining",
+                status.RemainingToday, status.DailyLimit);
+            LicenseTierText = Res.Get("License_Tier_Free");
+        }
+
+        OnPropertyChanged(nameof(ShowLicenseKeyButton));
+        OnPropertyChanged(nameof(LicenseKeyButtonText));
+        OnPropertyChanged(nameof(IsLimitReached));
+        StateChanged?.Invoke();
+    }
+
+    /// <summary>
+    /// Shows the daily-cap-reached modal once per dialog open, when the user
+    /// first attempts to stage or edit a change while at 0 remaining quota.
+    /// Staging itself isn't blocked — Apply is the choke point — but a single
+    /// proactive heads-up beats discovering it via a disabled Apply button.
+    /// </summary>
+    public void MaybeWarnLimitReachedOnce()
+    {
+        if (_limitWarningShown) return;
+        if (!_usageTracker.GetStatus().IsLimitReached) return;
+
+        _limitWarningShown = true;
+        _messageBox.ShowInfo(
+            Res.Get("LimitReached_Modal_Message"),
+            Res.Get("LimitReached_Modal_Title"));
+    }
+
+    public void InitializeUpdateCheck(bool forceRefresh = true)
+    {
+        if (_updateCheckService == null) return;
+
+        // Synchronous cached read so the badge shows up the moment the
+        // dialog opens — no flash where it appears half a second later.
+        try { AvailableUpdate = _updateCheckService.GetCached(); }
+        catch (Exception ex) { Log.Warning(ex, "UpdateCheck: GetCached threw"); }
+
+        if (!forceRefresh) return;
+
+        // Fire-and-forget refresh — never blocks the UI thread, never
+        // surfaces an error. Cache TTL gates the actual network hit.
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                var info = await _updateCheckService.CheckAsync().ConfigureAwait(false);
+                _ = _dispatcher.BeginInvoke(new Action(() => AvailableUpdate = info));
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "UpdateCheck: background CheckAsync threw");
+            }
+        });
+    }
+
+    private void ExecuteEnterLicenseKey()
+    {
+        if (_licenseService == null) return;
+
+        var dialog = new LicenseKeyDialog(_licenseService, _updateCheckService, _configLoader);
+        dialog.Owner = Application.Current?.Windows.OfType<Window>().FirstOrDefault(w => w.IsActive);
+        dialog.ShowDialog();
+        UpdateUsageStatus();
+        // The user may have toggled "Check for updates" — re-evaluate the badge.
+        InitializeUpdateCheck(forceRefresh: false);
+    }
+
+    private void ExecuteShowUpdateDetails()
+    {
+        var info = _availableUpdate;
+        if (info == null || _updateCheckService == null) return;
+
+        var dialog = new UpdateAvailableDialog(info);
+        dialog.Owner = Application.Current?.Windows.OfType<Window>().FirstOrDefault(w => w.IsActive);
+        dialog.ShowDialog();
+    }
+
+    private void ExecuteUpgradeToPro()
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo(ShopUrls.CheckoutUrl) { UseShellExecute = true });
+        }
+        catch
+        {
+            // Fallback: silently ignore if browser cannot be opened
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        // Unsubscribe so the lambda's `this` capture stops keeping the VM alive.
+        // We do NOT dispose _licenseService — the caller that constructed it owns it.
+        if (_licenseService != null && _licenseStateChangedHandler != null)
+        {
+            _licenseService.LicenseStateChanged -= _licenseStateChangedHandler;
+            _licenseStateChangedHandler = null;
+        }
+    }
+}

--- a/src/BlockParam/UI/SubscriptionViewModel.cs
+++ b/src/BlockParam/UI/SubscriptionViewModel.cs
@@ -222,12 +222,19 @@ public class SubscriptionViewModel : ViewModelBase, IDisposable
 
         // Fire-and-forget refresh — never blocks the UI thread, never
         // surfaces an error. Cache TTL gates the actual network hit.
+        // If the dialog closes while the background fetch is in flight,
+        // the dispatcher callback no-ops so we don't raise PropertyChanged
+        // on a disposed VM.
         _ = Task.Run(async () =>
         {
             try
             {
                 var info = await _updateCheckService.CheckAsync().ConfigureAwait(false);
-                _ = _dispatcher.BeginInvoke(new Action(() => AvailableUpdate = info));
+                _ = _dispatcher.BeginInvoke(new Action(() =>
+                {
+                    if (_disposed) return;
+                    AvailableUpdate = info;
+                }));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
First 5 of 9 planned slices for #80 — extract cohesive units of the
4,931-line `BulkChangeViewModel` into focused child VMs owned by the
host via composition. Each slice ships with its own focused test
class; XAML bindings rebound to the new child paths.

## Slices in this PR

| Slice | Child VM | Lines | Tests |
|---|---|---|---|
| 1 | `InspectorPanelsViewModel` | 79 | `InspectorPanelsViewModelTests` |
| 2 | `SubscriptionViewModel` | 286 | `SubscriptionViewModelTests` |
| 3 | `AutocompleteViewModel` | ~170 | `AutocompleteViewModelTests` |
| 4 | `PendingEditsViewModel` | 178 | `PendingEditsViewModelTests` |
| 5 | `BulkPreviewViewModel` | 98 | `BulkPreviewViewModelTests` |

Host VM goes from **4,931 → 4,468 lines** (−463 net), drops ~30
properties and ~10 method bodies. The slice pattern (child VM +
event-out + focused tests + XAML rebinding) is now established for
slices 6–9.

## Cross-slice contract

Children coordinate via events on the slice that owns the data, not
through the host:

- `Subscription.StateChanged` → host re-raises `ApplyTooltip` (the
  one host property that composes Apply state with subscription
  state).
- `Pending.RaisePendingCountChanged()` / `RaiseInvalidPendingChanged()`
  called by host after `_pendingEditStore` mutations.
- `BulkPreview.RaiseDerivedChanged()` after `Clear`+`Add(...)` batches
  in `ComputeBulkPreview`.
- `Inspector.PropertyChanged` subscribed by `BulkChangeDialog.xaml.cs`
  directly for the splitter-column animation — no host relay.

## What's NOT in this PR

The remaining 4 slices are the entangled core and warrant separate
review:

- **PR 0 prereq** — finish #78's snapshot setter as the only writer
  (~50 `_activeDbs[i]` read-site sweep). Only blocks slice 8.
- **Slice 6** — Search/filter (~350 LOC). Needs to split
  `ApplyAllFilters` from the tree's expansion logic.
- **Slice 7** — MemberTree (~900 LOC). Biggest XAML churn; owns
  selection / scope / manual selection / RootMembers.
- **Slice 8** — ActiveSet + DB switcher (~1,000 LOC). Depends on
  PR 0 landing first.
- **Slice 9** — Host VM cleanup: delete delegators, fold
  `RefreshAnchorDisplay`/`BuildTitle` into ActiveSet.

## Test plan

- [ ] CI green on both `v20` and `v21` jobs (each PR ran with
      `[run-ci]`; CI #29–#33 visible in Actions tab)
- [ ] Existing tests still pass — regression suite updated to use
      new binding paths (`vm.Pending.PendingEdits` etc.)
- [ ] Each new slice has its own focused test class
- [ ] Manual smoke test in TIA Portal V20 once installed: open
      dialog, exercise inspector toggles, license / update badges,
      autocomplete overlay, pending-edit panel, bulk preview
      summary

## Things to double-check on review

- `Subscription.Dispose()` chains from host VM `Dispose()` —
  preserves the LicenseStateChanged unsubscribe contract that
  `BulkChangeViewModelRegressionTests.Dispose_IsIdempotentAndTearsDown…`
  asserts.
- `Pending` slice still routes `_pendingEditStore` mutations through
  the host's existing 22 call sites; the slice's `PendingInlineEditCount`
  delegates via `Func<int>` callback. Store ownership migration is
  deliberately deferred to keep PR diff bounded.
- `AutocompleteViewModel.Match` static is now the single source of
  term-matching logic — previously duplicated across 4 host methods.

Refs #80. Builds on the partially-landed snapshot pattern from #78
(snapshot setter still copies back to legacy fields — slice 8 will
finish that).


---
_Generated by [Claude Code](https://claude.ai/code/session_01BKonjHGe9srB9iDYgqivT9)_