### PR TITLE
refactor(#80): extract SearchFilterViewModel slice (slice 6)

### DIFF
--- a/src/BlockParam.DevLauncher/CaptureScript.cs
+++ b/src/BlockParam.DevLauncher/CaptureScript.cs
@@ -268,10 +268,10 @@ public static class SceneApplier
         if (scene.Filter != null)
         {
             if (scene.Filter.SetpointsOnly.HasValue)
-                vm.ShowSetpointsOnly = scene.Filter.SetpointsOnly.Value;
+                vm.Filter.ShowSetpointsOnly = scene.Filter.SetpointsOnly.Value;
             if (scene.Filter.SearchText != null)
             {
-                vm.SearchQuery = scene.Filter.SearchText;
+                vm.Filter.SearchQuery = scene.Filter.SearchText;
                 vm.FlushPendingSearch();
             }
         }
@@ -513,7 +513,7 @@ public static class SceneApplier
             CollapseRecursive(root);
         vm.SelectedFlatMember = null;
         vm.SelectedScope = null;
-        vm.SearchQuery = "";
+        vm.Filter.SearchQuery = "";
         // Reset NewValue without tripping the user-touched flag so the next
         // scene's member selection can still drive the normal prefill path.
         vm.ResetNewValueSilent();

--- a/src/BlockParam.Tests/BulkChangeViewModelMultiDbTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelMultiDbTests.cs
@@ -409,13 +409,13 @@ public class BulkChangeViewModelMultiDbTests
         // common substring in member names. "speed" appears in flat-db.xml.
         // Even if it doesn't match in the peer, the multi-DB code path
         // still has to run against it without crashing.
-        vm.SearchQuery = "speed";
+        vm.Filter.SearchQuery = "speed";
 
         // No assertion on a specific number — the test asserts the wiring
         // (no crash, hit count is consistent with the AND-over-DBs result).
         // The pre-fix bug would silently report only focused-DB hits even
         // if the peer DB had matching members.
-        vm.SearchHitCount.Should().BeGreaterOrEqualTo(0);
+        vm.Filter.SearchHitCount.Should().BeGreaterOrEqualTo(0);
     }
 
     [Fact]

--- a/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
@@ -143,12 +143,12 @@ public class BulkChangeViewModelRegressionTests : IDisposable
     {
         var vm = CreateTwoDbVm();
 
-        vm.SearchQuery = "Speed";
+        vm.Filter.SearchQuery = "Speed";
         vm.FlushPendingSearch(); // cancels debounce, runs synchronously
 
         // FlatDB: "Speed" → 1 hit
         // NestedStructDB: "MaxSpeed" + "MinSpeed" → 2 hits
-        vm.SearchHitCount.Should().Be(3,
+        vm.Filter.SearchHitCount.Should().Be(3,
             "search hit count must sum across all active DBs: " +
             "FlatDB.Speed(1) + NestedStructDB.MaxSpeed+MinSpeed(2) = 3");
     }
@@ -178,7 +178,7 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         var configRoot = vm.RootMembers.FirstOrDefault(r => r.Name == "Config");
         configRoot.Should().NotBeNull("fixture must have a Config struct");
 
-        vm.SearchQuery = "Timeout";
+        vm.Filter.SearchQuery = "Timeout";
         vm.FlushPendingSearch();
 
         // After search the ancestor chain Config → Config.Settings must be expanded
@@ -216,9 +216,9 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         }");
         var vm = CreateFlatDbVm(configLoader: configLoader);
 
-        vm.HiddenByRuleCount.Should().Be(1,
+        vm.Filter.HiddenByRuleCount.Should().Be(1,
             "one rule hides Speed — count must be 1");
-        vm.ShowRuleFilterBanner.Should().BeTrue(
+        vm.Filter.ShowRuleFilterBanner.Should().BeTrue(
             "banner is shown whenever at least one member is hidden by a rule");
     }
 
@@ -906,7 +906,7 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         var vm = CreateFlatDbVm(licenseService: licenseService);
 
         // Kick both debounce timers
-        vm.SearchQuery = "Speed";    // schedules _searchDebounceTimer
+        vm.Filter.SearchQuery = "Speed";    // schedules Filter slice debounce timer
         vm.NewValue = "42";          // schedules _valueDebounceTimer
 
         var usageTextBefore = vm.Subscription.UsageStatusText;

--- a/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
@@ -222,6 +222,85 @@ public class BulkChangeViewModelRegressionTests : IDisposable
             "banner is shown whenever at least one member is hidden by a rule");
     }
 
+    /// <summary>
+    /// Test 4 — When an active-set change swaps the anchor to a DB with a
+    /// different UDT-resolution outcome, <see cref="SearchFilterViewModel.CanShowSetpointsOnly"/>
+    /// and <see cref="SearchFilterViewModel.ShowSetpointsOnlyTooltip"/> must
+    /// refresh. Both derive from <c>_active.Info.UnresolvedUdts</c> via the
+    /// slice's <c>getAnchorInfo</c> closure, and the slice has no way to
+    /// observe the anchor change on its own — the host's
+    /// <c>RebuildAfterActiveSetChanged</c> cascade has to call
+    /// <see cref="SearchFilterViewModel.RaiseSetpointsCapabilityChanged"/>.
+    /// Before this fix the checkbox stayed enabled-or-disabled based on the
+    /// original anchor even after the user removed it.
+    /// </summary>
+    [Fact]
+    public void ActiveSetChange_AnchorSwap_RaisesSetpointsCapability()
+    {
+        // Anchor: clean (no UnresolvedUdts) → CanShowSetpointsOnly==true.
+        // Peer:   has UnresolvedUdts + no UDT-refresh path → would be FALSE.
+        var anchorInfo = new DataBlockInfo(
+            "DB_Anchor", 1, "Optimized", "GlobalDB",
+            Array.Empty<MemberNode>(),
+            unresolvedUdts: Array.Empty<string>());
+        var peerInfo = new DataBlockInfo(
+            "DB_Peer", 2, "Optimized", "GlobalDB",
+            Array.Empty<MemberNode>(),
+            unresolvedUdts: new[] { "messageConfig_UDT" });
+
+        var configLoader = new ConfigLoader(null);
+        var bulkService = new BulkChangeService(new ChangeLogger(), configLoader);
+        var tracker = Substitute.For<IUsageTracker>();
+        tracker.GetStatus().Returns(new UsageStatus(0, 1000));
+        tracker.RecordUsage(Arg.Any<int>()).Returns(true);
+
+        // No onRefreshUdtTypes wired → CanShowSetpointsOnly tracks
+        // UnresolvedUdts.Count directly.
+        var vm = new BulkChangeViewModel(
+            anchorInfo, currentXml: "<Block />",
+            new HierarchyAnalyzer(), bulkService, tracker, configLoader,
+            messageBox: new NopMessageBox(),
+            additionalActiveDbs: new[] { new ActiveDb(peerInfo, "<Block />") });
+
+        vm.Filter.CanShowSetpointsOnly.Should().BeTrue(
+            "starting anchor has 0 unresolved UDTs and no refresh path → enabled");
+        vm.Filter.ShowSetpointsOnlyTooltip.Should().NotContain("Disabled",
+            "clean anchor: tooltip describes the filter, not the disabled state");
+
+        // Subscribe AFTER construction so the seed cascade doesn't poison the list.
+        var capabilityRaises = 0;
+        var tooltipRaises = 0;
+        vm.Filter.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(SearchFilterViewModel.CanShowSetpointsOnly))
+                capabilityRaises++;
+            if (e.PropertyName == nameof(SearchFilterViewModel.ShowSetpointsOnlyTooltip))
+                tooltipRaises++;
+        };
+
+        // Remove the anchor → peer (with UnresolvedUdts) becomes the new anchor.
+        // RequestRemoveActiveDb runs the State setter, which fires
+        // RebuildAfterActiveSetChanged → Filter.RaiseSetpointsCapabilityChanged().
+        var anchorDb = vm.AllActiveDbs.First(d => d.Info.Name == "DB_Anchor");
+        vm.RequestRemoveActiveDb(anchorDb);
+
+        vm.AllActiveDbs.Should().HaveCount(1);
+        vm.AllActiveDbs[0].Info.Name.Should().Be("DB_Peer",
+            "after removing the original anchor the peer occupies index 0");
+
+        capabilityRaises.Should().BeGreaterOrEqualTo(1,
+            "anchor swap must raise PropertyChanged for CanShowSetpointsOnly so the " +
+            "checkbox state can refresh");
+        tooltipRaises.Should().BeGreaterOrEqualTo(1,
+            "anchor swap must raise PropertyChanged for ShowSetpointsOnlyTooltip so the " +
+            "tooltip text refreshes");
+
+        vm.Filter.CanShowSetpointsOnly.Should().BeFalse(
+            "new anchor has 1 UnresolvedUdt and no refresh path → disabled");
+        vm.Filter.ShowSetpointsOnlyTooltip.Should().Contain("messageConfig_UDT",
+            "tooltip must surface the now-current anchor's missing UDT name");
+    }
+
     // ─────────────────────────────────────────────────────────────────────
     // Group B: BulkPreview rebuild
     // ─────────────────────────────────────────────────────────────────────

--- a/src/BlockParam.Tests/SearchFilterViewModelTests.cs
+++ b/src/BlockParam.Tests/SearchFilterViewModelTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Threading;
 using System.Windows.Threading;
 using BlockParam.Models;
 using BlockParam.UI;
@@ -190,6 +191,40 @@ public class SearchFilterViewModelTests
         raised.Should().Contain(nameof(SearchFilterViewModel.ShowSetpointsOnlyTooltip));
     }
 
+    /// <summary>
+    /// Headline reason the slice uses a <see cref="System.Threading.Timer"/>
+    /// + dispatcher trampoline rather than WPF's built-in <c>Binding.Delay</c>
+    /// is to coalesce consecutive keystrokes: a burst of edits inside the
+    /// 200&#160;ms window must result in exactly one filter pass on the
+    /// final value, not one per keystroke. Regression guard so a future
+    /// refactor of the setter (e.g. dropping the <c>_searchDebounceTimer?.Dispose()</c>
+    /// before re-arming) doesn't silently restore per-keystroke filtering.
+    /// </summary>
+    [Fact]
+    public void SearchQuery_RapidKeystrokes_CoalesceIntoSingleCallback()
+    {
+        int callbackCount = 0;
+        var vm = Build(onFiltersChanged: () => Interlocked.Increment(ref callbackCount));
+
+        vm.SearchQuery = "S";
+        vm.SearchQuery = "Sp";
+        vm.SearchQuery = "Spe";
+
+        // Wait past the 200ms debounce window so the third (latest) timer
+        // can fire; the first two should have been disposed and never run.
+        Thread.Sleep(400);
+
+        // Timer callbacks land on the threadpool and post their work via
+        // _dispatcher.BeginInvoke(...). The test thread's dispatcher queue
+        // doesn't pump on its own — drain it explicitly so the coalesced
+        // callback runs before we assert.
+        PumpDispatcher();
+
+        callbackCount.Should().Be(1,
+            "three consecutive keystrokes inside the 200ms window must coalesce " +
+            "into one filter pass; otherwise WPF would over-filter on every keystroke");
+    }
+
     [Fact]
     public void Dispose_IsIdempotent()
     {
@@ -242,5 +277,21 @@ public class SearchFilterViewModelTests
         var raised = new List<string?>();
         vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
         return raised;
+    }
+
+    /// <summary>
+    /// Drain the current thread's dispatcher queue by pushing a frame that
+    /// exits as soon as a background-priority continuation runs. Needed in
+    /// tests where the slice's debounce timer posts work via
+    /// <c>BeginInvoke</c> — without pumping, the posted action sits in the
+    /// queue and our assertions race the dispatcher.
+    /// </summary>
+    private static void PumpDispatcher()
+    {
+        var frame = new DispatcherFrame();
+        Dispatcher.CurrentDispatcher.BeginInvoke(
+            DispatcherPriority.Background,
+            new Action(() => frame.Continue = false));
+        Dispatcher.PushFrame(frame);
     }
 }

--- a/src/BlockParam.Tests/SearchFilterViewModelTests.cs
+++ b/src/BlockParam.Tests/SearchFilterViewModelTests.cs
@@ -203,23 +203,32 @@ public class SearchFilterViewModelTests
     [Fact]
     public void SearchQuery_RapidKeystrokes_CoalesceIntoSingleCallback()
     {
+        using var done = new ManualResetEventSlim();
         int callbackCount = 0;
-        var vm = Build(onFiltersChanged: () => Interlocked.Increment(ref callbackCount));
+        var vm = Build(onFiltersChanged: () =>
+        {
+            Interlocked.Increment(ref callbackCount);
+            done.Set();
+        });
 
         vm.SearchQuery = "S";
         vm.SearchQuery = "Sp";
         vm.SearchQuery = "Spe";
 
-        // Wait past the 200ms debounce window so the third (latest) timer
-        // can fire; the first two should have been disposed and never run.
-        Thread.Sleep(400);
+        // The threadpool timer fires ~200ms after the last setter, then
+        // posts work via _dispatcher.BeginInvoke. The test thread's
+        // dispatcher only drains when we pump it, so poll-pump until the
+        // callback signals (or we time out generously).
+        var deadline = DateTime.UtcNow.AddSeconds(3);
+        while (DateTime.UtcNow < deadline && !done.IsSet)
+        {
+            PumpDispatcher();
+            if (done.IsSet) break;
+            Thread.Sleep(25);
+        }
 
-        // Timer callbacks land on the threadpool and post their work via
-        // _dispatcher.BeginInvoke(...). The test thread's dispatcher queue
-        // doesn't pump on its own — drain it explicitly so the coalesced
-        // callback runs before we assert.
-        PumpDispatcher();
-
+        done.IsSet.Should().BeTrue(
+            "the debounce timer must eventually fire its filter callback");
         callbackCount.Should().Be(1,
             "three consecutive keystrokes inside the 200ms window must coalesce " +
             "into one filter pass; otherwise WPF would over-filter on every keystroke");

--- a/src/BlockParam.Tests/SearchFilterViewModelTests.cs
+++ b/src/BlockParam.Tests/SearchFilterViewModelTests.cs
@@ -1,0 +1,246 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Windows.Threading;
+using BlockParam.Models;
+using BlockParam.UI;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Focused tests for the search + tree-filter slice (#80 slice 6).
+/// </summary>
+public class SearchFilterViewModelTests
+{
+    [Fact]
+    public void Defaults_AreEmpty()
+    {
+        var vm = Build();
+
+        vm.SearchQuery.Should().BeEmpty();
+        vm.HasSearchQuery.Should().BeFalse();
+        vm.SearchHitCount.Should().Be(0);
+        vm.HiddenByRuleCount.Should().Be(0);
+        vm.ShowRuleFilterBanner.Should().BeFalse();
+        vm.RuleFilterBannerText.Should().Contain("0");
+        vm.ShowSetpointsOnly.Should().BeFalse();
+        vm.HasPendingSearchDebounce.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SearchQuery_Setter_RaisesPropertyChangedAndSchedulesDebounce()
+    {
+        var vm = Build();
+        var raised = Capture(vm);
+
+        vm.SearchQuery = "Speed";
+
+        vm.SearchQuery.Should().Be("Speed");
+        vm.HasSearchQuery.Should().BeTrue();
+        vm.HasPendingSearchDebounce.Should().BeTrue(
+            "a 200ms debounce timer must be armed after a keystroke");
+        raised.Should().Contain(nameof(SearchFilterViewModel.SearchQuery));
+        raised.Should().Contain(nameof(SearchFilterViewModel.HasSearchQuery));
+    }
+
+    [Fact]
+    public void FlushPendingSearch_CancelsTimerAndFiresCallback()
+    {
+        int callbackCount = 0;
+        var vm = Build(onFiltersChanged: () => callbackCount++);
+
+        vm.SearchQuery = "Speed";
+        vm.HasPendingSearchDebounce.Should().BeTrue();
+        // The setter armed a 200ms timer; without flush the callback would fire
+        // asynchronously after delay. We verify flush cancels the timer + fires
+        // immediately.
+        callbackCount.Should().Be(0, "setter alone does not invoke callback synchronously");
+
+        vm.FlushPendingSearch();
+
+        vm.HasPendingSearchDebounce.Should().BeFalse();
+        callbackCount.Should().Be(1, "FlushPendingSearch must fire the filter callback");
+    }
+
+    [Fact]
+    public void SearchHitCount_Set_RaisesPropertyChanged()
+    {
+        var vm = Build();
+        var raised = Capture(vm);
+
+        vm.SearchHitCount = 7;
+
+        vm.SearchHitCount.Should().Be(7);
+        raised.Should().Contain(nameof(SearchFilterViewModel.SearchHitCount));
+    }
+
+    [Fact]
+    public void HiddenByRuleCount_Set_RaisesBannerPropertiesAndCount()
+    {
+        var vm = Build();
+        var raised = Capture(vm);
+
+        vm.HiddenByRuleCount = 3;
+
+        vm.HiddenByRuleCount.Should().Be(3);
+        vm.ShowRuleFilterBanner.Should().BeTrue();
+        raised.Should().Contain(nameof(SearchFilterViewModel.HiddenByRuleCount));
+        raised.Should().Contain(nameof(SearchFilterViewModel.ShowRuleFilterBanner));
+        raised.Should().Contain(nameof(SearchFilterViewModel.RuleFilterBannerText));
+    }
+
+    [Fact]
+    public void HiddenByRuleCount_SameValue_DoesNotRaise()
+    {
+        var vm = Build();
+        var raised = Capture(vm);
+
+        vm.HiddenByRuleCount = 0; // already 0
+
+        raised.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ShowSetpointsOnly_OffToOn_FiresSetpointsCallbackThenFilterCallback()
+    {
+        int setpointsCallback = 0;
+        int filtersCallback = 0;
+        var vm = Build(
+            onFiltersChanged: () => filtersCallback++,
+            onSetpointsTurnedOn: () => setpointsCallback++);
+
+        vm.ShowSetpointsOnly = true;
+
+        vm.ShowSetpointsOnly.Should().BeTrue();
+        setpointsCallback.Should().Be(1, "OFF→ON transition must fire the UDT-refresh callback");
+        filtersCallback.Should().Be(1, "every toggle must request a filter pass");
+    }
+
+    [Fact]
+    public void ShowSetpointsOnly_OnToOff_DoesNotFireSetpointsCallback()
+    {
+        int setpointsCallback = 0;
+        int filtersCallback = 0;
+        var vm = Build(
+            onFiltersChanged: () => filtersCallback++,
+            onSetpointsTurnedOn: () => setpointsCallback++);
+
+        vm.ShowSetpointsOnly = true;
+        setpointsCallback.Should().Be(1);
+
+        vm.ShowSetpointsOnly = false;
+
+        vm.ShowSetpointsOnly.Should().BeFalse();
+        setpointsCallback.Should().Be(1, "ON→OFF transition must not re-refresh UDTs");
+        filtersCallback.Should().Be(2, "OFF→ON and ON→OFF both must request a filter pass");
+    }
+
+    [Fact]
+    public void ShowSetpointsOnly_SameValue_DoesNotFireFilterCallback()
+    {
+        int filtersCallback = 0;
+        var vm = Build(onFiltersChanged: () => filtersCallback++);
+
+        vm.ShowSetpointsOnly = false; // already false
+
+        filtersCallback.Should().Be(0);
+    }
+
+    [Fact]
+    public void CanShowSetpointsOnly_FalseWhenUnresolvedAndNoRefresh()
+    {
+        var info = MakeInfo(unresolved: new[] { "messageConfig_UDT" });
+        var vm = Build(getAnchorInfo: () => info, hasUdtRefresh: false);
+
+        vm.CanShowSetpointsOnly.Should().BeFalse();
+        vm.ShowSetpointsOnlyTooltip.Should().Contain("messageConfig_UDT");
+        vm.ShowSetpointsOnlyTooltip.Should().Contain("Disabled");
+    }
+
+    [Fact]
+    public void CanShowSetpointsOnly_TrueWhenHasRefreshEvenIfUnresolved()
+    {
+        var info = MakeInfo(unresolved: new[] { "messageConfig_UDT" });
+        var vm = Build(getAnchorInfo: () => info, hasUdtRefresh: true);
+
+        vm.CanShowSetpointsOnly.Should().BeTrue();
+        vm.ShowSetpointsOnlyTooltip.Should().Contain("re-exported");
+    }
+
+    [Fact]
+    public void CanShowSetpointsOnly_TrueWhenAllUdtsResolved()
+    {
+        var info = MakeInfo(unresolved: new string[0]);
+        var vm = Build(getAnchorInfo: () => info);
+
+        vm.CanShowSetpointsOnly.Should().BeTrue();
+        vm.ShowSetpointsOnlyTooltip.Should().Contain("SetPoint");
+    }
+
+    [Fact]
+    public void RaiseSetpointsCapabilityChanged_NotifiesCapabilityAndTooltip()
+    {
+        var vm = Build();
+        var raised = Capture(vm);
+
+        vm.RaiseSetpointsCapabilityChanged();
+
+        raised.Should().Contain(nameof(SearchFilterViewModel.CanShowSetpointsOnly));
+        raised.Should().Contain(nameof(SearchFilterViewModel.ShowSetpointsOnlyTooltip));
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var vm = Build();
+
+        var ex1 = Record.Exception(() => vm.Dispose());
+        ex1.Should().BeNull();
+
+        var ex2 = Record.Exception(() => vm.Dispose());
+        ex2.Should().BeNull();
+    }
+
+    [Fact]
+    public void Dispose_AfterArmedDebounce_DoesNotThrow()
+    {
+        var vm = Build();
+        vm.SearchQuery = "Speed";
+        vm.HasPendingSearchDebounce.Should().BeTrue();
+
+        var ex = Record.Exception(() => vm.Dispose());
+        ex.Should().BeNull();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────
+
+    private static SearchFilterViewModel Build(
+        Func<DataBlockInfo>? getAnchorInfo = null,
+        bool hasUdtRefresh = false,
+        Action? onFiltersChanged = null,
+        Action? onSetpointsTurnedOn = null)
+    {
+        return new SearchFilterViewModel(
+            Dispatcher.CurrentDispatcher,
+            getAnchorInfo ?? (() => MakeInfo()),
+            hasUdtRefresh,
+            onFiltersChanged ?? (() => { }),
+            onSetpointsTurnedOn);
+    }
+
+    private static DataBlockInfo MakeInfo(IReadOnlyList<string>? unresolved = null) =>
+        new DataBlockInfo(
+            "DB_Test", 1, "Optimized", "GlobalDB",
+            Array.Empty<MemberNode>(),
+            unresolved);
+
+    private static List<string?> Capture(INotifyPropertyChanged vm)
+    {
+        var raised = new List<string?>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        return raised;
+    }
+}

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -278,25 +278,25 @@
                               Fill="#666" Width="14" Height="14" Stretch="Uniform"/>
                     </Button>
                     <CheckBox Content="{loc:Loc Dialog_ShowSetpointsOnly}"
-                              IsChecked="{Binding ShowSetpointsOnly}"
-                              IsEnabled="{Binding CanShowSetpointsOnly}"
-                              ToolTip="{Binding ShowSetpointsOnlyTooltip}"
+                              IsChecked="{Binding Filter.ShowSetpointsOnly}"
+                              IsEnabled="{Binding Filter.CanShowSetpointsOnly}"
+                              ToolTip="{Binding Filter.ShowSetpointsOnlyTooltip}"
                               VerticalAlignment="Center" Margin="0,0,0,0" DockPanel.Dock="Left"/>
                     <TextBox x:Name="SearchBox"
-                             Text="{Binding SearchQuery, UpdateSourceTrigger=PropertyChanged}"
+                             Text="{Binding Filter.SearchQuery, UpdateSourceTrigger=PropertyChanged}"
                              Width="200" Padding="4,2" VerticalAlignment="Center"
                              Margin="12,0,0,0" DockPanel.Dock="Left"/>
-                    <TextBlock Text="{Binding SearchHitCount, StringFormat='{}{0} hits'}"
+                    <TextBlock Text="{Binding Filter.SearchHitCount, StringFormat='{}{0} hits'}"
                                VerticalAlignment="Center" Foreground="#888"
                                HorizontalAlignment="Right" Margin="8,0,8,0"
-                               Visibility="{Binding HasSearchQuery, Converter={StaticResource BoolToVis}}"/>
+                               Visibility="{Binding Filter.HasSearchQuery, Converter={StaticResource BoolToVis}}"/>
                 </DockPanel>
 
                 <!-- Passive banner: rule filter hiding members (#23) -->
                 <Border DockPanel.Dock="Top"
                         Background="#FFF8E1" BorderBrush="#E0C97F" BorderThickness="1"
                         Padding="8,4" Margin="0,0,0,4"
-                        Visibility="{Binding ShowRuleFilterBanner, Converter={StaticResource BoolToVis}}">
+                        Visibility="{Binding Filter.ShowRuleFilterBanner, Converter={StaticResource BoolToVis}}">
                     <DockPanel>
                         <Button DockPanel.Dock="Right"
                                 Content="{loc:Loc Dialog_RuleFilterBanner_Link}"
@@ -304,7 +304,7 @@
                                 Background="Transparent" BorderThickness="0"
                                 Foreground="#0078D7" Cursor="Hand" Padding="4,0"
                                 VerticalAlignment="Center"/>
-                        <TextBlock Text="{Binding RuleFilterBannerText}"
+                        <TextBlock Text="{Binding Filter.RuleFilterBannerText}"
                                    Foreground="#6B5500" VerticalAlignment="Center"/>
                     </DockPanel>
                 </Border>

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -164,12 +164,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private string _statusText = "";
     private string _validationError = "";
     private string _constraintInfo = "";
-    private string _searchQuery = "";
-    private int _searchHitCount;
-    private Timer? _searchDebounceTimer;
     private Timer? _valueDebounceTimer;
-    private int _hiddenByRuleCount;
-    private bool _showSetpointsOnly;
     private bool _showConstants;
     private bool _constantsForced;
     private string _tagTableAge = "";
@@ -253,6 +248,20 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             : null;
         // Autocomplete suggestion slice (#80 slice 3).
         Autocomplete = new AutocompleteViewModel();
+        // Search + tree-filter slice (#80 slice 6). Slice owns SearchQuery /
+        // SetPoint toggle / banner state; the filter pass itself (ApplyAllFilters
+        // + RefreshFlatList) stays here because it walks the multi-DB tree
+        // and is too entangled with host state to move in this PR.
+        Filter = new SearchFilterViewModel(
+            _dispatcher,
+            getAnchorInfo: () => _active.Info,
+            hasUdtRefresh: _onRefreshUdtTypes != null,
+            onFiltersChanged: () =>
+            {
+                ApplyAllFilters();
+                RefreshFlatList();
+            },
+            onSetpointsTurnedOn: _onRefreshUdtTypes != null ? TryRefreshUdtCache : (Action?)null);
 
         UpdateTagTableAge();
 
@@ -432,6 +441,13 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     public PendingEditsViewModel Pending { get; }
 
     /// <summary>
+    /// Search + tree-filter slice (#80 slice 6). Owns the search box,
+    /// search-hit / hidden-by-rule counters, and the SetPoint-only toggle.
+    /// XAML binds via <c>{Binding Filter.SearchQuery}</c> etc.
+    /// </summary>
+    public SearchFilterViewModel Filter { get; }
+
+    /// <summary>
     /// One entry per DB the user has switched away from with un-applied
     /// pending edits (#59). Each entry renders as its own inspector section
     /// so the staged work stays visible across switches; clicking the section
@@ -565,110 +581,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             }
         }
     }
-
-    public string SearchQuery
-    {
-        get => _searchQuery;
-        set
-        {
-            if (SetProperty(ref _searchQuery, value))
-            {
-                OnPropertyChanged(nameof(HasSearchQuery));
-                // Debounce search: WPF Binding.Delay uses DispatcherTimer which
-                // doesn't work reliably when hosted inside TIA Portal (WinForms host
-                // without Application.Current). Use Threading.Timer + Dispatcher instead.
-                _searchDebounceTimer?.Dispose();
-                _searchDebounceTimer = new Timer(_ =>
-                {
-                    _dispatcher.BeginInvoke(new Action(() =>
-                    {
-                        ApplyAllFilters();
-                        RefreshFlatList();
-                    }));
-                }, null, 200, Timeout.Infinite);
-            }
-        }
-    }
-
-    public int SearchHitCount
-    {
-        get => _searchHitCount;
-        private set => SetProperty(ref _searchHitCount, value);
-    }
-
-    public bool HasSearchQuery => !string.IsNullOrWhiteSpace(_searchQuery);
-
-    /// <summary>
-    /// Number of leaf members currently hidden by <c>excludeFromSetpoints</c> rules.
-    /// Rules are always applied — the banner surfaces their effect so users understand
-    /// why entries are missing and can open the Config Editor to review them (#23).
-    /// </summary>
-    public int HiddenByRuleCount
-    {
-        get => _hiddenByRuleCount;
-        private set
-        {
-            if (SetProperty(ref _hiddenByRuleCount, value))
-            {
-                OnPropertyChanged(nameof(ShowRuleFilterBanner));
-                OnPropertyChanged(nameof(RuleFilterBannerText));
-            }
-        }
-    }
-
-    /// <summary>True when at least one rule is currently hiding a leaf member.</summary>
-    public bool ShowRuleFilterBanner => _hiddenByRuleCount > 0;
-
-    /// <summary>Localized banner text: "Rule filter is hiding N member(s) — review rules in Config Editor".</summary>
-    public string RuleFilterBannerText => Res.Format("Dialog_RuleFilterBanner", _hiddenByRuleCount);
-
-    /// <summary>
-    /// When on, hide every leaf that is not a UDT-resolved SetPoint. AND-combined
-    /// with the always-on rule filter. If UDT types are missing when toggled on,
-    /// the VM transparently exports them from TIA Portal and re-parses the DB.
-    /// </summary>
-    public bool ShowSetpointsOnly
-    {
-        get => _showSetpointsOnly;
-        set
-        {
-            // On OFF→ON we revalidate the UDT cache against TIA's ModifiedDate stamps.
-            // The check is cheap when nothing changed; stale entries get re-exported.
-            if (value && !_showSetpointsOnly && _onRefreshUdtTypes != null)
-                TryRefreshUdtCache();
-
-            if (SetProperty(ref _showSetpointsOnly, value))
-            {
-                ApplyAllFilters();
-                RefreshFlatList();
-            }
-        }
-    }
-
-    /// <summary>
-    /// The checkbox is enabled unless we are certain the filter cannot work —
-    /// i.e. the DB references UDTs that are not cached AND no refresh path is wired.
-    /// When a refresh callback exists, clicking triggers a fresh export automatically.
-    /// </summary>
-    public bool CanShowSetpointsOnly
-        => _active.Info.UnresolvedUdts.Count == 0 || _onRefreshUdtTypes != null;
-
-    /// <summary>Tooltip shown on the checkbox.</summary>
-    public string ShowSetpointsOnlyTooltip
-    {
-        get
-        {
-            if (_active.Info.UnresolvedUdts.Count == 0)
-                return "Only show members marked as SetPoint (Einstellwert) in the UDT type definition.";
-
-            if (_onRefreshUdtTypes != null)
-                return "Only show members marked as SetPoint. UDT types will be re-exported from TIA Portal when enabled.";
-
-            var missing = string.Join(", ", _active.Info.UnresolvedUdts);
-            return $"Disabled: UDT type definitions are missing ({missing}) and no PLC connection is available to export them.";
-        }
-    }
-
 
     public string StatusText
     {
@@ -2381,16 +2293,13 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
     /// <summary>
     /// Scripted-only companion to <see cref="FlushPendingHighlighting"/>:
-    /// cancels the 200ms debounce on <see cref="SearchQuery"/> and runs the
-    /// filter + flat-list refresh synchronously.
+    /// cancels the 200ms debounce on <see cref="SearchFilterViewModel.SearchQuery"/>
+    /// and runs the filter + flat-list refresh synchronously. Delegates to
+    /// <see cref="SearchFilterViewModel.FlushPendingSearch"/> on the
+    /// <see cref="Filter"/> slice; kept as a host-side shim so existing test /
+    /// capture-script call sites don't have to chase the new path.
     /// </summary>
-    internal void FlushPendingSearch()
-    {
-        _searchDebounceTimer?.Dispose();
-        _searchDebounceTimer = null;
-        ApplyAllFilters();
-        RefreshFlatList();
-    }
+    internal void FlushPendingSearch() => Filter.FlushPendingSearch();
 
     /// <summary>
     /// Scripted-only: clears <see cref="NewValue"/> and the internal
@@ -2881,17 +2790,18 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // path leaves in other active DBs as search hits.
         var perDbSearchPaths = new Dictionary<ActiveDb, HashSet<string>>();
         int totalSearchHits = 0;
-        if (!string.IsNullOrWhiteSpace(_searchQuery))
+        var searchQuery = Filter.SearchQuery;
+        if (!string.IsNullOrWhiteSpace(searchQuery))
         {
             foreach (var db in AllActiveDbs)
             {
-                var result = _searchService.Search(db.Info, _searchQuery);
+                var result = _searchService.Search(db.Info, searchQuery);
                 perDbSearchPaths[db] =
                     new HashSet<string>(result.Matches.Select(m => m.Path));
                 totalSearchHits += result.HitCount;
             }
         }
-        SearchHitCount = totalSearchHits;
+        Filter.SearchHitCount = totalSearchHits;
 
         var config = _configLoader.GetConfig();
 
@@ -2908,7 +2818,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                 totalHidden += db.Info.AllMembers().Count(m => m.IsLeaf && excl.Contains(m.Path));
             }
         }
-        HiddenByRuleCount = totalHidden;
+        Filter.HiddenByRuleCount = totalHidden;
 
         if (HasMultipleActiveDbs)
         {
@@ -2924,7 +2834,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                     ruleFilterActive: true,
                     searchMatchPaths: sp,
                     excludedByRules: ex,
-                    showSetpointsOnly: _showSetpointsOnly);
+                    showSetpointsOnly: Filter.ShowSetpointsOnly);
                 if (sp != null) SmartExpandSearchMatches(syntheticRoot, sp);
             }
         }
@@ -2933,7 +2843,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             perDbSearchPaths.TryGetValue(_active, out var searchPaths);
             perDbExcludeSet.TryGetValue(_active, out var excludeSet);
             foreach (var root in RootMembers)
-                root.ApplyFilter(ruleFilterActive: true, searchPaths, excludeSet, _showSetpointsOnly);
+                root.ApplyFilter(ruleFilterActive: true, searchPaths, excludeSet, Filter.ShowSetpointsOnly);
             if (searchPaths != null)
             {
                 foreach (var root in RootMembers)
@@ -2958,7 +2868,8 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// </summary>
     private void ReExpandNonAffected()
     {
-        if (string.IsNullOrWhiteSpace(_searchQuery)) return;
+        var searchQuery = Filter.SearchQuery;
+        if (string.IsNullOrWhiteSpace(searchQuery)) return;
 
         if (HasMultipleActiveDbs)
         {
@@ -2968,14 +2879,14 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             {
                 var db = kvp.Key;
                 var syntheticRoot = kvp.Value;
-                var result = _searchService.Search(db.Info, _searchQuery);
+                var result = _searchService.Search(db.Info, searchQuery);
                 var searchPaths = new HashSet<string>(result.Matches.Select(m => m.Path));
                 SmartExpandSearchMatches(syntheticRoot, searchPaths);
             }
         }
         else
         {
-            var result = _searchService.Search(_active.Info, _searchQuery);
+            var result = _searchService.Search(_active.Info, searchQuery);
             var searchPaths = new HashSet<string>(result.Matches.Select(m => m.Path));
             foreach (var root in RootMembers)
                 SmartExpandSearchMatches(root, searchPaths);
@@ -3197,8 +3108,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
             RefreshTree(_active.Xml, resolver, commentResolver);
 
-            OnPropertyChanged(nameof(CanShowSetpointsOnly));
-            OnPropertyChanged(nameof(ShowSetpointsOnlyTooltip));
+            Filter.RaiseSetpointsCapabilityChanged();
         }
         catch (Exception ex)
         {
@@ -4469,10 +4379,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         _valueDebounceTimer?.Dispose();
         _valueDebounceTimer = null;
-        _searchDebounceTimer?.Dispose();
-        _searchDebounceTimer = null;
 
-        // Subscription owns the LicenseStateChanged subscription (#80 slice 2).
+        // Slices own their own disposable state.
+        Filter.Dispose();
         Subscription.Dispose();
     }
 }

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -1594,6 +1594,13 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // inspector header badge/summary stays stale until the next
         // ComputeBulkPreview cycle.
         BulkPreview.RaiseDerivedChanged();
+        // CanShowSetpointsOnly / ShowSetpointsOnlyTooltip derive from the
+        // anchor's UnresolvedUdts via the Filter slice's getAnchorInfo
+        // closure. When the active-set change swaps the anchor to a DB with
+        // a different UDT-resolution outcome, the checkbox's enabled state
+        // and tooltip have to refresh — the slice has no way to observe the
+        // anchor change on its own.
+        Filter.RaiseSetpointsCapabilityChanged();
         OnPropertyChanged(nameof(HasMultipleActiveDbs));
         OnPropertyChanged(nameof(SelectedFlatMember));
         OnPropertyChanged(nameof(SelectedScope));

--- a/src/BlockParam/UI/SearchFilterViewModel.cs
+++ b/src/BlockParam/UI/SearchFilterViewModel.cs
@@ -1,0 +1,210 @@
+using System.Threading;
+using System.Windows.Threading;
+using BlockParam.Localization;
+using BlockParam.Models;
+
+namespace BlockParam.UI;
+
+/// <summary>
+/// Search + tree-filter slice (#80 slice 6).
+///
+/// <para>
+/// Owns the search box state (<see cref="SearchQuery"/> with its 200&#160;ms
+/// debounce timer, <see cref="SearchHitCount"/>, <see cref="HasSearchQuery"/>),
+/// the rule-filter banner counters
+/// (<see cref="HiddenByRuleCount"/> /
+/// <see cref="ShowRuleFilterBanner"/> / <see cref="RuleFilterBannerText"/>),
+/// and the SetPoint-only toggle plus its capability/tooltip properties
+/// (<see cref="ShowSetpointsOnly"/>, <see cref="CanShowSetpointsOnly"/>,
+/// <see cref="ShowSetpointsOnlyTooltip"/>).
+/// </para>
+///
+/// <para>
+/// The actual filter application stays on the host VM —
+/// <c>ApplyAllFilters()</c> + <c>RefreshFlatList()</c> walk the multi-DB
+/// tree and remain too entangled with host state (DB→synthetic-root map,
+/// rule loader, exclude-set builder) to migrate without a much larger
+/// change. The slice fires a single <c>onFiltersChanged</c> callback for
+/// every state transition that requires the tree to re-filter
+/// (debounced search keystroke, SetPoint toggle, scripted flush), and an
+/// optional <c>onSetpointsTurnedOn</c> callback so the host can refresh
+/// the UDT cache on the OFF→ON transition before the filter pass runs.
+/// </para>
+///
+/// <para>
+/// <see cref="ShowConstants"/> is intentionally <i>not</i> here even
+/// though the issue body lists it under this slice: it does not affect
+/// the tree filter, only the autocomplete suggestion list, and the
+/// natural home is the autocomplete slice in a future touch-up.
+/// </para>
+/// </summary>
+public class SearchFilterViewModel : ViewModelBase, IDisposable
+{
+    private readonly Dispatcher _dispatcher;
+    private readonly Func<DataBlockInfo> _getAnchorInfo;
+    private readonly bool _hasUdtRefresh;
+    private readonly Action _onFiltersChanged;
+    private readonly Action? _onSetpointsTurnedOn;
+
+    private string _searchQuery = "";
+    private int _searchHitCount;
+    private int _hiddenByRuleCount;
+    private bool _showSetpointsOnly;
+    private Timer? _searchDebounceTimer;
+    private bool _disposed;
+
+    public SearchFilterViewModel(
+        Dispatcher dispatcher,
+        Func<DataBlockInfo> getAnchorInfo,
+        bool hasUdtRefresh,
+        Action onFiltersChanged,
+        Action? onSetpointsTurnedOn = null)
+    {
+        _dispatcher = dispatcher;
+        _getAnchorInfo = getAnchorInfo;
+        _hasUdtRefresh = hasUdtRefresh;
+        _onFiltersChanged = onFiltersChanged;
+        _onSetpointsTurnedOn = onSetpointsTurnedOn;
+    }
+
+    /// <summary>
+    /// Search box text. Setter debounces 200&#160;ms before firing
+    /// <c>onFiltersChanged</c>; WPF's <c>Binding.Delay</c> uses a
+    /// <c>DispatcherTimer</c> that doesn't fire reliably inside TIA Portal's
+    /// WinForms host, hence the explicit <see cref="Timer"/>.
+    /// </summary>
+    public string SearchQuery
+    {
+        get => _searchQuery;
+        set
+        {
+            if (SetProperty(ref _searchQuery, value))
+            {
+                OnPropertyChanged(nameof(HasSearchQuery));
+                _searchDebounceTimer?.Dispose();
+                _searchDebounceTimer = new Timer(_ =>
+                {
+                    _dispatcher.BeginInvoke(new Action(_onFiltersChanged));
+                }, null, 200, Timeout.Infinite);
+            }
+        }
+    }
+
+    /// <summary>Total search hits across all active DBs (the host writes this from <c>ApplyAllFilters</c>).</summary>
+    public int SearchHitCount
+    {
+        get => _searchHitCount;
+        internal set => SetProperty(ref _searchHitCount, value);
+    }
+
+    public bool HasSearchQuery => !string.IsNullOrWhiteSpace(_searchQuery);
+
+    /// <summary>
+    /// Number of leaf members hidden by <c>excludeFromSetpoints</c> rules.
+    /// Host writes this from <c>ApplyAllFilters</c>; banner properties below
+    /// re-raise automatically when it changes.
+    /// </summary>
+    public int HiddenByRuleCount
+    {
+        get => _hiddenByRuleCount;
+        internal set
+        {
+            if (SetProperty(ref _hiddenByRuleCount, value))
+            {
+                OnPropertyChanged(nameof(ShowRuleFilterBanner));
+                OnPropertyChanged(nameof(RuleFilterBannerText));
+            }
+        }
+    }
+
+    public bool ShowRuleFilterBanner => _hiddenByRuleCount > 0;
+
+    public string RuleFilterBannerText => Res.Format("Dialog_RuleFilterBanner", _hiddenByRuleCount);
+
+    /// <summary>
+    /// When on, hide every leaf that is not a UDT-resolved SetPoint.
+    /// AND-combined with the always-on rule filter. On OFF→ON the optional
+    /// <c>onSetpointsTurnedOn</c> callback runs first so the host can
+    /// re-export UDT types if its cache is stale, then the filter pass
+    /// fires via <c>onFiltersChanged</c>.
+    /// </summary>
+    public bool ShowSetpointsOnly
+    {
+        get => _showSetpointsOnly;
+        set
+        {
+            if (value && !_showSetpointsOnly && _onSetpointsTurnedOn != null)
+                _onSetpointsTurnedOn();
+
+            if (SetProperty(ref _showSetpointsOnly, value))
+                _onFiltersChanged();
+        }
+    }
+
+    /// <summary>
+    /// The SetPoint-only checkbox is enabled unless the filter cannot work —
+    /// i.e. the anchor DB references UDTs that are not cached AND no refresh
+    /// path is wired. When a refresh callback exists, toggling on triggers
+    /// a fresh export automatically.
+    /// </summary>
+    public bool CanShowSetpointsOnly
+        => _getAnchorInfo().UnresolvedUdts.Count == 0 || _hasUdtRefresh;
+
+    /// <summary>Tooltip shown on the SetPoint-only checkbox.</summary>
+    public string ShowSetpointsOnlyTooltip
+    {
+        get
+        {
+            var info = _getAnchorInfo();
+            if (info.UnresolvedUdts.Count == 0)
+                return "Only show members marked as SetPoint (Einstellwert) in the UDT type definition.";
+
+            if (_hasUdtRefresh)
+                return "Only show members marked as SetPoint. UDT types will be re-exported from TIA Portal when enabled.";
+
+            var missing = string.Join(", ", info.UnresolvedUdts);
+            return $"Disabled: UDT type definitions are missing ({missing}) and no PLC connection is available to export them.";
+        }
+    }
+
+    /// <summary>
+    /// Re-raise <see cref="CanShowSetpointsOnly"/> +
+    /// <see cref="ShowSetpointsOnlyTooltip"/>. The host calls this after
+    /// the anchor DB changes or a successful UDT cache refresh, since both
+    /// derive from <c>_active.Info.UnresolvedUdts</c> and the slice has no
+    /// way to observe that.
+    /// </summary>
+    public void RaiseSetpointsCapabilityChanged()
+    {
+        OnPropertyChanged(nameof(CanShowSetpointsOnly));
+        OnPropertyChanged(nameof(ShowSetpointsOnlyTooltip));
+    }
+
+    /// <summary>
+    /// True when a search keystroke has scheduled a debounce timer that
+    /// hasn't fired yet. Scripting / test seam.
+    /// </summary>
+    internal bool HasPendingSearchDebounce => _searchDebounceTimer != null;
+
+    /// <summary>
+    /// Cancels the pending 200&#160;ms <see cref="SearchQuery"/> debounce
+    /// and fires the filter callback synchronously. Used by scripted
+    /// scenarios (DevLauncher captures, regression tests) so the next
+    /// frame reflects the staged search state.
+    /// </summary>
+    internal void FlushPendingSearch()
+    {
+        _searchDebounceTimer?.Dispose();
+        _searchDebounceTimer = null;
+        _onFiltersChanged();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _searchDebounceTimer?.Dispose();
+        _searchDebounceTimer = null;
+    }
+}


### PR DESCRIPTION
## Summary

Carves the search box / SetPoint toggle / rule-banner state out of
`BulkChangeViewModel` into a new `SearchFilterViewModel` slice
(#80 slice 6 — "Search/filter").

`SearchFilterViewModel` owns:

- `SearchQuery` (+ 200&#160;ms debounce timer) / `HasSearchQuery`
- `SearchHitCount`
- `HiddenByRuleCount` / `ShowRuleFilterBanner` / `RuleFilterBannerText`
- `ShowSetpointsOnly` / `CanShowSetpointsOnly` / `ShowSetpointsOnlyTooltip`
- `FlushPendingSearch` + `HasPendingSearchDebounce` (scripted seams)

The host VM keeps the actual filter pass (`ApplyAllFilters` +
`RefreshFlatList`) because it walks the multi-DB tree and is too
entangled with host state (`_dbToSynthetic`, `_searchService`, exclude-
set builder) to migrate in this PR. The slice fires a single
`onFiltersChanged` callback on every state transition that needs a tree
re-filter, and an optional `onSetpointsTurnedOn` callback so the host
can refresh the UDT cache on the OFF→ON transition before the filter
pass runs.

`ShowConstants` is intentionally **not** in this slice even though the
original issue body lists it here — it does not affect the tree filter,
only the autocomplete suggestion list, so it belongs with the
autocomplete slice in a future touch-up. Including it here would have
required pulling `ReloadSuggestions()` (autocomplete plumbing) into the
search slice and muddied the cut.

XAML rebinds to `{Binding Filter.X}` following the pattern from slices
1–5. Tests / capture-script call sites switch to `vm.Filter.X`;
`vm.FlushPendingSearch` is kept as a one-line shim on the host so
existing tests / capture-script don't have to chase the new path.

Host VM: **4,478 → 4,387 lines** (−91 from this slice; running total
for #80 is now ~−554 across slices 1–6).

## Test plan

- [ ] CI build (`v20`) succeeds against the stubs
- [ ] CI build (`v21`) succeeds against the stubs
- [ ] `xUnit` `v20` job green — includes new `SearchFilterViewModelTests`
- [ ] Existing regression tests still pass:
      `SearchQuery_MultiDb_HitCountSumsAcrossAllActiveDbs`,
      `SearchQuery_SmartExpandsCollapsedAncestors`,
      `HiddenByRuleCount_TracksExcludeFromSetpointsRules`,
      `Dispose_IsIdempotentAndTearsDownTimersAndLicenseSubscription`
- [ ] `BulkChangeViewModelMultiDbTests` (now using `vm.Filter.SearchQuery`)
- [ ] DevLauncher CaptureScript still drives `Filter.ShowSetpointsOnly` /
      `Filter.SearchQuery` correctly when rerun locally (not covered by CI)

Refs #80.

https://claude.ai/code/session_0168J7dK7tApviBaDquX6gUd

---
_Generated by [Claude Code](https://claude.ai/code/session_0168J7dK7tApviBaDquX6gUd)_