### PR TITLE
refactor(#80): extract MemberTreeViewModel slice (slice 7a)

### DIFF
--- a/src/BlockParam.DevLauncher/CaptureScript.cs
+++ b/src/BlockParam.DevLauncher/CaptureScript.cs
@@ -280,7 +280,7 @@ public static class SceneApplier
         {
             foreach (var path in scene.Expand)
             {
-                var node = FindByPath(vm.RootMembers, path);
+                var node = FindByPath(vm.Tree.RootMembers, path);
                 if (node == null)
                 {
                     Serilog.Log.Warning("Scene {Id}: expand path not found: {Path}", scene.Id, path);
@@ -293,7 +293,7 @@ public static class SceneApplier
 
         if (scene.Select != null)
         {
-            var node = FindByPath(vm.RootMembers, scene.Select);
+            var node = FindByPath(vm.Tree.RootMembers, scene.Select);
             if (node == null)
             {
                 Serilog.Log.Warning("Scene {Id}: select path not found: {Path}", scene.Id, scene.Select);
@@ -304,7 +304,7 @@ public static class SceneApplier
                 vm.RefreshFlatList();
                 // SelectedFlatMember requires the node to be in the flat list;
                 // RefreshFlatList above guarantees that.
-                var flat = vm.FlatMembers.FirstOrDefault(m => m.Path == node.Path);
+                var flat = vm.Tree.FlatMembers.FirstOrDefault(m => m.Path == node.Path);
                 vm.SelectedFlatMember = flat ?? node;
             }
         }
@@ -475,7 +475,7 @@ public static class SceneApplier
             return;
         }
 
-        var node = FindByPath(vm.RootMembers, ie.Path);
+        var node = FindByPath(vm.Tree.RootMembers, ie.Path);
         if (node == null)
         {
             Serilog.Log.Warning("Scene {Id}: inlineEdit path not found: {Path}", scene.Id, ie.Path);
@@ -509,7 +509,7 @@ public static class SceneApplier
         if (vm.Pending.HasPendingEdits)
             vm.DiscardPendingSilent();
         vm.Inspector.IsInspectorCollapsed = false;
-        foreach (var root in vm.RootMembers)
+        foreach (var root in vm.Tree.RootMembers)
             CollapseRecursive(root);
         vm.SelectedFlatMember = null;
         vm.SelectedScope = null;

--- a/src/BlockParam.Tests/BulkChangeViewModelDbSwitcherTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelDbSwitcherTests.cs
@@ -200,7 +200,7 @@ public class BulkChangeViewModelDbSwitcherTests
         // Stage on the anchor (PLC_Line1). Use EditableStartValue (production
         // path) so the PendingEditStore is populated — CountPendingEditsForDb
         // reads from the store to decide whether to prompt before remove.
-        var anchorRoot = vm.RootMembers.First(r => r.Name == aInfo.Name);
+        var anchorRoot = vm.Tree.RootMembers.First(r => r.Name == aInfo.Name);
         anchorRoot.AllDescendants().First(n => n.IsLeaf).EditableStartValue = "111";
 
         // Remove anchor → Keep (stash).
@@ -245,7 +245,7 @@ public class BulkChangeViewModelDbSwitcherTests
         // Stage on the anchor. Use EditableStartValue (production path) so the
         // PendingEditStore is populated — CountPendingEditsForDb reads from the
         // store to decide whether to prompt before remove.
-        var anchorRoot = vm.RootMembers.First(r => r.Name == aInfo.Name);
+        var anchorRoot = vm.Tree.RootMembers.First(r => r.Name == aInfo.Name);
         anchorRoot.AllDescendants().First(n => n.IsLeaf).EditableStartValue = "777";
 
         // Remove anchor → Keep (stash).
@@ -295,7 +295,7 @@ public class BulkChangeViewModelDbSwitcherTests
         // 1. Stage on A (anchor). Use EditableStartValue (production path) so
         // the PendingEditStore is populated — CountPendingEditsForDb reads from
         // the store to decide whether to prompt before remove.
-        var anchorRoot = vm.RootMembers.First(r => r.Name == aInfo.Name);
+        var anchorRoot = vm.Tree.RootMembers.First(r => r.Name == aInfo.Name);
         anchorRoot.AllDescendants().First(n => n.IsLeaf).EditableStartValue = "111";
 
         // 2. Remove A with Keep → A stashed, B becomes sole active anchor.
@@ -307,7 +307,7 @@ public class BulkChangeViewModelDbSwitcherTests
         vm.StashedDbs[0].DbName.Should().Be(aInfo.Name);
 
         // 3. Stage on B (now anchor) and Apply.
-        vm.RootMembers.First(m => m.IsLeaf).EditableStartValue = "222";
+        vm.Tree.RootMembers.First(m => m.IsLeaf).EditableStartValue = "222";
         vm.HasPendingChanges = true;   // Apply path normally toggles this; set explicitly so CommitChanges fires.
         vm.CommitChanges().Should().BeTrue();
 

--- a/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
@@ -66,8 +66,8 @@ public class BulkChangeViewModelInvariantTests
         env.Vm.AllActiveDbs.Should().HaveCount(2);
         env.Vm.PlcPills.Select(p => p.PlcName).Should().BeEquivalentTo(
             new[] { "PLC_A", "PLC_B" });
-        env.Vm.RootMembers.Should().HaveCount(2);
-        env.Vm.RootMembers.Should().AllSatisfy(r => r.Datatype.Should().Be("DB"));
+        env.Vm.Tree.RootMembers.Should().HaveCount(2);
+        env.Vm.Tree.RootMembers.Should().AllSatisfy(r => r.Datatype.Should().Be("DB"));
         env.Mbx.AskYesNoCancelCallCount.Should().Be(0, "pure-add does not prompt");
         AssertInvariants(env.Vm);
     }
@@ -256,7 +256,7 @@ public class BulkChangeViewModelInvariantTests
             "NestedStructDB's stash entry pops on restore");
 
         // Stash edits replay onto the live tree.
-        var restored = env.Vm.RootMembers
+        var restored = env.Vm.Tree.RootMembers
             .SelectMany(r => new[] { r }.Concat(r.AllDescendants()))
             .FirstOrDefault(n => n.IsLeaf && n.PendingValue == pendingValue);
         restored.Should().NotBeNull("stashed edit must land on the rebuilt tree");
@@ -306,7 +306,7 @@ public class BulkChangeViewModelInvariantTests
         env.Vm.AllActiveDbs[0].Info.Name.Should().Be("NestedStructDB");
         env.Vm.HasStashedDbs.Should().BeFalse();
 
-        var restored = env.Vm.RootMembers
+        var restored = env.Vm.Tree.RootMembers
             .SelectMany(r => new[] { r }.Concat(r.AllDescendants()))
             .FirstOrDefault(n => n.IsLeaf && n.PendingValue == pendingValue);
         restored.Should().NotBeNull("stashed edit lands on the single-DB tree");
@@ -347,7 +347,7 @@ public class BulkChangeViewModelInvariantTests
         // peer drop, i.e. while we're in single-DB shape. Use EditableStartValue
         // (production path) so the PendingEditStore is populated — CountPendingEditsForDb
         // reads from the store to decide whether to prompt before remove.
-        var anchorLeaf = env.Vm.RootMembers.SelectMany(r => new[] { r }.Concat(r.AllDescendants()))
+        var anchorLeaf = env.Vm.Tree.RootMembers.SelectMany(r => new[] { r }.Concat(r.AllDescendants()))
             .First(n => n.IsLeaf && !string.IsNullOrEmpty(n.StartValue));
         anchorLeaf.EditableStartValue = anchorLeaf.StartValue == "0" ? "1" : "0";
 
@@ -559,7 +559,7 @@ public class BulkChangeViewModelInvariantTests
             .Build();
 
         // Multi-DB shape: pick 2 leaves from FlatDB's synthetic subtree.
-        var anchorRoot = env.Vm.RootMembers.First(r => r.Name == "FlatDB");
+        var anchorRoot = env.Vm.Tree.RootMembers.First(r => r.Name == "FlatDB");
         var anchorLeaves = new[] { anchorRoot }
             .Concat(anchorRoot.AllDescendants())
             .Where(n => n.IsLeaf)
@@ -585,7 +585,7 @@ public class BulkChangeViewModelInvariantTests
         env.Vm.IsManualMode.Should().BeFalse("0 manual paths → not in manual mode");
 
         // Now the second half: select 2 leaves in the survivor (now flat tree).
-        var peerLeaves = env.Vm.RootMembers
+        var peerLeaves = env.Vm.Tree.RootMembers
             .SelectMany(r => new[] { r }.Concat(r.AllDescendants()))
             .Where(n => n.IsLeaf)
             .Take(2)
@@ -634,7 +634,7 @@ public class BulkChangeViewModelInvariantTests
         // Tree rebuilt: multi-DB → single-DB (flat) shape, all VMs replaced.
         env.Vm.AllActiveDbs.Should().HaveCount(1, "peer was silently removed");
         env.Mbx.AskYesNoCancelCallCount.Should().Be(0, "no edits on peer → no prompt");
-        env.Vm.RootMembers.Should().AllSatisfy(r =>
+        env.Vm.Tree.RootMembers.Should().AllSatisfy(r =>
             r.Datatype.Should().NotBe("DB"), "single-DB shape: no synthetic roots");
 
         // Find the anchor's leaf in the new flat tree.
@@ -699,11 +699,11 @@ public class BulkChangeViewModelInvariantTests
             .WithPeer("nested-struct-db.xml")
             .Build();
 
-        env.Vm.RootMembers.Should().HaveCount(2,
+        env.Vm.Tree.RootMembers.Should().HaveCount(2,
             "setup: multi-DB tree with one synthetic root per DB");
 
-        var dbARoot = env.Vm.RootMembers.First(r => r.Name == "FlatDB");
-        var dbBRoot = env.Vm.RootMembers.First(r => r.Name == "NestedStructDB");
+        var dbARoot = env.Vm.Tree.RootMembers.First(r => r.Name == "FlatDB");
+        var dbBRoot = env.Vm.Tree.RootMembers.First(r => r.Name == "NestedStructDB");
         var dbALeaf = new[] { dbARoot }.Concat(dbARoot.AllDescendants())
             .First(n => n.IsLeaf);
         var dbBLeaf = new[] { dbBRoot }.Concat(dbBRoot.AllDescendants())
@@ -714,7 +714,7 @@ public class BulkChangeViewModelInvariantTests
         // Then select a leaf in DB A — DB B's selection must clear.
         dbALeaf.IsSelected = true;
 
-        var allLeaves = env.Vm.RootMembers
+        var allLeaves = env.Vm.Tree.RootMembers
             .SelectMany(r => new[] { r }.Concat(r.AllDescendants()))
             .Where(n => n.IsLeaf)
             .ToList();
@@ -816,14 +816,14 @@ public class BulkChangeViewModelInvariantTests
         // (3) tree shape matches active-set count
         if (vm.AllActiveDbs.Count == 1)
         {
-            vm.RootMembers.Should().AllSatisfy(r => r.Datatype.Should().NotBe("DB"),
+            vm.Tree.RootMembers.Should().AllSatisfy(r => r.Datatype.Should().NotBe("DB"),
                 "invariant 3 (single-DB): top-level members are flat, no synthetic group");
         }
         else
         {
-            vm.RootMembers.Should().HaveCount(vm.AllActiveDbs.Count,
+            vm.Tree.RootMembers.Should().HaveCount(vm.AllActiveDbs.Count,
                 "invariant 3 (multi-DB): one synthetic root per active DB");
-            vm.RootMembers.Should().AllSatisfy(r => r.Datatype.Should().Be("DB",
+            vm.Tree.RootMembers.Should().AllSatisfy(r => r.Datatype.Should().Be("DB",
                 "invariant 3 (multi-DB): every root is a synthetic Datatype='DB' group"));
         }
 
@@ -845,7 +845,7 @@ public class BulkChangeViewModelInvariantTests
         // (6) PendingEdits only references nodes still reachable in the live
         // tree — removing a DB from the active set must vacate that DB's
         // leaves from the bound "pending changes" inspector list.
-        var reachableNodes = vm.RootMembers
+        var reachableNodes = vm.Tree.RootMembers
             .SelectMany(r => new[] { r }.Concat(r.AllDescendants()))
             .ToHashSet();
         var orphanedPaths = vm.Pending.PendingEdits
@@ -913,9 +913,9 @@ public class BulkChangeViewModelInvariantTests
     /// </summary>
     private static MemberNodeViewModel FindFirstPendingLeaf(BulkChangeViewModel vm, string dbName)
     {
-        var roots = vm.RootMembers.Count > 0 && vm.RootMembers[0].Datatype == "DB"
-            ? vm.RootMembers.Where(r => r.Name == dbName)
-            : vm.RootMembers;
+        var roots = vm.Tree.RootMembers.Count > 0 && vm.Tree.RootMembers[0].Datatype == "DB"
+            ? vm.Tree.RootMembers.Where(r => r.Name == dbName)
+            : vm.Tree.RootMembers;
         return roots.SelectMany(r => new[] { r }.Concat(r.AllDescendants()))
             .First(n => n.IsLeaf && n.IsPendingInlineEdit);
     }
@@ -1070,10 +1070,10 @@ public class BulkChangeViewModelInvariantTests
             {
                 var dbName = kvp.Key;
                 var count = kvp.Value;
-                var roots = vm.RootMembers.Count > 0 && vm.RootMembers[0].Datatype == "DB"
-                    ? vm.RootMembers.Where(r => r.Name == dbName).ToList()
+                var roots = vm.Tree.RootMembers.Count > 0 && vm.Tree.RootMembers[0].Datatype == "DB"
+                    ? vm.Tree.RootMembers.Where(r => r.Name == dbName).ToList()
                     : (loaded.Values.Any(v => v.info.Name == dbName)
-                        ? vm.RootMembers.ToList()
+                        ? vm.Tree.RootMembers.ToList()
                         : new List<MemberNodeViewModel>());
                 if (roots.Count == 0)
                     throw new System.InvalidOperationException(

--- a/src/BlockParam.Tests/BulkChangeViewModelMultiDbTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelMultiDbTests.cs
@@ -95,12 +95,12 @@ public class BulkChangeViewModelMultiDbTests
         // This is the "extra layer of nesting depth" the user asked for.
         var (vm, _, _, _, _) = CreateMultiDbVm();
 
-        vm.RootMembers.Should().HaveCount(2,
+        vm.Tree.RootMembers.Should().HaveCount(2,
             "one synthetic group per active DB (focused + 1 peer)");
-        vm.RootMembers.Should().AllSatisfy(r =>
+        vm.Tree.RootMembers.Should().AllSatisfy(r =>
             r.Datatype.Should().Be("DB",
                 "synthetic groups carry Datatype='DB' so the tree template can render distinct chrome"));
-        vm.RootMembers[0].Children.Should().NotBeEmpty(
+        vm.Tree.RootMembers[0].Children.Should().NotBeEmpty(
             "synthetic root's children are the DB's real top-level members");
     }
 
@@ -123,8 +123,8 @@ public class BulkChangeViewModelMultiDbTests
 
         // Top-level members must NOT be Datatype="DB" — that's the
         // synthetic-marker reserved for multi-DB mode.
-        vm.RootMembers.Should().NotBeEmpty();
-        vm.RootMembers.Should().AllSatisfy(r =>
+        vm.Tree.RootMembers.Should().NotBeEmpty();
+        vm.Tree.RootMembers.Should().AllSatisfy(r =>
             r.Datatype.Should().NotBe("DB"));
     }
 
@@ -137,8 +137,8 @@ public class BulkChangeViewModelMultiDbTests
         var (vm, _, _, _, applyOrder) = CreateMultiDbVm();
 
         // Stage one inline edit on each DB so both have something to apply.
-        var focusedSyntheticRoot = vm.RootMembers[0];
-        var peerSyntheticRoot = vm.RootMembers[1];
+        var focusedSyntheticRoot = vm.Tree.RootMembers[0];
+        var peerSyntheticRoot = vm.Tree.RootMembers[1];
         var focusedLeaf = focusedSyntheticRoot.AllDescendants().First(n => n.IsLeaf);
         var peerLeaf = peerSyntheticRoot.AllDescendants().First(n => n.IsLeaf);
         focusedLeaf.EditableStartValue = focusedLeaf.StartValue == "0" ? "1" : "0";
@@ -158,8 +158,8 @@ public class BulkChangeViewModelMultiDbTests
         // is charged once for the SUM of changes across all active DBs.
         var (vm, tracker, _, _, _) = CreateMultiDbVm();
 
-        var focusedLeaf = vm.RootMembers[0].AllDescendants().First(n => n.IsLeaf);
-        var peerLeaf = vm.RootMembers[1].AllDescendants().First(n => n.IsLeaf);
+        var focusedLeaf = vm.Tree.RootMembers[0].AllDescendants().First(n => n.IsLeaf);
+        var peerLeaf = vm.Tree.RootMembers[1].AllDescendants().First(n => n.IsLeaf);
         focusedLeaf.EditableStartValue = focusedLeaf.StartValue == "0" ? "1" : "0";
         peerLeaf.EditableStartValue = peerLeaf.StartValue == "0" ? "1" : "0";
 
@@ -198,8 +198,8 @@ public class BulkChangeViewModelMultiDbTests
             onApply: _ => focusedApplied = true,
             additionalActiveDbs: new[] { peerDb });
 
-        var focusedLeaf = vm.RootMembers[0].AllDescendants().First(n => n.IsLeaf);
-        var peerLeaf = vm.RootMembers[1].AllDescendants().First(n => n.IsLeaf);
+        var focusedLeaf = vm.Tree.RootMembers[0].AllDescendants().First(n => n.IsLeaf);
+        var peerLeaf = vm.Tree.RootMembers[1].AllDescendants().First(n => n.IsLeaf);
         focusedLeaf.EditableStartValue = focusedLeaf.StartValue == "0" ? "1" : "0";
         peerLeaf.EditableStartValue = peerLeaf.StartValue == "0" ? "1" : "0";
 
@@ -296,12 +296,12 @@ public class BulkChangeViewModelMultiDbTests
             additionalActiveDbs: new[] { peerDb });
 
         // Stage one leaf edit in each DB.
-        var focusedLeaf = vm.RootMembers
+        var focusedLeaf = vm.Tree.RootMembers
             .First(r => r.Name == focused.Name)
             .AllDescendants().First(n => n.IsLeaf);
         focusedLeaf.EditableStartValue = focusedLeaf.StartValue == "0" ? "1" : "0";
 
-        var peerLeaf = vm.RootMembers
+        var peerLeaf = vm.Tree.RootMembers
             .First(r => r.Name == peer.Name)
             .AllDescendants().First(n => n.IsLeaf);
         peerLeaf.EditableStartValue = peerLeaf.StartValue == "0" ? "1" : "0";
@@ -373,7 +373,7 @@ public class BulkChangeViewModelMultiDbTests
             additionalActiveDbs: new[] { peerDb });
 
         // Stage one edit on the peer's tree.
-        var peerLeaf = vm.RootMembers
+        var peerLeaf = vm.Tree.RootMembers
             .First(r => r.Name == peer.Name)
             .AllDescendants().First(n => n.IsLeaf);
         peerLeaf.EditableStartValue = peerLeaf.StartValue == "0" ? "1" : "0";
@@ -428,8 +428,8 @@ public class BulkChangeViewModelMultiDbTests
         vm.HasMultipleActiveDbs.Should().BeTrue();
 
         // Find a leaf in each DB.
-        var focusedRoot = vm.RootMembers.First();
-        var peerRoot = vm.RootMembers.Last();
+        var focusedRoot = vm.Tree.RootMembers.First();
+        var peerRoot = vm.Tree.RootMembers.Last();
         var focusedLeaf = focusedRoot.AllDescendants().First(n => n.IsLeaf);
         var peerLeaf = peerRoot.AllDescendants().First(n => n.IsLeaf);
 
@@ -479,10 +479,10 @@ public class BulkChangeViewModelMultiDbTests
         // Single-DB shape pre-toggle: top-level members are flat, no synthetic
         // group node.
         vm.HasMultipleActiveDbs.Should().BeFalse();
-        vm.RootMembers.Should().AllSatisfy(r =>
+        vm.Tree.RootMembers.Should().AllSatisfy(r =>
             r.Datatype.Should().NotBe("DB",
                 "single-DB shape exposes leaves directly, not under a synthetic group"));
-        var preFlat = vm.FlatMembers.Count;
+        var preFlat = vm.Tree.FlatMembers.Count;
 
         // Open dropdown so FilteredDataBlockItems gets populated, then toggle
         // the peer row on.
@@ -494,12 +494,12 @@ public class BulkChangeViewModelMultiDbTests
         vm.AllActiveDbs.Should().HaveCount(2,
             "the dropdown toggle should add the peer DB to the active set");
         vm.HasMultipleActiveDbs.Should().BeTrue();
-        vm.RootMembers.Should().HaveCount(2,
+        vm.Tree.RootMembers.Should().HaveCount(2,
             "tree must rebuild as two synthetic per-DB group nodes");
-        vm.RootMembers.Should().AllSatisfy(r =>
+        vm.Tree.RootMembers.Should().AllSatisfy(r =>
             r.Datatype.Should().Be("DB",
                 "multi-DB shape wraps each DB's members in a synthetic group"));
-        vm.FlatMembers.Count.Should().BeGreaterThan(preFlat,
+        vm.Tree.FlatMembers.Count.Should().BeGreaterThan(preFlat,
             "the flat list must include nodes from the newly added peer");
     }
 
@@ -693,7 +693,7 @@ public class BulkChangeViewModelMultiDbTests
         // Stage a pending edit on the peer's tree. Use EditableStartValue
         // (production path) so the PendingEditStore is populated — CountPendingEditsForDb
         // reads from the store to decide whether to prompt before remove.
-        var peerLeaf = vm.RootMembers
+        var peerLeaf = vm.Tree.RootMembers
             .First(r => r.Name == peer.Name)
             .AllDescendants().First(n => n.IsLeaf);
         var original = peerLeaf.StartValue ?? "0";
@@ -727,7 +727,7 @@ public class BulkChangeViewModelMultiDbTests
         // The pending edit landed on the live tree. After solo, the active
         // set is single-DB so RootMembers is flat (no synthetic group root)
         // — search the leaves directly.
-        var restoredLeaf = vm.RootMembers
+        var restoredLeaf = vm.Tree.RootMembers
             .SelectMany(r => new[] { r }.Concat(r.AllDescendants()))
             .First(n => n.IsLeaf && n.PendingValue == pending);
         restoredLeaf.PendingValue.Should().Be(pending);

--- a/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
@@ -175,7 +175,7 @@ public class BulkChangeViewModelRegressionTests : IDisposable
             bulkService, tracker, configLoader, messageBox: new NopMessageBox());
 
         // Verify initial state — Config is present at root level with children collapsed
-        var configRoot = vm.RootMembers.FirstOrDefault(r => r.Name == "Config");
+        var configRoot = vm.Tree.RootMembers.FirstOrDefault(r => r.Name == "Config");
         configRoot.Should().NotBeNull("fixture must have a Config struct");
 
         vm.Filter.SearchQuery = "Timeout";
@@ -316,10 +316,10 @@ public class BulkChangeViewModelRegressionTests : IDisposable
     {
         var vm = CreateUdtVm();
 
-        FlatTreeManager.ExpandAll(vm.RootMembers);
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
         vm.RefreshFlatList();
 
-        var leaf = vm.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
+        var leaf = vm.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
         vm.SelectedFlatMember = leaf;
 
         // Pick the broadest scope (all 4 ModuleId instances)
@@ -346,10 +346,10 @@ public class BulkChangeViewModelRegressionTests : IDisposable
     {
         var vm = CreateUdtVm();
 
-        FlatTreeManager.ExpandAll(vm.RootMembers);
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
         vm.RefreshFlatList();
 
-        var leaf = vm.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
+        var leaf = vm.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
         vm.SelectedFlatMember = leaf;
 
         var scope = vm.AvailableScopes.OrderByDescending(s => s.MatchCount).First();
@@ -384,10 +384,10 @@ public class BulkChangeViewModelRegressionTests : IDisposable
     {
         var vm = CreateUdtVm();
 
-        FlatTreeManager.ExpandAll(vm.RootMembers);
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
         vm.RefreshFlatList();
 
-        var moduleLeaves = vm.FlatMembers.Where(m => m.Name == "ModuleId" && m.IsLeaf).ToList();
+        var moduleLeaves = vm.Tree.FlatMembers.Where(m => m.Name == "ModuleId" && m.IsLeaf).ToList();
         moduleLeaves.Should().HaveCount(4, "fixture has 4 ModuleId leaves");
 
         // Stage a pending inline edit on the first leaf
@@ -422,10 +422,10 @@ public class BulkChangeViewModelRegressionTests : IDisposable
     {
         var vm = CreateUdtVm();
 
-        FlatTreeManager.ExpandAll(vm.RootMembers);
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
         vm.RefreshFlatList();
 
-        vm.SelectedFlatMember = vm.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
+        vm.SelectedFlatMember = vm.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
         var scope = vm.AvailableScopes.OrderByDescending(s => s.MatchCount).First();
         vm.SelectedScope = scope;
 
@@ -438,7 +438,7 @@ public class BulkChangeViewModelRegressionTests : IDisposable
             "homogeneous originals should produce 'orig ⇢ new' format");
 
         // Make one leaf heterogeneous by staging a pending edit
-        var leaves = vm.FlatMembers.Where(m => m.Name == "ModuleId" && m.IsLeaf).ToList();
+        var leaves = vm.Tree.FlatMembers.Where(m => m.Name == "ModuleId" && m.IsLeaf).ToList();
         // SPEC AMBIGUITY: The BulkPreviewSummary checks OriginalValue (StartValue) for
         // homogeneity, not PendingValue. So editing one leaf's EditableStartValue changes
         // its effective value shown in BulkPreview but OriginalValue stays as StartValue="42".
@@ -453,11 +453,11 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         vm.Dispose();
 
         var vm2 = CreateFlatDbVm();
-        FlatTreeManager.ExpandAll(vm2.RootMembers);
+        FlatTreeManager.ExpandAll(vm2.Tree.RootMembers);
         vm2.RefreshFlatList();
 
-        var speed = vm2.FlatMembers.First(m => m.Name == "Speed" && m.IsLeaf);
-        var enable = vm2.FlatMembers.First(m => m.Name == "Enable" && m.IsLeaf);
+        var speed = vm2.Tree.FlatMembers.First(m => m.Name == "Speed" && m.IsLeaf);
+        var enable = vm2.Tree.FlatMembers.First(m => m.Name == "Enable" && m.IsLeaf);
 
         vm2.UpdateManualSelection(
             added: new[] { speed, enable },
@@ -489,10 +489,10 @@ public class BulkChangeViewModelRegressionTests : IDisposable
     {
         var vm = CreateUdtVm();
 
-        FlatTreeManager.ExpandAll(vm.RootMembers);
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
         vm.RefreshFlatList();
 
-        var leaves = vm.FlatMembers.Where(m => m.IsLeaf).Take(2).ToList();
+        var leaves = vm.Tree.FlatMembers.Where(m => m.IsLeaf).Take(2).ToList();
         leaves.Should().HaveCount(2, "fixture must have at least 2 leaves");
 
         vm.UpdateManualSelection(
@@ -518,13 +518,13 @@ public class BulkChangeViewModelRegressionTests : IDisposable
     {
         var vm = CreateFlatDbVm();
 
-        FlatTreeManager.ExpandAll(vm.RootMembers);
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
         vm.RefreshFlatList();
 
         // flat-db.xml: Speed (Int), Temperature (Real), Enable (Bool)
-        var speed = vm.FlatMembers.First(m => m.Name == "Speed" && m.IsLeaf);
-        var temp = vm.FlatMembers.First(m => m.Name == "Temperature" && m.IsLeaf);
-        var enable = vm.FlatMembers.First(m => m.Name == "Enable" && m.IsLeaf);
+        var speed = vm.Tree.FlatMembers.First(m => m.Name == "Speed" && m.IsLeaf);
+        var temp = vm.Tree.FlatMembers.First(m => m.Name == "Temperature" && m.IsLeaf);
+        var enable = vm.Tree.FlatMembers.First(m => m.Name == "Enable" && m.IsLeaf);
 
         speed.Datatype.Should().NotBe(enable.Datatype,
             "Speed (Int) and Enable (Bool) must have different datatypes");
@@ -536,11 +536,11 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         vm.Dispose();
 
         var vm2 = CreateUdtVm();
-        FlatTreeManager.ExpandAll(vm2.RootMembers);
+        FlatTreeManager.ExpandAll(vm2.Tree.RootMembers);
         vm2.RefreshFlatList();
 
         // UDT fixture: ModuleId (Int), ElementId (Int), MessageId (Int), Active (Bool)
-        var intLeaves = vm2.FlatMembers.Where(m => m.Name == "ModuleId" && m.IsLeaf).Take(2).ToList();
+        var intLeaves = vm2.Tree.FlatMembers.Where(m => m.Name == "ModuleId" && m.IsLeaf).Take(2).ToList();
         intLeaves.Should().HaveCount(2, "fixture needs at least 2 Int leaves");
         intLeaves.Should().AllSatisfy(l => l.Datatype.Should().Be("Int"));
 
@@ -554,7 +554,7 @@ public class BulkChangeViewModelRegressionTests : IDisposable
             "2 Int leaves → all same datatype → homogeneous");
 
         // Add a Bool leaf — breaks homogeneity
-        var boolLeaf = vm2.FlatMembers.First(m => m.Name == "Active" && m.IsLeaf);
+        var boolLeaf = vm2.Tree.FlatMembers.First(m => m.Name == "Active" && m.IsLeaf);
         boolLeaf.Datatype.Should().Be("Bool");
 
         vm2.UpdateManualSelection(
@@ -585,11 +585,11 @@ public class BulkChangeViewModelRegressionTests : IDisposable
     {
         var vm = CreateFlatDbVm();
 
-        FlatTreeManager.ExpandAll(vm.RootMembers);
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
         vm.RefreshFlatList();
 
         // Stage 2 leaves (manual mode requires >= 2)
-        var leaves = vm.FlatMembers.Where(m => m.IsLeaf).Take(2).ToList();
+        var leaves = vm.Tree.FlatMembers.Where(m => m.IsLeaf).Take(2).ToList();
         vm.UpdateManualSelection(
             added: leaves,
             removed: System.Array.Empty<MemberNodeViewModel>(),
@@ -660,9 +660,9 @@ public class BulkChangeViewModelRegressionTests : IDisposable
             tagTableCache: cache,
             messageBox: new NopMessageBox());
 
-        FlatTreeManager.ExpandAll(vm2.RootMembers);
+        FlatTreeManager.ExpandAll(vm2.Tree.RootMembers);
         vm2.RefreshFlatList();
-        var leaf = vm2.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
+        var leaf = vm2.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
         leaf.IsLeaf.Should().BeTrue();
 
         // Empty filter → all 50
@@ -717,9 +717,9 @@ public class BulkChangeViewModelRegressionTests : IDisposable
             messageBox: new NopMessageBox());
 
         // Select a leaf so ReloadSuggestions has a model to work with
-        FlatTreeManager.ExpandAll(vm.RootMembers);
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
         vm.RefreshFlatList();
-        var leaf = vm.FlatMembers.First(m => m.IsLeaf);
+        var leaf = vm.Tree.FlatMembers.First(m => m.IsLeaf);
         vm.SelectedFlatMember = leaf;
 
         // Confirm starting state: ShowConstants=false → Suggestions empty
@@ -773,9 +773,9 @@ public class BulkChangeViewModelRegressionTests : IDisposable
             tagTableCache: cache,
             messageBox: new NopMessageBox());
 
-        FlatTreeManager.ExpandAll(vm.RootMembers);
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
         vm.RefreshFlatList();
-        vm.SelectedFlatMember = vm.FlatMembers.First(m => m.IsLeaf);
+        vm.SelectedFlatMember = vm.Tree.FlatMembers.First(m => m.IsLeaf);
 
         // Force ShowConstants on to populate _suggestions
         vm.ShowConstants = true;
@@ -849,11 +849,11 @@ public class BulkChangeViewModelRegressionTests : IDisposable
             bulkService, tracker, configLoader,
             messageBox: new NopMessageBox());
 
-        FlatTreeManager.ExpandAll(vm.RootMembers);
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
         vm.RefreshFlatList();
 
         // Select a ModuleId leaf (child of Msg_CommError) and pick the broadest scope
-        var leaf = vm.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
+        var leaf = vm.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
         vm.SelectedFlatMember = leaf;
         vm.AvailableScopes.Should().NotBeEmpty("ModuleId has repeated occurrences → scope available");
         vm.SelectedScope = vm.AvailableScopes.OrderByDescending(s => s.MatchCount).First();
@@ -863,7 +863,7 @@ public class BulkChangeViewModelRegressionTests : IDisposable
 
         // The Msg_CommError parent nodes should have PreviewComment populated
         // (GenerateForScope walks up from ModuleId → Msg_CommError, finds the rule)
-        var nodesWithPreviewComment = vm.RootMembers
+        var nodesWithPreviewComment = vm.Tree.RootMembers
             .SelectMany(r => new[] { r }.Concat(r.AllDescendants()))
             .Where(n => n.PreviewComment != null)
             .ToList();
@@ -874,9 +874,9 @@ public class BulkChangeViewModelRegressionTests : IDisposable
 
         // No-comment-rule path: VM without comment rules should have no PreviewComment set
         var vm2 = CreateUdtVm(); // no rules
-        FlatTreeManager.ExpandAll(vm2.RootMembers);
+        FlatTreeManager.ExpandAll(vm2.Tree.RootMembers);
         vm2.RefreshFlatList();
-        vm2.SelectedFlatMember = vm2.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
+        vm2.SelectedFlatMember = vm2.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
         if (vm2.AvailableScopes.Count > 0)
         {
             vm2.SelectedScope = vm2.AvailableScopes.First();
@@ -884,7 +884,7 @@ public class BulkChangeViewModelRegressionTests : IDisposable
             vm2.FlushPendingHighlighting();
         }
 
-        var commentedNoRule = vm2.RootMembers
+        var commentedNoRule = vm2.Tree.RootMembers
             .SelectMany(r => new[] { r }.Concat(r.AllDescendants()))
             .Where(n => n.PreviewComment != null)
             .ToList();
@@ -930,13 +930,13 @@ public class BulkChangeViewModelRegressionTests : IDisposable
             bulkService, tracker, configLoader,
             messageBox: new NopMessageBox());
 
-        FlatTreeManager.ExpandAll(vm.RootMembers);
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
         vm.RefreshFlatList();
 
         // Select a ModuleId leaf and pick the broadest scope — same setup as
         // test 14. The scope cascade populates PreviewComment on the
         // Msg_CommError parents.
-        var leaf = vm.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
+        var leaf = vm.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
         vm.SelectedFlatMember = leaf;
         vm.SelectedScope = vm.AvailableScopes.OrderByDescending(s => s.MatchCount).First();
         vm.NewValue = "99";
@@ -954,9 +954,9 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         // PreviewComment set, so CollectPendingCommentNodes finds zero targets
         // and ApplyCommentPreviews returns the input XML unchanged.
         var vm2 = CreateFlatDbVm();
-        FlatTreeManager.ExpandAll(vm2.RootMembers);
+        FlatTreeManager.ExpandAll(vm2.Tree.RootMembers);
         vm2.RefreshFlatList();
-        vm2.RootMembers.First(m => m.Name == "Speed").EditableStartValue = "99";
+        vm2.Tree.RootMembers.First(m => m.Name == "Speed").EditableStartValue = "99";
 
         var flatXml = TestFixtures.LoadXml("flat-db.xml");
         var unchanged = vm2.ApplyCommentPreviews(flatXml);

--- a/src/BlockParam.Tests/BulkChangeViewModelTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelTests.cs
@@ -143,7 +143,7 @@ public class BulkChangeViewModelTests : IDisposable
             "existing violations must not flip HasInlineError — that's the Apply blocker");
 
         // Stage a valid pending edit on a *different* member so Apply has work
-        var enable = vm.RootMembers.Single(m => m.Name == "Enable");
+        var enable = vm.Tree.RootMembers.Single(m => m.Name == "Enable");
         enable.EditableStartValue = "false";
 
         vm.ApplyCommand.CanExecute(null).Should().BeTrue(
@@ -162,11 +162,11 @@ public class BulkChangeViewModelTests : IDisposable
     {
         var vm = CreateViewModelWithRule("udt-instances-db.xml", @"{ ""rules"": [] }");
 
-        FlatTreeManager.ExpandAll(vm.RootMembers);
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
         vm.RefreshFlatList();
 
         // Fixture has 4 ModuleId leaves, all already at "42".
-        var moduleId = vm.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
+        var moduleId = vm.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
         vm.SelectedFlatMember = moduleId;
 
         var dbScope = vm.AvailableScopes.First(s => s.MatchCount == 4);
@@ -193,12 +193,12 @@ public class BulkChangeViewModelTests : IDisposable
     {
         var vm = CreateViewModelWithRule("udt-instances-db.xml", @"{ ""rules"": [] }");
 
-        FlatTreeManager.ExpandAll(vm.RootMembers);
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
         vm.RefreshFlatList();
 
         // Pick 3 ModuleId leaves (all "42") + 1 MessageId leaf (e.g. "101").
-        var moduleIds = vm.FlatMembers.Where(m => m.Name == "ModuleId" && m.IsLeaf).Take(3).ToList();
-        var messageId = vm.FlatMembers.First(m => m.Name == "MessageId" && m.IsLeaf);
+        var moduleIds = vm.Tree.FlatMembers.Where(m => m.Name == "ModuleId" && m.IsLeaf).Take(3).ToList();
+        var messageId = vm.Tree.FlatMembers.First(m => m.Name == "MessageId" && m.IsLeaf);
         var picks = moduleIds.Concat(new[] { messageId }).ToList();
 
         vm.UpdateManualSelection(picks, Array.Empty<MemberNodeViewModel>(), false);
@@ -235,8 +235,8 @@ public class BulkChangeViewModelTests : IDisposable
         var vm = new BulkChangeViewModel(db, xml, analyzer, bulkService, usageTracker, configLoader);
 
         // Stage two pending edits — one would fit (remaining=1), two will not.
-        vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
-        vm.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
+        vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+        vm.Tree.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
 
         vm.Pending.PendingInlineEditCount.Should().Be(2);
         vm.ApplyCommand.CanExecute(null).Should().BeFalse(
@@ -263,8 +263,8 @@ public class BulkChangeViewModelTests : IDisposable
 
         var vm = new BulkChangeViewModel(db, xml, analyzer, bulkService, usageTracker, configLoader);
 
-        vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
-        vm.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
+        vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+        vm.Tree.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
 
         vm.ApplyCommand.CanExecute(null).Should().BeTrue(
             "two pending edits fit under remaining=10");
@@ -303,8 +303,8 @@ public class BulkChangeViewModelTests : IDisposable
         license.IsProActive.Returns(true);
         var vm = CreateViewModelWithUsage(new UsageStatus(150, 200), license);
 
-        vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
-        vm.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
+        vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+        vm.Tree.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
 
         vm.ApplyTooltip.Should().NotContain(
             "remaining today",
@@ -331,7 +331,7 @@ public class BulkChangeViewModelTests : IDisposable
     public void ApplyTooltip_SingleEditWithHeadroom_OmitsCostLine()
     {
         var vm = CreateViewModelWithUsage(new UsageStatus(0, 200)); // 200 remaining
-        vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+        vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
 
         vm.Pending.PendingInlineEditCount.Should().Be(1);
         vm.ApplyTooltip.Should().NotContain("remaining today",
@@ -368,8 +368,8 @@ public class BulkChangeViewModelTests : IDisposable
         WithEnglishUICulture(() =>
         {
             var vm = CreateViewModelWithUsage(new UsageStatus(0, 200));
-            vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
-            vm.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
+            vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+            vm.Tree.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
 
             vm.Pending.PendingInlineEditCount.Should().Be(2);
             vm.ApplyTooltip.Should()
@@ -390,7 +390,7 @@ public class BulkChangeViewModelTests : IDisposable
         WithEnglishUICulture(() =>
         {
             var vm = CreateViewModelWithUsage(new UsageStatus(170, 200)); // 30 remaining
-            vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+            vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
 
             vm.Pending.PendingInlineEditCount.Should().Be(1);
             vm.ApplyTooltip.Should()
@@ -415,8 +415,8 @@ public class BulkChangeViewModelTests : IDisposable
         ((INotifyPropertyChanged)vm).PropertyChanged += (_, e) => changedProps.Add(e.PropertyName);
 
         // Stage two edits — both transitions (0 → 1 and 1 → 2) should re-fire ApplyTooltip.
-        vm.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
-        vm.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
+        vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+        vm.Tree.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
 
         changedProps.Should().Contain(nameof(BulkChangeViewModel.ApplyTooltip),
             "the binding can't re-evaluate without this notification");

--- a/src/BlockParam.Tests/MemberTreeViewModelTests.cs
+++ b/src/BlockParam.Tests/MemberTreeViewModelTests.cs
@@ -1,0 +1,380 @@
+using System.Collections.Generic;
+using System.Linq;
+using BlockParam.Localization;
+using BlockParam.Models;
+using BlockParam.UI;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Focused tests for the tree-shape + flat-list + expand/collapse slice
+/// (#80 slice 7a).
+/// </summary>
+public class MemberTreeViewModelTests
+{
+    [Fact]
+    public void Defaults_EmptyTreeUntilBuildCalled()
+    {
+        var vm = Build(activeDbs: Array.Empty<ActiveDb>());
+
+        vm.RootMembers.Should().BeEmpty();
+        vm.FlatMembers.Should().BeEmpty();
+        vm.ModelToVm.Should().BeEmpty();
+        vm.ModelToDb.Should().BeEmpty();
+        vm.DbToSynthetic.Should().BeEmpty();
+        vm.IsRefreshing.Should().BeFalse();
+    }
+
+    [Fact]
+    public void BuildFromActiveDbs_SingleDb_FlatTopLevelMembersAndIndexedLookups()
+    {
+        var (db, speed, _) = MakeFlatDb("DB_Flat");
+        var vm = Build(activeDbs: new[] { db });
+
+        vm.BuildRootMembersFromActiveDbs();
+
+        // Single-DB shape: top-level members directly at root, no synthetic wrapper.
+        vm.RootMembers.Should().HaveCount(2,
+            "single-DB session puts the anchor DB's top-level members at root");
+        vm.RootMembers.Should().AllSatisfy(r => r.Datatype.Should().NotBe("DB"));
+        vm.DbToSynthetic.Should().BeEmpty(
+            "single-DB session does not create synthetic group roots");
+
+        // Lookup dicts must cover every member by reference.
+        vm.ModelToVm.Should().ContainKey(speed);
+        vm.ModelToDb[speed].Should().BeSameAs(db);
+    }
+
+    [Fact]
+    public void BuildFromActiveDbs_MultiDb_SyntheticGroupPerDb()
+    {
+        var (dbA, _, _) = MakeFlatDb("DB_A");
+        var (dbB, _, _) = MakeFlatDb("DB_B");
+        var vm = Build(activeDbs: new[] { dbA, dbB });
+
+        vm.BuildRootMembersFromActiveDbs();
+
+        // Multi-DB shape: one synthetic group root per active DB.
+        vm.RootMembers.Should().HaveCount(2);
+        vm.RootMembers.Should().AllSatisfy(r => r.Datatype.Should().Be("DB",
+            "every multi-DB root is a synthetic group wrapper"));
+        vm.DbToSynthetic.Should().HaveCount(2);
+        vm.DbToSynthetic[dbA].Should().NotBeNull();
+        vm.DbToSynthetic[dbB].Should().NotBeNull();
+
+        // Synthetic group is expanded by default so children are visible.
+        vm.RootMembers.Should().AllSatisfy(r => r.IsExpanded.Should().BeTrue());
+    }
+
+    [Fact]
+    public void BuildFromActiveDbs_MultiDb_NameCollision_PrefixesByPlc()
+    {
+        var (dbA, _, _) = MakeFlatDb("DB_Foo", plcName: "PLC_1");
+        var (dbB, _, _) = MakeFlatDb("DB_Foo", plcName: "PLC_2");
+        var vm = Build(
+            activeDbs: new[] { dbA, dbB },
+            currentPlcName: "PLC_1");
+
+        vm.BuildRootMembersFromActiveDbs();
+
+        // Cross-PLC collision: both names match → both synthetic roots are
+        // prefixed with their owning PLC so the user can tell them apart.
+        vm.RootMembers.Select(r => r.Name).Should().Equal(
+            "PLC_1 / DB_Foo", "PLC_2 / DB_Foo");
+    }
+
+    [Fact]
+    public void BuildFromActiveDbs_RaisesRootsRebuilt()
+    {
+        var (db, _, _) = MakeFlatDb("DB_X");
+        var vm = Build(activeDbs: new[] { db });
+
+        var rebuiltCount = 0;
+        vm.RootsRebuilt += () => rebuiltCount++;
+
+        vm.BuildRootMembersFromActiveDbs();
+        rebuiltCount.Should().Be(1);
+
+        // Re-build fires again (host uses this to seed pending edits).
+        vm.BuildRootMembersFromActiveDbs();
+        rebuiltCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void BuildFromActiveDbs_ClearsPriorLookupsAndRoots()
+    {
+        var (db1, _, _) = MakeFlatDb("DB_1");
+        var (db2, _, _) = MakeFlatDb("DB_2");
+        var activeDbs = new List<ActiveDb> { db1 };
+        var vm = Build(activeDbs: () => activeDbs);
+
+        vm.BuildRootMembersFromActiveDbs();
+        var firstRoot = vm.RootMembers[0];
+        var firstModel = firstRoot.Model;
+        vm.ModelToVm.Should().ContainKey(firstModel);
+
+        // Swap the active set and rebuild — old VMs/models must be evicted.
+        activeDbs.Clear();
+        activeDbs.Add(db2);
+        vm.BuildRootMembersFromActiveDbs();
+
+        vm.RootMembers.Should().NotContain(firstRoot,
+            "rebuild must mint fresh VMs from the new active set");
+        vm.ModelToVm.Should().NotContainKey(firstModel,
+            "lookups must be cleared so writes don't route to disposed VMs");
+    }
+
+    [Fact]
+    public void BuildFromActiveDbs_InvokesSubscribeCallbackForEveryMintedVm()
+    {
+        var (db, _, _) = MakeFlatDb("DB_S");
+        var subscribed = new List<MemberNodeViewModel>();
+        var vm = Build(activeDbs: new[] { db }, subscribeToVm: subscribed.Add);
+
+        vm.BuildRootMembersFromActiveDbs();
+
+        subscribed.Should().NotBeEmpty(
+            "host's StartValueEdited subscription must run on every new VM " +
+            "so inline edits in the new tree route into the pending store");
+        // Each subscription is for a distinct minted VM.
+        subscribed.Distinct().Count().Should().Be(subscribed.Count);
+    }
+
+    [Fact]
+    public void FindVmByModel_ReturnsModelToVmEntry()
+    {
+        var (db, speed, _) = MakeFlatDb("DB_F");
+        var vm = Build(activeDbs: new[] { db });
+        vm.BuildRootMembersFromActiveDbs();
+
+        var resolved = vm.FindVmByModel(speed);
+
+        resolved.Should().NotBeNull();
+        resolved!.Model.Should().BeSameAs(speed);
+    }
+
+    [Fact]
+    public void FindVmByModel_StaleModel_ReturnsNull()
+    {
+        var (db, _, _) = MakeFlatDb("DB_F");
+        var (_, otherSpeed, _) = MakeFlatDb("DB_Other");
+        var vm = Build(activeDbs: new[] { db });
+        vm.BuildRootMembersFromActiveDbs();
+
+        // Model from a DB that isn't in the active set — must not resolve.
+        vm.FindVmByModel(otherSpeed).Should().BeNull();
+    }
+
+    [Fact]
+    public void FindActiveDbForModel_ResolvesOwningDb()
+    {
+        var (db, speed, _) = MakeFlatDb("DB_F");
+        var vm = Build(activeDbs: new[] { db });
+        vm.BuildRootMembersFromActiveDbs();
+
+        vm.FindActiveDbForModel(speed).Should().BeSameAs(db);
+    }
+
+    [Fact]
+    public void FindNodeByPath_LocatesByPathString()
+    {
+        var (db, _, _) = MakeFlatDb("DB_F");
+        var vm = Build(activeDbs: new[] { db });
+        vm.BuildRootMembersFromActiveDbs();
+
+        var found = vm.FindNodeByPath("Speed");
+        found.Should().NotBeNull();
+        found!.Name.Should().Be("Speed");
+
+        vm.FindNodeByPath("DoesNotExist").Should().BeNull();
+    }
+
+    [Fact]
+    public void FindNodeByPathInDb_RestrictsToOwningDb()
+    {
+        var (dbA, _, _) = MakeFlatDb("DB_A");
+        var (dbB, _, _) = MakeFlatDb("DB_B");
+        var vm = Build(activeDbs: new[] { dbA, dbB });
+        vm.BuildRootMembersFromActiveDbs();
+
+        var foundInA = vm.FindNodeByPathInDb("Speed", dbA);
+        foundInA.Should().NotBeNull();
+        // Reference points into dbA's subtree, not dbB's.
+        vm.FindActiveDbForModel(foundInA!.Model).Should().BeSameAs(dbA);
+
+        var foundInB = vm.FindNodeByPathInDb("Speed", dbB);
+        foundInB.Should().NotBeNull();
+        vm.FindActiveDbForModel(foundInB!.Model).Should().BeSameAs(dbB);
+        foundInB.Should().NotBeSameAs(foundInA,
+            "same path string in two DBs must resolve to distinct VMs");
+    }
+
+    [Fact]
+    public void RebuildFlatList_PopulatesFlatMembers()
+    {
+        var (db, _, _) = MakeFlatDb("DB_F");
+        var vm = Build(activeDbs: new[] { db });
+        vm.BuildRootMembersFromActiveDbs();
+
+        vm.RebuildFlatList();
+
+        vm.FlatMembers.Should().NotBeEmpty();
+        vm.FlatMembers.Should().Contain(m => m.Name == "Speed");
+    }
+
+    [Fact]
+    public void RebuildFlatList_InvokesInsideRefreshScopeWhileIsRefreshingIsTrue()
+    {
+        var (db, _, _) = MakeFlatDb("DB_F");
+        var vm = Build(activeDbs: new[] { db });
+        vm.BuildRootMembersFromActiveDbs();
+
+        bool wasTrueInsideCallback = false;
+        vm.RebuildFlatList(insideRefreshScope: () =>
+        {
+            wasTrueInsideCallback = vm.IsRefreshing;
+        });
+
+        wasTrueInsideCallback.Should().BeTrue(
+            "the callback runs after the flat list rebuild but before IsRefreshing " +
+            "clears — host uses this scope to restore selection without re-entering " +
+            "OnMemberSelected");
+        vm.IsRefreshing.Should().BeFalse(
+            "the flag clears once the callback returns");
+    }
+
+    [Fact]
+    public void RebuildFlatList_ReEntry_IsSilentlyIgnored()
+    {
+        var (db, _, _) = MakeFlatDb("DB_F");
+        var vm = Build(activeDbs: new[] { db });
+        vm.BuildRootMembersFromActiveDbs();
+
+        int innerInvocations = 0;
+        vm.RebuildFlatList(insideRefreshScope: () =>
+        {
+            // Re-enter from within the scope — the second call must be a no-op
+            // because IsRefreshing is true.
+            vm.RebuildFlatList(insideRefreshScope: () => innerInvocations++);
+        });
+
+        innerInvocations.Should().Be(0,
+            "re-entry while IsRefreshing must short-circuit before the inner callback runs");
+    }
+
+    [Fact]
+    public void ToggleExpand_FlipsIsExpandedAndRebuildsFlatList()
+    {
+        var (dbA, _, _) = MakeNestedDb("DB_N");
+        var vm = Build(activeDbs: new[] { dbA });
+        vm.BuildRootMembersFromActiveDbs();
+        vm.RebuildFlatList();
+
+        var nestedRoot = vm.RootMembers[0];
+        nestedRoot.IsExpanded.Should().BeFalse("single-DB roots start collapsed");
+
+        var beforeCount = vm.FlatMembers.Count;
+        vm.ToggleExpand(nestedRoot);
+
+        nestedRoot.IsExpanded.Should().BeTrue();
+        vm.FlatMembers.Count.Should().BeGreaterThan(beforeCount,
+            "expanding a root must reveal its children in the flat list");
+    }
+
+    [Fact]
+    public void ExpandAllCommand_ExpandsEveryRoot()
+    {
+        var (dbA, _, _) = MakeNestedDb("DB_N");
+        var vm = Build(activeDbs: new[] { dbA });
+        vm.BuildRootMembersFromActiveDbs();
+
+        vm.ExpandAllCommand.Execute(null);
+
+        vm.RootMembers.Should().AllSatisfy(r => r.IsExpanded.Should().BeTrue());
+    }
+
+    [Fact]
+    public void CollapseAllCommand_CollapsesEveryRoot()
+    {
+        var (dbA, _, _) = MakeNestedDb("DB_N");
+        var vm = Build(activeDbs: new[] { dbA });
+        vm.BuildRootMembersFromActiveDbs();
+        vm.ExpandAllCommand.Execute(null);
+
+        vm.CollapseAllCommand.Execute(null);
+
+        vm.RootMembers.Should().AllSatisfy(r => r.IsExpanded.Should().BeFalse());
+    }
+
+    [Fact]
+    public void ExpandAllChildren_OnGroupRoot_ExpandsEveryDescendant()
+    {
+        var (dbA, _, _) = MakeNestedDb("DB_N");
+        var vm = Build(activeDbs: new[] { dbA });
+        vm.BuildRootMembersFromActiveDbs();
+
+        var root = vm.RootMembers[0];
+        vm.ExpandAllChildren(root);
+
+        foreach (var d in root.AllDescendants())
+        {
+            if (d.HasChildren) d.IsExpanded.Should().BeTrue();
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Fixtures
+    // ─────────────────────────────────────────────────────────────────────
+
+    private static MemberTreeViewModel Build(
+        IReadOnlyList<ActiveDb>? activeDbs = null,
+        Func<IReadOnlyList<ActiveDb>>? activeDbsFactory = null,
+        string currentPlcName = "",
+        Action<MemberNodeViewModel>? subscribeToVm = null) =>
+        new MemberTreeViewModel(
+            getActiveDbs: activeDbsFactory ?? (() => activeDbs ?? Array.Empty<ActiveDb>()),
+            getCurrentPlcName: () => currentPlcName,
+            commentLanguagePolicy: new CommentLanguagePolicy(null, null, new[] { "en-GB" }),
+            subscribeToVm: subscribeToVm ?? (_ => { }));
+
+    /// <summary>Overload accepting a live factory so tests can swap the
+    /// active set between calls without rebuilding the slice.</summary>
+    private static MemberTreeViewModel Build(
+        Func<IReadOnlyList<ActiveDb>> activeDbs,
+        string currentPlcName = "",
+        Action<MemberNodeViewModel>? subscribeToVm = null) =>
+        new MemberTreeViewModel(
+            getActiveDbs: activeDbs,
+            getCurrentPlcName: () => currentPlcName,
+            commentLanguagePolicy: new CommentLanguagePolicy(null, null, new[] { "en-GB" }),
+            subscribeToVm: subscribeToVm ?? (_ => { }));
+
+    /// <summary>
+    /// Two top-level members, one of which is a leaf "Speed". Fully usable
+    /// as an <see cref="ActiveDb"/>.
+    /// </summary>
+    private static (ActiveDb db, MemberNode speed, MemberNode enableFlag) MakeFlatDb(
+        string name, string plcName = "")
+    {
+        var speed = new MemberNode("Speed", "Int", "0", "Speed", null, Array.Empty<MemberNode>());
+        var enableFlag = new MemberNode("Enable", "Bool", "false", "Enable", null, Array.Empty<MemberNode>());
+        var info = new DataBlockInfo(name, 1, "Optimized", "GlobalDB", new[] { speed, enableFlag });
+        return (new ActiveDb(info, $"<Block name='{name}' />", onApply: null, plcName: plcName),
+                speed, enableFlag);
+    }
+
+    /// <summary>
+    /// One nested struct member with two children. Used by expand/collapse
+    /// tests that need a real ancestor-with-descendants shape.
+    /// </summary>
+    private static (ActiveDb db, MemberNode group, MemberNode leaf) MakeNestedDb(string name)
+    {
+        var leafA = new MemberNode("Speed", "Int", "0", "Group.Speed", null, Array.Empty<MemberNode>());
+        var leafB = new MemberNode("Temp", "Int", "0", "Group.Temp", null, Array.Empty<MemberNode>());
+        var group = new MemberNode("Group", "Struct", null, "Group", null, new[] { leafA, leafB });
+        var info = new DataBlockInfo(name, 1, "Optimized", "GlobalDB", new[] { group });
+        return (new ActiveDb(info, $"<Block name='{name}' />"), group, leafA);
+    }
+}

--- a/src/BlockParam.Tests/MemberTreeViewModelTests.cs
+++ b/src/BlockParam.Tests/MemberTreeViewModelTests.cs
@@ -193,17 +193,20 @@ public class MemberTreeViewModelTests
         vm.BuildRootMembersFromActiveDbs();
 
         // MakeNestedDb produces one struct ("Group") with two leaves
-        // ("Speed", "Temp") per DB. Multi-DB also adds the synthetic group VM
-        // per DB. Subscribe is called for every descendant including the
-        // synthetic group itself (which is fine — the synthetic node has no
-        // StartValueEdited semantics, the subscription is a no-op).
-        subscribed.Should().HaveCountGreaterOrEqualTo(
-            /* per DB: synthetic + Group + Speed + Temp = 4, two DBs = 8 */ 8,
+        // ("Speed", "Temp") per DB. AddDbGroupRoot iterates
+        // groupVm.AllDescendants() which excludes the synthetic root itself
+        // (AllDescendants returns child-and-below only), so per DB the slice
+        // subscribes Group + Speed + Temp = 3. Two DBs = 6 total. Asserting
+        // the exact contract count: an accidental "subscribe roots only" or
+        // "subscribe leaves only" regression would shift this number.
+        subscribed.Should().HaveCount(6,
             "every descendant in every active DB's synthetic subtree must be wired");
         // Both DB subtrees must contribute — a single-DB regression would
-        // produce 4 entries from dbA only.
-        subscribed.Select(v => v.Name).Should().Contain("Speed");
-        subscribed.Select(v => v.Name).Should().Contain("Temp");
+        // produce 3 entries from dbA only.
+        subscribed.Select(v => v.Name).Where(n => n == "Speed").Should().HaveCount(2,
+            "the Speed leaf in each of the two active DBs must be wired");
+        subscribed.Select(v => v.Name).Where(n => n == "Temp").Should().HaveCount(2,
+            "the Temp leaf in each of the two active DBs must be wired");
     }
 
     [Fact]

--- a/src/BlockParam.Tests/MemberTreeViewModelTests.cs
+++ b/src/BlockParam.Tests/MemberTreeViewModelTests.cs
@@ -102,6 +102,38 @@ public class MemberTreeViewModelTests
         rebuiltCount.Should().Be(2);
     }
 
+    /// <summary>
+    /// The host's <c>SeedVmsFromStore</c> subscribes to <c>RootsRebuilt</c>
+    /// and immediately calls <c>Tree.ModelToVm.TryGetValue(node, ...)</c> on
+    /// every pending entry. If the slice ever fires the event before the
+    /// lookup dictionaries are populated, pending-edit seeding would
+    /// silently drop every entry — which is exactly the kind of regression
+    /// the slice extraction was supposed to prevent.
+    /// </summary>
+    [Fact]
+    public void BuildFromActiveDbs_RootsRebuilt_FiresAfterLookupsArePopulated()
+    {
+        var (db, speed, _) = MakeFlatDb("DB_X");
+        var vm = Build(activeDbs: new[] { db });
+
+        bool lookupReadyInHandler = false;
+        bool speedResolvedInHandler = false;
+        vm.RootsRebuilt += () =>
+        {
+            lookupReadyInHandler = vm.ModelToVm.Count > 0;
+            speedResolvedInHandler = vm.FindVmByModel(speed) != null;
+        };
+
+        vm.BuildRootMembersFromActiveDbs();
+
+        lookupReadyInHandler.Should().BeTrue(
+            "ModelToVm must be populated before the event fires — the host's " +
+            "SeedVmsFromStore looks up by MemberNode and would silently drop " +
+            "every pending edit if the dict were still empty");
+        speedResolvedInHandler.Should().BeTrue(
+            "FindVmByModel must work inside the handler for every minted node");
+    }
+
     [Fact]
     public void BuildFromActiveDbs_ClearsPriorLookupsAndRoots()
     {
@@ -127,7 +159,7 @@ public class MemberTreeViewModelTests
     }
 
     [Fact]
-    public void BuildFromActiveDbs_InvokesSubscribeCallbackForEveryMintedVm()
+    public void BuildFromActiveDbs_SingleDb_InvokesSubscribeCallbackForEveryMintedVm()
     {
         var (db, _, _) = MakeFlatDb("DB_S");
         var subscribed = new List<MemberNodeViewModel>();
@@ -140,6 +172,38 @@ public class MemberTreeViewModelTests
             "so inline edits in the new tree route into the pending store");
         // Each subscription is for a distinct minted VM.
         subscribed.Distinct().Count().Should().Be(subscribed.Count);
+    }
+
+    /// <summary>
+    /// Multi-DB rebuilds go through <c>AddDbGroupRoot</c>, which iterates
+    /// every descendant of the synthetic group VM and invokes
+    /// <c>_subscribeToVm</c> per node. Single-DB coverage (above) only
+    /// exercises the top-level loop; this test locks the multi-DB
+    /// descendant-walk so an accidental "subscribe roots only" regression
+    /// would leave nested members unwired for inline editing.
+    /// </summary>
+    [Fact]
+    public void BuildFromActiveDbs_MultiDb_InvokesSubscribeCallbackForEveryDescendant()
+    {
+        var (dbA, _, _) = MakeNestedDb("DB_A");
+        var (dbB, _, _) = MakeNestedDb("DB_B");
+        var subscribed = new List<MemberNodeViewModel>();
+        var vm = Build(activeDbs: new[] { dbA, dbB }, subscribeToVm: subscribed.Add);
+
+        vm.BuildRootMembersFromActiveDbs();
+
+        // MakeNestedDb produces one struct ("Group") with two leaves
+        // ("Speed", "Temp") per DB. Multi-DB also adds the synthetic group VM
+        // per DB. Subscribe is called for every descendant including the
+        // synthetic group itself (which is fine — the synthetic node has no
+        // StartValueEdited semantics, the subscription is a no-op).
+        subscribed.Should().HaveCountGreaterOrEqualTo(
+            /* per DB: synthetic + Group + Speed + Temp = 4, two DBs = 8 */ 8,
+            "every descendant in every active DB's synthetic subtree must be wired");
+        // Both DB subtrees must contribute — a single-DB regression would
+        // produce 4 entries from dbA only.
+        subscribed.Select(v => v.Name).Should().Contain("Speed");
+        subscribed.Select(v => v.Name).Should().Contain("Temp");
     }
 
     [Fact]
@@ -232,17 +296,41 @@ public class MemberTreeViewModelTests
         vm.BuildRootMembersFromActiveDbs();
 
         bool wasTrueInsideCallback = false;
+        int flatCountInsideCallback = -1;
         vm.RebuildFlatList(insideRefreshScope: () =>
         {
             wasTrueInsideCallback = vm.IsRefreshing;
+            flatCountInsideCallback = vm.FlatMembers.Count;
         });
 
         wasTrueInsideCallback.Should().BeTrue(
             "the callback runs after the flat list rebuild but before IsRefreshing " +
             "clears — host uses this scope to restore selection without re-entering " +
             "OnMemberSelected");
+        flatCountInsideCallback.Should().BeGreaterThan(0,
+            "the doc comment promises the flat list is *already* rebuilt when the " +
+            "callback fires, so selection-restore code can look up the new VM by " +
+            "path against FlatMembers");
         vm.IsRefreshing.Should().BeFalse(
             "the flag clears once the callback returns");
+    }
+
+    [Fact]
+    public void RebuildFlatList_CallbackThrows_StillClearsIsRefreshing()
+    {
+        var (db, _, _) = MakeFlatDb("DB_F");
+        var vm = Build(activeDbs: new[] { db });
+        vm.BuildRootMembersFromActiveDbs();
+
+        var act = () => vm.RebuildFlatList(insideRefreshScope: () =>
+            throw new InvalidOperationException("callback boom"));
+
+        // Whatever the callback does, the slice must not leak IsRefreshing=true —
+        // otherwise the SelectedFlatMember setter on the host stays permanently
+        // gated against re-entry.
+        act.Should().Throw<InvalidOperationException>();
+        vm.IsRefreshing.Should().BeFalse(
+            "try/finally must clear IsRefreshing even when the callback throws");
     }
 
     [Fact]

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -311,13 +311,13 @@
 
                 <!-- Expand/Collapse All + Color legend -->
                 <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0,0,0,4">
-                    <Button Command="{Binding ExpandAllCommand}"
+                    <Button Command="{Binding Tree.ExpandAllCommand}"
                             Width="20" Height="16"
                             Background="Transparent" BorderThickness="0"
                             ToolTip="{loc:Loc Dialog_ExpandAll}" Cursor="Hand" Margin="0,0,2,0">
                         <Path Data="M 0,0 L 8,0 L 4,6 Z" Fill="#666" Width="8" Height="6" Stretch="Uniform"/>
                     </Button>
-                    <Button Command="{Binding CollapseAllCommand}"
+                    <Button Command="{Binding Tree.CollapseAllCommand}"
                             Width="20" Height="16"
                             Background="Transparent" BorderThickness="0"
                             ToolTip="{loc:Loc Dialog_CollapseAll}" Cursor="Hand" Margin="0,0,8,0">
@@ -341,7 +341,7 @@
                 <!-- Member Table fills the rest of the column -->
                 <ListView
                       x:Name="MemberListView"
-                      ItemsSource="{Binding FlatMembers}"
+                      ItemsSource="{Binding Tree.FlatMembers}"
                       SelectedItem="{Binding SelectedFlatMember}"
                       SelectionMode="Extended"
                       BorderBrush="#CCCCCC" BorderThickness="1"

--- a/src/BlockParam/UI/BulkChangeDialog.xaml.cs
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml.cs
@@ -141,7 +141,7 @@ public partial class BulkChangeDialog : Window
         var vmCheck = DataContext as BulkChangeViewModel;
         var addedList = e.AddedItems.OfType<MemberNodeViewModel>().ToList();
         var removedList = e.RemovedItems.OfType<MemberNodeViewModel>().ToList();
-        bool refreshing = vmCheck?.IsRefreshing == true;
+        bool refreshing = vmCheck?.Tree.IsRefreshing == true;
 
         // Ignore selection changes that are actually caused by the VM mutating
         // the FlatMembers ObservableCollection during a refresh — they are ghost
@@ -657,7 +657,7 @@ public partial class BulkChangeDialog : Window
 
     private static MemberNodeViewModel? FindFlatByPath(BulkChangeViewModel vm, string path)
     {
-        foreach (var m in vm.FlatMembers)
+        foreach (var m in vm.Tree.FlatMembers)
             if (m.Path == path) return m;
         return null;
     }
@@ -883,11 +883,11 @@ public partial class BulkChangeDialog : Window
         menu.Items.Clear();
 
         var expandItem = new MenuItem { Header = Res.Get("Context_ExpandAllChildren") };
-        expandItem.Click += (_, _) => vm.ExpandAllChildren(memberVm);
+        expandItem.Click += (_, _) => vm.Tree.ExpandAllChildren(memberVm);
         menu.Items.Add(expandItem);
 
         var collapseItem = new MenuItem { Header = Res.Get("Context_CollapseAllChildren") };
-        collapseItem.Click += (_, _) => vm.CollapseAllChildren(memberVm);
+        collapseItem.Click += (_, _) => vm.Tree.CollapseAllChildren(memberVm);
         menu.Items.Add(collapseItem);
     }
 

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -65,7 +65,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private readonly ConfigLoader _configLoader;
     private readonly Func<string>? _onBackup;   // callback to create backup, returns backup path
     private readonly Action<string>? _onRestore; // callback to restore from backup path
-    private readonly FlatTreeManager _flatTreeManager = new();
     private readonly SimaticMLWriter _writer = new();
     private readonly MemberSearchService _searchService = new();
     private readonly IMessageBoxService _messageBox;
@@ -114,18 +113,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private readonly Dictionary<string, StashedDbState> _stashedDbs =
         new(StringComparer.Ordinal);
 
-    // Model-to-VM and model-to-DB lookups for multi-DB routing (#58). Same
-    // path string can occur in multiple DBs, so reference equality on
-    // MemberNode is the unambiguous way to map a scope match back to its
-    // tree VM (where pending values live) and to its owning ActiveDb (where
-    // the xml lives). Rebuilt on every BuildRootMembersFromActiveDbs.
-    private readonly Dictionary<MemberNode, MemberNodeViewModel> _modelToVm = new();
-    private readonly Dictionary<MemberNode, ActiveDb> _modelToDb = new();
-    // Multi-DB only (#58): the synthetic group VM that wraps each ActiveDb's
-    // members. Used to route per-DB scans (ClearPendingValuesForDb,
-    // CountPendingEditsForDb, ...) by reference instead of by Info.Name +
-    // PlcName comparisons that would still collide across PLC boundaries.
-    private readonly Dictionary<ActiveDb, MemberNodeViewModel> _dbToSynthetic = new();
+    // Tree-shape state (RootMembers, flat list, model lookups, synthetic-
+    // group routing) lives on the MemberTreeViewModel slice (#80 slice 7a).
+    // The host accesses it via the Tree property — see the constructor.
 
     // Session-scoped store for pending inline-edit values, keyed by MemberNode
     // reference. Survives BuildRootMembersFromActiveDbs rebuilds — fresh VMs
@@ -168,7 +158,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private bool _showConstants;
     private bool _constantsForced;
     private string _tagTableAge = "";
-    private bool _isRefreshing;
+    // _isRefreshing moved to MemberTreeViewModel as Tree.IsRefreshing (slice 7a).
     private bool _lastApplySucceeded;
     private bool _hasPendingChanges;
     private readonly IReadOnlyList<string> _projectLanguages;
@@ -290,14 +280,19 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         Pending = new PendingEditsViewModel(() => _pendingEditStore.Count);
         StashedDbs = new ObservableCollection<StashedDbState>();
 
-        // Build tree view models. Multi-DB workflow (#58): when more than
-        // one DB is active, every active DB becomes a synthetic top-level
-        // "DB" group whose children are that DB's actual members.
-        // The user picked this shape over a flat union so each match in the
-        // tree carries a visible DB-of-origin label, and scope walks
-        // naturally extend one level deeper.
-        RootMembers = new ObservableCollection<MemberNodeViewModel>();
-        BuildRootMembersFromActiveDbs();
+        // Tree-shape + flat-list + expand/collapse slice (#80 slice 7a).
+        // Multi-DB workflow (#58): when more than one DB is active, every
+        // active DB becomes a synthetic top-level "DB" group whose children
+        // are that DB's actual members. The user picked this shape over a
+        // flat union so each match carries a visible DB-of-origin label,
+        // and scope walks naturally extend one level deeper.
+        Tree = new MemberTreeViewModel(
+            getActiveDbs: () => _activeDbs.AsReadOnly(),
+            getCurrentPlcName: () => _currentPlcName,
+            commentLanguagePolicy: _commentLanguagePolicy,
+            subscribeToVm: SubscribeStartValueEdited);
+        Tree.RootsRebuilt += OnTreeRootsRebuilt;
+        Tree.BuildRootMembersFromActiveDbs();
         RefreshRuleHints();
         RebuildPlcPills();
 
@@ -311,8 +306,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         EditConfigCommand = new RelayCommand(ExecuteEditConfig);
         RefreshConstantsCommand = new RelayCommand(ExecuteRefreshConstants);
-        ExpandAllCommand = new RelayCommand(ExecuteExpandAll);
-        CollapseAllCommand = new RelayCommand(ExecuteCollapseAll);
         // Inspector-panel expand/collapse state lives on its own slice VM
         // (#80 slice 1). The dialog code-behind subscribes to
         // `Inspector.PropertyChanged` directly for the splitter-column
@@ -423,8 +416,22 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         get => _title;
         private set => SetProperty(ref _title, value);
     }
-    public ObservableCollection<MemberNodeViewModel> RootMembers { get; }
     public ObservableCollection<ScopeLevel> AvailableScopes { get; }
+
+    /// <summary>
+    /// Tree-shape + flat-list + expand/collapse slice (#80 slice 7a). Owns
+    /// the <c>RootMembers</c> tree, the <c>FlatMembers</c> projection, the
+    /// three <c>MemberNode</c>/<c>ActiveDb</c> lookup dictionaries, and the
+    /// expand-all / collapse-all commands. XAML binds via
+    /// <c>{Binding Tree.RootMembers}</c>, <c>{Binding Tree.FlatMembers}</c>,
+    /// <c>{Binding Tree.ExpandAllCommand}</c> etc.
+    /// </summary>
+    public MemberTreeViewModel Tree { get; }
+
+    /// <summary>Convenience alias for <c>Tree.RootMembers</c>. Selection /
+    /// scope / Apply code on the host walks this many times; the alias
+    /// keeps those call sites short.</summary>
+    private ObservableCollection<MemberNodeViewModel> RootMembers => Tree.RootMembers;
 
     /// <summary>
     /// Bulk-preview collection slice (#80 slice 5). Owns the live preview
@@ -456,9 +463,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     public ObservableCollection<StashedDbState> StashedDbs { get; }
 
     public bool HasStashedDbs => StashedDbs.Count > 0;
-
-    /// <summary>Flat list for the ListView (proper column alignment).</summary>
-    public ObservableCollection<MemberNodeViewModel> FlatMembers => _flatTreeManager.FlatList;
 
     public event Action? RequestClose;
 
@@ -714,8 +718,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     public ICommand DiscardPendingCommand { get; }
 
     public ICommand EditConfigCommand { get; }
-    public ICommand ExpandAllCommand { get; }
-    public ICommand CollapseAllCommand { get; }
     public ICommand ClearManualSelectionCommand { get; }
 
     // --- DB-switcher dropdown (#59) ---
@@ -745,72 +747,29 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// <c>Datatype="DB"</c> so the tree template can render them with a
     /// distinct chrome.
     /// </summary>
-    private void BuildRootMembersFromActiveDbs()
-    {
-        // Always rebuild the routing dictionaries so every model node is
-        // mapped to its current VM + owning DB. Stale entries from a prior
-        // tree would route writes to disposed VMs.
-        _modelToVm.Clear();
-        _modelToDb.Clear();
-        _dbToSynthetic.Clear();
-
-        if (_activeDbs.Count == 1)
-        {
-            // Single-DB: flat list of top-level members, identical to legacy.
-            var only = _activeDbs[0];
-            foreach (var member in only.Info.Members)
-            {
-                var vm = new MemberNodeViewModel(member, null, _commentLanguagePolicy);
-                SubscribeStartValueEdited(vm);
-                IndexSubtree(vm, only);
-                RootMembers.Add(vm);
-            }
-        }
-        else
-        {
-            // Multi-DB: one synthetic group node per DB. Children are the DB's
-            // real top-level members, reused by reference — Path strings stay
-            // unchanged, so existing rule patterns / scope-detection on member
-            // paths still match across DBs.
-            // Cross-PLC name collision: two PLCs can each host a DB called
-            // "DB_Foo". Tag any colliding synthetic root with its PLC prefix so
-            // the user can tell them apart in the tree.
-            var nameCounts = _activeDbs
-                .GroupBy(d => d.Info.Name, StringComparer.Ordinal)
-                .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
-            for (int i = 0; i < _activeDbs.Count; i++)
-            {
-                var db = _activeDbs[i];
-                var plc = i == 0 ? _currentPlcName : db.PlcName;
-                bool collides = nameCounts.TryGetValue(db.Info.Name, out var c) && c > 1;
-                var displayName = collides && !string.IsNullOrEmpty(plc)
-                    ? $"{plc} / {db.Info.Name}"
-                    : db.Info.Name;
-                AddDbGroupRoot(db, displayName);
-            }
-        }
-
-        // Seed any pending values that survived the rebuild (active-set
-        // transitions preserve MemberNode instances but mint fresh VMs).
-        // Called unconditionally — single-DB rebuilds are just as likely to
-        // need store seeding as multi-DB ones (e.g. peer chip removed while
-        // the anchor DB had a pending inline edit in progress).
-        SeedVmsFromStore();
-    }
+    /// <summary>
+    /// Post-rebuild hook fired by <see cref="MemberTreeViewModel.RootsRebuilt"/>.
+    /// The tree slice owns the fresh <c>MemberNodeViewModel</c> instances; the
+    /// host owns the pending-edit store + the validator, so the seeding pass
+    /// stays here. (Slice 7a kept the host-side pending-store coupling so the
+    /// slice doesn't acquire a store reference.)
+    /// </summary>
+    private void OnTreeRootsRebuilt() => SeedVmsFromStore();
 
     /// <summary>
     /// Restores pending-edit state from <see cref="_pendingEditStore"/> onto
     /// freshly-constructed <see cref="MemberNodeViewModel"/> instances after a
-    /// tree rebuild. Called at the end of <see cref="BuildRootMembersFromActiveDbs"/>
-    /// so every active-set transition (solo, chip-×, reactivate) automatically
-    /// preserves in-progress edits without callers needing to stash/restore manually.
+    /// tree rebuild. Called via <see cref="MemberTreeViewModel.RootsRebuilt"/>
+    /// after every <c>BuildRootMembersFromActiveDbs</c>, so active-set
+    /// transitions (solo, chip-×, reactivate) automatically preserve
+    /// in-progress edits without callers needing to stash/restore manually.
     /// </summary>
     private void SeedVmsFromStore()
     {
         var validator = BuildValidator();
         foreach (var (node, pendingValue) in _pendingEditStore.GetAll())
         {
-            if (!_modelToVm.TryGetValue(node, out var vm))
+            if (!Tree.ModelToVm.TryGetValue(node, out var vm))
                 continue;
             // Set the field directly to avoid firing OnSingleValueEdited,
             // which would write back to the store (creating a loop) and
@@ -824,73 +783,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             vm.InlineErrorMessage = error;
         }
     }
-
-    private void AddDbGroupRoot(ActiveDb db, string displayName)
-    {
-        var info = db.Info;
-        var synthetic = new MemberNode(
-            name: displayName,
-            datatype: "DB",
-            startValue: null,
-            path: info.Name,
-            parent: null,
-            children: info.Members);
-        var groupVm = new MemberNodeViewModel(synthetic, null, _commentLanguagePolicy);
-        // Subscribe edited-value events on every leaf descendant so inline
-        // edits in any active DB bubble up to the VM the same way
-        // single-DB edits do.
-        foreach (var descendant in groupVm.AllDescendants())
-            SubscribeStartValueEdited(descendant);
-        groupVm.IsExpanded = true;
-        _dbToSynthetic[db] = groupVm;
-        // Map every real (non-synthetic) descendant to its VM + owning DB so
-        // multi-DB scope hits route writes to the right tree / xml.
-        foreach (var descendant in groupVm.AllDescendants())
-        {
-            // Skip the synthetic group node itself — its Model has Datatype="DB"
-            // and isn't a real member. Identifying it by reference equality
-            // against the synthetic instance avoids relying on Datatype string
-            // matching, which is fragile.
-            if (ReferenceEquals(descendant.Model, synthetic)) continue;
-            _modelToVm[descendant.Model] = descendant;
-            _modelToDb[descendant.Model] = db;
-        }
-        RootMembers.Add(groupVm);
-    }
-
-    /// <summary>
-    /// Indexes every node in <paramref name="rootVm"/>'s subtree (root
-    /// included) into <see cref="_modelToVm"/> + <see cref="_modelToDb"/>.
-    /// Used by the single-DB code path; multi-DB indexes inside
-    /// <see cref="AddDbGroupRoot"/> with the synthetic-skip rule.
-    /// </summary>
-    private void IndexSubtree(MemberNodeViewModel rootVm, ActiveDb db)
-    {
-        _modelToVm[rootVm.Model] = rootVm;
-        _modelToDb[rootVm.Model] = db;
-        foreach (var descendant in rootVm.AllDescendants())
-        {
-            _modelToVm[descendant.Model] = descendant;
-            _modelToDb[descendant.Model] = db;
-        }
-    }
-
-    /// <summary>
-    /// Resolves a <see cref="MemberNode"/> (model) to its tree VM. Preferred
-    /// over <see cref="FindNodeByPath"/> when the caller already has the
-    /// model — it's O(1), and unambiguous in multi-DB sessions where the
-    /// same Path string can exist in multiple DBs.
-    /// </summary>
-    private MemberNodeViewModel? FindVmByModel(MemberNode model) =>
-        _modelToVm.TryGetValue(model, out var vm) ? vm : null;
-
-    /// <summary>
-    /// Returns the active DB that owns <paramref name="model"/>, or null
-    /// when the node is not part of the current tree (e.g. a stale model
-    /// from before the last RefreshTree).
-    /// </summary>
-    private ActiveDb? FindActiveDbForModel(MemberNode model) =>
-        _modelToDb.TryGetValue(model, out var db) ? db : null;
 
     /// <summary>
     /// All DBs currently being edited in this dialog session (#58). Always
@@ -1572,8 +1464,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         _selectedFlatMember = null;
         _selectedScope = null;
         _manualSelectedPaths.Clear();
-        RootMembers.Clear();
-        BuildRootMembersFromActiveDbs();
+        // Tree.BuildRootMembersFromActiveDbs clears RootMembers + the lookup
+        // dicts internally — no separate RootMembers.Clear() needed.
+        Tree.BuildRootMembersFromActiveDbs();
         ApplyAllFilters();
         RefreshFlatList();
         RebuildPlcPills();
@@ -1774,11 +1667,11 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private StashedDbState? CaptureStashForDb(ActiveDb db)
     {
         var entries = new List<StashedEditEntry>();
-        foreach (var (node, pendingValue) in _pendingEditStore.GetForDb(db, _modelToDb))
+        foreach (var (node, pendingValue) in _pendingEditStore.GetForDb(db, Tree.ModelToDb))
         {
             // Resolve to the VM to read StartValue (which is model-derived
             // and stable). If the VM can't be found the model is still valid.
-            var vm = FindVmByModel(node);
+            var vm = Tree.FindVmByModel(node);
             entries.Add(new StashedEditEntry(
                 node.Path,
                 vm?.StartValue ?? node.StartValue ?? "",
@@ -1876,18 +1769,18 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// </summary>
     private void ClearPendingValuesForDb(ActiveDb db)
     {
-        // Walk _modelToDb to find VMs owned by this DB and clear their
+        // Walk Tree.ModelToDb to find VMs owned by this DB and clear their
         // pending state. Keyed by MemberNode reference — safe in multi-DB
         // sessions where the same path can appear in multiple DBs.
-        foreach (var kvp in _modelToDb)
+        foreach (var kvp in Tree.ModelToDb)
         {
             if (!ReferenceEquals(kvp.Value, db)) continue;
-            if (_modelToVm.TryGetValue(kvp.Key, out var vm) && vm.IsPendingInlineEdit)
+            if (Tree.ModelToVm.TryGetValue(kvp.Key, out var vm) && vm.IsPendingInlineEdit)
                 vm.ClearPending();
         }
         // Evict from the store so a later tree rebuild doesn't re-populate
         // values that were just committed.
-        _pendingEditStore.ClearForDb(db, _modelToDb);
+        _pendingEditStore.ClearForDb(db, Tree.ModelToDb);
     }
 
     /// <summary>
@@ -1897,7 +1790,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// O(subtree size), and correct even when the tree hasn't rebuilt yet.
     /// </summary>
     private int CountPendingEditsForDb(ActiveDb db)
-        => _pendingEditStore.CountForDb(db, _modelToDb);
+        => _pendingEditStore.CountForDb(db, Tree.ModelToDb);
 
     /// <summary>
     /// Best-effort "apply this DB's edits before we remove it" (#58
@@ -1919,7 +1812,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         // Store-based: unambiguous in multi-DB sessions (MemberNode identity),
         // correct even when the tree hasn't rebuilt yet (store survives rebuilds).
-        var pendingEdits = _pendingEditStore.GetForDb(db, _modelToDb).ToList();
+        var pendingEdits = _pendingEditStore.GetForDb(db, Tree.ModelToDb).ToList();
         if (pendingEdits.Count == 0) return true;
 
         var status = Subscription.GetUsageStatus();
@@ -1946,7 +1839,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             if (totalChanged > 0) Subscription.RecordUsage(totalChanged);
             // The edits are now committed to TIA — evict the DB's store entries
             // so a subsequent tree rebuild doesn't re-populate committed values.
-            _pendingEditStore.ClearForDb(db, _modelToDb);
+            _pendingEditStore.ClearForDb(db, Tree.ModelToDb);
             return true;
         }
         catch (OperationCanceledException)
@@ -2065,7 +1958,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         {
             var node = scopedTo != null
                 ? FindNodeByPathInDb(edit.Path, scopedTo)
-                : FindNodeByPath(edit.Path);
+                : Tree.FindNodeByPath(edit.Path);
             if (node is { IsLeaf: true })
             {
                 // Restore-without-quota: setting EditableStartValue would route
@@ -2266,22 +2159,11 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
     // --- Public methods (called from code-behind) ---
 
-    /// <summary>
-    /// Toggles expand/collapse for a node and refreshes the flat list.
-    /// </summary>
-    public void ToggleExpand(MemberNodeViewModel node)
-    {
-        _flatTreeManager.ToggleExpand(node, RootMembers);
-    }
+    // ToggleExpand / IsRefreshing moved to MemberTreeViewModel (slice 7a).
+    // Code-behind that needs them now reads `vm.Tree.ToggleExpand` /
+    // `vm.Tree.IsRefreshing`.
 
     // --- Private methods ---
-
-    /// <summary>
-    /// True while <see cref="RefreshFlatList"/> is rebuilding <see cref="FlatMembers"/>.
-    /// The view checks this in its SelectionChanged handler to ignore the ghost
-    /// "removed items" events WPF raises when the ItemsSource is mutated.
-    /// </summary>
-    public bool IsRefreshing => _isRefreshing;
 
     /// <summary>
     /// For scripted scenarios (DevLauncher screenshot capture, future UI tests):
@@ -2323,34 +2205,25 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
     public void RefreshFlatList()
     {
-        if (_isRefreshing) return;
-        _isRefreshing = true;
-        try
+        // Pre-PR shape (one combined try/finally on the host) is preserved by
+        // routing the selection-restore + multi-select rehydration through
+        // Tree.RebuildFlatList's insideRefreshScope callback — both still run
+        // while Tree.IsRefreshing is true, so SelectedFlatMember setter +
+        // code-behind SelectionChanged stay suppressed during the rebuild.
+        var selectedPath = _selectedFlatMember?.Path;
+        Tree.RebuildFlatList(insideRefreshScope: () =>
         {
-            var selectedPath = _selectedFlatMember?.Path;
-            _flatTreeManager.Refresh(RootMembers);
-
-            // Restore selection in the new flat list (same node by path)
             if (selectedPath != null)
             {
-                var restored = _flatTreeManager.FlatList
-                    .FirstOrDefault(m => m.Path == selectedPath);
+                var restored = Tree.FlatMembers.FirstOrDefault(m => m.Path == selectedPath);
                 // Set backing field directly to avoid re-triggering OnMemberSelected
                 _selectedFlatMember = restored;
                 OnPropertyChanged(nameof(SelectedFlatMember));
                 OnPropertyChanged(nameof(HasSelection));
                 OnPropertyChanged(nameof(SelectedMemberDisplay));
             }
-
-            // Rehydrate multi-selection while _isRefreshing is still true so that
-            // cascaded SelectedItem changes (e.g. from SelectedItems.Clear()) do
-            // NOT trigger OnMemberSelected → UpdateHighlighting → recursion.
             FlatListRefreshed?.Invoke();
-        }
-        finally
-        {
-            _isRefreshing = false;
-        }
+        });
     }
 
     private void OnMemberSelected(MemberNodeViewModel? memberVm)
@@ -2418,7 +2291,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         AnalysisResult result;
         if (HasMultipleActiveDbs)
         {
-            var owningDb = FindActiveDbForModel(memberVm.Model)?.Info ?? _active.Info;
+            var owningDb = Tree.FindActiveDbForModel(memberVm.Model)?.Info ?? _active.Info;
             var allInfos = AllActiveDbs.Select(a => a.Info).ToList();
             result = _analyzer.AnalyzeMulti(allInfos, owningDb, memberVm.Model);
         }
@@ -2544,7 +2417,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                     // Multi-DB safe: route by model reference, not path string.
                     // Same path can exist in multiple DBs; FindVmByModel is
                     // O(1) and always picks the right DB's tree VM.
-                    var node = FindVmByModel(m);
+                    var node = Tree.FindVmByModel(m);
                     if (node == null || !node.IsLeaf) continue;
                     TryAddPreviewEntry(node);
                 }
@@ -2625,7 +2498,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // Multi-DB safe lookup: a model is owned by exactly one ActiveDb,
         // so reference equality picks the right tree VM regardless of which
         // DBs share the path string.
-        var vm = FindVmByModel(model);
+        var vm = Tree.FindVmByModel(model);
         if (vm != null && vm.IsPendingInlineEdit)
             return vm.EditableStartValue;
         return model.StartValue;
@@ -2647,7 +2520,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         {
             // Comment previews target scope members → route by model
             // reference for cross-DB safety (#58).
-            var vm = FindVmByModel(target);
+            var vm = Tree.FindVmByModel(target);
             if (vm != null)
             {
                 vm.PreviewComment = comment;
@@ -2694,33 +2567,18 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         }
     }
 
-    private MemberNodeViewModel? FindNodeByPath(string path)
-    {
-        foreach (var root in RootMembers)
-        {
-            var found = FindNodeByPathRecursive(root, path);
-            if (found != null) return found;
-        }
-        return null;
-    }
-
     /// <summary>
-    /// DB-scoped variant of <see cref="FindNodeByPath"/>. Callers pass this
-    /// when member Paths can repeat across DBs (the stash holds the bare
-    /// member path, not "DbName.MemberPath") — without scoping, a
-    /// reactivate-additive would replay edits onto whichever DB happened
-    /// to be checked first.
-    ///
-    /// Strict: callers must only invoke this when the active set is in
-    /// multi-DB shape (i.e. after the State cascade has populated
-    /// <see cref="_dbToSynthetic"/> for <paramref name="owner"/>). If the
-    /// synthetic root isn't found, returns null + warns — a future
+    /// Diagnostic wrapper around <see cref="MemberTreeViewModel.FindNodeByPathInDb"/>:
+    /// the slice returns null when the active set isn't in multi-DB shape
+    /// yet (its <c>_dbToSynthetic</c> doesn't have an entry for
+    /// <paramref name="owner"/>), the host adds the warn-log so a future
     /// ordering bug surfaces as "stashed edit dropped" in the log instead
-    /// of silently aliasing onto another DB.
+    /// of silently aliasing onto another DB. The slice intentionally has
+    /// no <c>Serilog</c> dependency.
     /// </summary>
     private MemberNodeViewModel? FindNodeByPathInDb(string path, ActiveDb owner)
     {
-        if (!_dbToSynthetic.TryGetValue(owner, out var synthetic))
+        if (!Tree.DbToSynthetic.ContainsKey(owner))
         {
             Log.Warning(
                 "FindNodeByPathInDb({Path}) called for {Db} but no synthetic " +
@@ -2729,23 +2587,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                 path, owner.Info.Name);
             return null;
         }
-        foreach (var child in synthetic.Children)
-        {
-            var found = FindNodeByPathRecursive(child, path);
-            if (found != null) return found;
-        }
-        return null;
-    }
-
-    private static MemberNodeViewModel? FindNodeByPathRecursive(MemberNodeViewModel node, string path)
-    {
-        if (node.Path == path) return node;
-        foreach (var child in node.Children)
-        {
-            var found = FindNodeByPathRecursive(child, path);
-            if (found != null) return found;
-        }
-        return null;
+        return Tree.FindNodeByPathInDb(path, owner);
     }
 
     /// <summary>
@@ -2759,7 +2601,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         var result = new HashSet<MemberNodeViewModel>();
         foreach (var m in models)
         {
-            var vm = FindVmByModel(m);
+            var vm = Tree.FindVmByModel(m);
             if (vm != null) result.Add(vm);
         }
         return result;
@@ -2831,7 +2673,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         {
             // Route per synthetic root so each DB's filter sets only affect
             // its own subtree.
-            foreach (var kvp in _dbToSynthetic)
+            foreach (var kvp in Tree.DbToSynthetic)
             {
                 var db = kvp.Key;
                 var syntheticRoot = kvp.Value;
@@ -2882,7 +2724,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         {
             // Per-DB search so a path that's a hit in one DB doesn't smart-
             // expand the same path in other active DBs that don't have a hit.
-            foreach (var kvp in _dbToSynthetic)
+            foreach (var kvp in Tree.DbToSynthetic)
             {
                 var db = kvp.Key;
                 var syntheticRoot = kvp.Value;
@@ -2969,7 +2811,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         if (_bulkErrorPaths.Count == 0) return;
         foreach (var path in _bulkErrorPaths)
         {
-            var n = FindNodeByPath(path);
+            var n = Tree.FindNodeByPath(path);
             if (n != null && !n.IsPendingInlineEdit)
             {
                 n.HasInlineError = false;
@@ -3167,35 +3009,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             : $"{newest:yyyy-MM-dd HH:mm}";
     }
 
-    private void ExecuteExpandAll()
-    {
-        FlatTreeManager.ExpandAll(RootMembers);
-        RefreshFlatList();
-    }
-
-    private void ExecuteCollapseAll()
-    {
-        FlatTreeManager.CollapseAll(RootMembers);
-        RefreshFlatList();
-    }
-
-    /// <summary>
-    /// Expands a node and all its descendants, then refreshes the flat list.
-    /// </summary>
-    public void ExpandAllChildren(MemberNodeViewModel node)
-    {
-        FlatTreeManager.ExpandAllChildren(node);
-        RefreshFlatList();
-    }
-
-    /// <summary>
-    /// Collapses a node and all its descendants, then refreshes the flat list.
-    /// </summary>
-    public void CollapseAllChildren(MemberNodeViewModel node)
-    {
-        FlatTreeManager.CollapseAllChildren(node);
-        RefreshFlatList();
-    }
+    // ExpandAll / CollapseAll commands + ExpandAllChildren / CollapseAllChildren
+    // methods moved to MemberTreeViewModel (slice 7a). Code-behind callers
+    // route through `vm.Tree.ExpandAllChildren(node)` etc.
 
     /// <summary>Can stage bulk scope or manual-selection values as pending.</summary>
     private bool CanExecuteSetPending()
@@ -3231,7 +3047,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         return _selectedScope.MatchingMembers.Count(m =>
         {
-            var node = FindNodeByPath(m.Path);
+            var node = Tree.FindNodeByPath(m.Path);
             // Unresolved paths can't be staged by SetPendingOnNodes, so don't
             // count them — that's exactly the inflation the old label had.
             return node != null && WouldChange(node);
@@ -3604,7 +3420,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         {
             // Store-based: unambiguous in multi-PLC sessions; correct even if
             // the tree hasn't rebuilt after a recent active-set transition.
-            var edits = _pendingEditStore.GetForDb(db, _modelToDb).ToList();
+            var edits = _pendingEditStore.GetForDb(db, Tree.ModelToDb).ToList();
             if (edits.Count == 0) continue;
             totalChanges += edits.Count;
             perDb.Add((db, edits));
@@ -3817,7 +3633,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             var byDb = new Dictionary<ActiveDb, List<MemberNode>>();
             foreach (var member in _selectedScope.MatchingMembers)
             {
-                var owningDb = FindActiveDbForModel(member);
+                var owningDb = Tree.FindActiveDbForModel(member);
                 if (owningDb == null) continue;
                 if (!byDb.TryGetValue(owningDb, out var list))
                 {
@@ -4139,8 +3955,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // the committed (and now applied) edit set.
         _pendingEditStore.ClearAll();
 
-        RootMembers.Clear();
-        BuildRootMembersFromActiveDbs();
+        // Tree.BuildRootMembersFromActiveDbs clears RootMembers + the lookup
+        // dicts internally.
+        Tree.BuildRootMembersFromActiveDbs();
         RefreshRuleHints();
         RebuildExistingIssues();
 
@@ -4154,7 +3971,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // Restore selection and re-trigger scope analysis
         if (selectedPath != null)
         {
-            var restored = _flatTreeManager.FlatList.FirstOrDefault(m => m.Path == selectedPath);
+            var restored = Tree.FlatMembers.FirstOrDefault(m => m.Path == selectedPath);
             if (restored != null)
             {
                 _selectedFlatMember = restored;
@@ -4172,7 +3989,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                 AnalysisResult result;
                 if (HasMultipleActiveDbs)
                 {
-                    var owningDb = FindActiveDbForModel(restored.Model)?.Info ?? _active.Info;
+                    var owningDb = Tree.FindActiveDbForModel(restored.Model)?.Info ?? _active.Info;
                     var allInfos = AllActiveDbs.Select(a => a.Info).ToList();
                     result = _analyzer.AnalyzeMulti(allInfos, owningDb, restored.Model);
                 }

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -532,7 +532,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         get => _selectedFlatMember;
         set
         {
-            if (_isRefreshing) return; // Don't re-trigger during flat list rebuild
+            if (Tree.IsRefreshing) return; // Don't re-trigger during flat list rebuild
             if (SetProperty(ref _selectedFlatMember, value))
             {
                 OnMemberSelected(value);

--- a/src/BlockParam/UI/MemberTreeViewModel.cs
+++ b/src/BlockParam/UI/MemberTreeViewModel.cs
@@ -1,0 +1,388 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Input;
+using BlockParam.Models;
+
+namespace BlockParam.UI;
+
+/// <summary>
+/// Tree-shape + flat-list + expand/collapse slice (#80 slice 7a).
+///
+/// <para>
+/// Owns the <see cref="RootMembers"/> collection that backs the dialog's
+/// tree, the flat-list projection used by the WPF
+/// <c>ListView</c>/<c>GridView</c>, the three <c>MemberNode</c>/
+/// <c>ActiveDb</c> lookup dictionaries that route writes back to the
+/// right tree VM, and the expand-all / collapse-all commands.
+/// </para>
+///
+/// <para>
+/// <b>What stays on the host (slice 7b territory):</b> selection state
+/// (<c>SelectedFlatMember</c>, <c>SelectedScope</c>, <c>AvailableScopes</c>,
+/// <c>_manualSelectedPaths</c>), scope analysis (<c>OnMemberSelected</c>),
+/// manual-selection state machine (<c>UpdateManualSelection</c>), and the
+/// selection-restore wrapper around <see cref="RebuildFlatList"/>. The
+/// host's <c>RefreshFlatList</c> calls <see cref="RebuildFlatList"/> in
+/// between save-selection and restore-selection steps.
+/// </para>
+///
+/// <para>
+/// <b>Dependency on slice 8 (active-set) state:</b> the slice doesn't own
+/// the active DB set — it takes <c>getActiveDbs</c> / <c>getCurrentPlcName</c>
+/// callbacks so multi-DB tree shape stays correct without the slice
+/// holding its own copy. When slice 8 lands these callbacks reduce to
+/// reading one composed VM.
+/// </para>
+///
+/// <para>
+/// <b>Why no pending-store dependency:</b> the pending-store seeding after
+/// a tree rebuild is host-side (<c>SeedVmsFromStore</c> reads
+/// <c>Tree.ModelToVm</c> + the host's <c>_pendingEditStore</c>). The slice
+/// fires <see cref="RootsRebuilt"/> after <see cref="BuildRootMembersFromActiveDbs"/>
+/// so the host can run its post-rebuild hooks (seeding + validation)
+/// without the slice depending on the store.
+/// </para>
+/// </summary>
+public class MemberTreeViewModel : ViewModelBase
+{
+    private readonly FlatTreeManager _flatTreeManager = new();
+    private readonly Func<IReadOnlyList<ActiveDb>> _getActiveDbs;
+    private readonly Func<string> _getCurrentPlcName;
+    private readonly CommentLanguagePolicy _commentLanguagePolicy;
+    private readonly Action<MemberNodeViewModel> _subscribeToVm;
+
+    private readonly Dictionary<MemberNode, MemberNodeViewModel> _modelToVm = new();
+    private readonly Dictionary<MemberNode, ActiveDb> _modelToDb = new();
+    private readonly Dictionary<ActiveDb, MemberNodeViewModel> _dbToSynthetic = new();
+
+    private bool _isRefreshing;
+
+    public MemberTreeViewModel(
+        Func<IReadOnlyList<ActiveDb>> getActiveDbs,
+        Func<string> getCurrentPlcName,
+        CommentLanguagePolicy commentLanguagePolicy,
+        Action<MemberNodeViewModel> subscribeToVm)
+    {
+        _getActiveDbs = getActiveDbs;
+        _getCurrentPlcName = getCurrentPlcName;
+        _commentLanguagePolicy = commentLanguagePolicy;
+        _subscribeToVm = subscribeToVm;
+
+        RootMembers = new ObservableCollection<MemberNodeViewModel>();
+        ExpandAllCommand = new RelayCommand(ExecuteExpandAll);
+        CollapseAllCommand = new RelayCommand(ExecuteCollapseAll);
+    }
+
+    /// <summary>
+    /// Top-level tree VMs. Single-DB session = one entry per top-level
+    /// member of the anchor DB; multi-DB session = one synthetic
+    /// <c>Datatype="DB"</c> group per active DB whose children are that
+    /// DB's real members.
+    /// </summary>
+    public ObservableCollection<MemberNodeViewModel> RootMembers { get; }
+
+    /// <summary>
+    /// Flat-list projection of <see cref="RootMembers"/> respecting current
+    /// expand/collapse + visibility state. Bound by the <c>ListView</c>.
+    /// </summary>
+    public ObservableCollection<MemberNodeViewModel> FlatMembers => _flatTreeManager.FlatList;
+
+    /// <summary>
+    /// True while <see cref="RebuildFlatList"/> is in flight. Read by the
+    /// dialog's <c>SelectionChanged</c> handler in code-behind to ignore
+    /// ghost "removed items" events WPF raises when the <c>ItemsSource</c>
+    /// is mutated.
+    /// </summary>
+    public bool IsRefreshing
+    {
+        get => _isRefreshing;
+        private set => SetProperty(ref _isRefreshing, value);
+    }
+
+    /// <summary>
+    /// <c>MemberNode</c> → owning tree VM. O(1) replacement for the
+    /// path-string walk in <see cref="FindNodeByPath"/>; unambiguous in
+    /// multi-DB sessions where the same path string can appear in
+    /// multiple DBs.
+    /// </summary>
+    public IReadOnlyDictionary<MemberNode, MemberNodeViewModel> ModelToVm => _modelToVm;
+
+    /// <summary>
+    /// <c>MemberNode</c> → owning <c>ActiveDb</c>. Used by the host's
+    /// pending-edit store + multi-DB scope routing to write back to the
+    /// right tree / xml.
+    /// </summary>
+    public IReadOnlyDictionary<MemberNode, ActiveDb> ModelToDb => _modelToDb;
+
+    /// <summary>
+    /// <c>ActiveDb</c> → its synthetic group root in the multi-DB tree.
+    /// Empty in single-DB sessions. Used by <see cref="FindNodeByPathInDb"/>
+    /// and by the host's <c>ApplyAllFilters</c> to route per-DB filter
+    /// sets to the correct subtree.
+    /// </summary>
+    public IReadOnlyDictionary<ActiveDb, MemberNodeViewModel> DbToSynthetic => _dbToSynthetic;
+
+    public ICommand ExpandAllCommand { get; }
+    public ICommand CollapseAllCommand { get; }
+
+    /// <summary>
+    /// Raised once <see cref="BuildRootMembersFromActiveDbs"/> has rebuilt
+    /// <see cref="RootMembers"/> + the lookup dictionaries. The host
+    /// subscribes to re-seed pending-edit state, refresh rule hints,
+    /// rebuild existing-issues, and similar post-rebuild hooks.
+    /// </summary>
+    public event Action? RootsRebuilt;
+
+    /// <summary>
+    /// Rebuilds <see cref="RootMembers"/> + the three lookup dictionaries
+    /// from the current active-DB set. Single-DB session puts top-level
+    /// members of the anchor DB directly at root; multi-DB session creates
+    /// one synthetic group per DB. Fires <see cref="RootsRebuilt"/> when
+    /// the new shape is ready.
+    /// </summary>
+    public void BuildRootMembersFromActiveDbs()
+    {
+        // Always rebuild the routing dictionaries so every model node is
+        // mapped to its current VM + owning DB. Stale entries from a prior
+        // tree would route writes to disposed VMs.
+        _modelToVm.Clear();
+        _modelToDb.Clear();
+        _dbToSynthetic.Clear();
+        RootMembers.Clear();
+
+        var activeDbs = _getActiveDbs();
+
+        if (activeDbs.Count == 1)
+        {
+            // Single-DB: flat list of top-level members, identical to legacy.
+            var only = activeDbs[0];
+            foreach (var member in only.Info.Members)
+            {
+                var vm = new MemberNodeViewModel(member, null, _commentLanguagePolicy);
+                _subscribeToVm(vm);
+                IndexSubtree(vm, only);
+                RootMembers.Add(vm);
+            }
+        }
+        else
+        {
+            // Multi-DB: one synthetic group node per DB. Children are the DB's
+            // real top-level members, reused by reference — Path strings stay
+            // unchanged, so existing rule patterns / scope-detection on member
+            // paths still match across DBs.
+            // Cross-PLC name collision: two PLCs can each host a DB called
+            // "DB_Foo". Tag any colliding synthetic root with its PLC prefix so
+            // the user can tell them apart in the tree.
+            var anchorPlc = _getCurrentPlcName();
+            var nameCounts = activeDbs
+                .GroupBy(d => d.Info.Name, StringComparer.Ordinal)
+                .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+            for (int i = 0; i < activeDbs.Count; i++)
+            {
+                var db = activeDbs[i];
+                var plc = i == 0 ? anchorPlc : db.PlcName;
+                bool collides = nameCounts.TryGetValue(db.Info.Name, out var c) && c > 1;
+                var displayName = collides && !string.IsNullOrEmpty(plc)
+                    ? $"{plc} / {db.Info.Name}"
+                    : db.Info.Name;
+                AddDbGroupRoot(db, displayName);
+            }
+        }
+
+        RootsRebuilt?.Invoke();
+    }
+
+    private void AddDbGroupRoot(ActiveDb db, string displayName)
+    {
+        var info = db.Info;
+        var synthetic = new MemberNode(
+            name: displayName,
+            datatype: "DB",
+            startValue: null,
+            path: info.Name,
+            parent: null,
+            children: info.Members);
+        var groupVm = new MemberNodeViewModel(synthetic, null, _commentLanguagePolicy);
+        // Subscribe edited-value events on every leaf descendant so inline
+        // edits in any active DB bubble up to the VM the same way
+        // single-DB edits do.
+        foreach (var descendant in groupVm.AllDescendants())
+            _subscribeToVm(descendant);
+        groupVm.IsExpanded = true;
+        _dbToSynthetic[db] = groupVm;
+        // Map every real (non-synthetic) descendant to its VM + owning DB so
+        // multi-DB scope hits route writes to the right tree / xml.
+        foreach (var descendant in groupVm.AllDescendants())
+        {
+            // Skip the synthetic group node itself — its Model has Datatype="DB"
+            // and isn't a real member. Identifying it by reference equality
+            // against the synthetic instance avoids relying on Datatype string
+            // matching, which is fragile.
+            if (ReferenceEquals(descendant.Model, synthetic)) continue;
+            _modelToVm[descendant.Model] = descendant;
+            _modelToDb[descendant.Model] = db;
+        }
+        RootMembers.Add(groupVm);
+    }
+
+    /// <summary>
+    /// Indexes every node in <paramref name="rootVm"/>'s subtree (root
+    /// included) into <see cref="_modelToVm"/> + <see cref="_modelToDb"/>.
+    /// Used by the single-DB code path; multi-DB indexes inside
+    /// <see cref="AddDbGroupRoot"/> with the synthetic-skip rule.
+    /// </summary>
+    private void IndexSubtree(MemberNodeViewModel rootVm, ActiveDb db)
+    {
+        _modelToVm[rootVm.Model] = rootVm;
+        _modelToDb[rootVm.Model] = db;
+        foreach (var descendant in rootVm.AllDescendants())
+        {
+            _modelToVm[descendant.Model] = descendant;
+            _modelToDb[descendant.Model] = db;
+        }
+    }
+
+    /// <summary>
+    /// Rebuilds <see cref="FlatMembers"/> from the current
+    /// <see cref="RootMembers"/> tree state. Re-entry is silently
+    /// ignored — the cascade that triggered the inner call is mid-flight
+    /// and will refresh again when it returns.
+    ///
+    /// <para>
+    /// <paramref name="insideRefreshScope"/> is invoked after the flat
+    /// list has been rebuilt but while <see cref="IsRefreshing"/> is
+    /// still <c>true</c>. The host uses this hook to restore selection +
+    /// raise its <c>FlatListRefreshed</c> event without exposing a
+    /// separate "set IsRefreshing manually" API on the slice. Code-behind
+    /// gates <c>SelectionChanged</c> on <see cref="IsRefreshing"/> to
+    /// suppress ghost row drops while the <c>ItemsSource</c> is mutating.
+    /// </para>
+    /// </summary>
+    public void RebuildFlatList(Action? insideRefreshScope = null)
+    {
+        if (IsRefreshing) return;
+        IsRefreshing = true;
+        try
+        {
+            _flatTreeManager.Refresh(RootMembers);
+            insideRefreshScope?.Invoke();
+        }
+        finally
+        {
+            IsRefreshing = false;
+        }
+    }
+
+    /// <summary>
+    /// Toggles expand/collapse for a single node and refreshes the flat
+    /// list so the visible rows reflect the new state.
+    /// </summary>
+    public void ToggleExpand(MemberNodeViewModel node)
+    {
+        _flatTreeManager.ToggleExpand(node, RootMembers);
+    }
+
+    /// <summary>
+    /// Expands <paramref name="node"/> and every descendant, then rebuilds
+    /// the flat list.
+    /// </summary>
+    public void ExpandAllChildren(MemberNodeViewModel node)
+    {
+        FlatTreeManager.ExpandAllChildren(node);
+        RebuildFlatList();
+    }
+
+    /// <summary>
+    /// Collapses <paramref name="node"/> and every descendant, then rebuilds
+    /// the flat list.
+    /// </summary>
+    public void CollapseAllChildren(MemberNodeViewModel node)
+    {
+        FlatTreeManager.CollapseAllChildren(node);
+        RebuildFlatList();
+    }
+
+    private void ExecuteExpandAll()
+    {
+        FlatTreeManager.ExpandAll(RootMembers);
+        RebuildFlatList();
+    }
+
+    private void ExecuteCollapseAll()
+    {
+        FlatTreeManager.CollapseAll(RootMembers);
+        RebuildFlatList();
+    }
+
+    /// <summary>
+    /// O(1) resolve of a <see cref="MemberNode"/> to its tree VM via
+    /// <see cref="ModelToVm"/>. Preferred over <see cref="FindNodeByPath"/>
+    /// when the caller already has the model — same path string in a
+    /// different DB is a different model instance, so this disambiguates
+    /// naturally.
+    /// </summary>
+    public MemberNodeViewModel? FindVmByModel(MemberNode model) =>
+        _modelToVm.TryGetValue(model, out var vm) ? vm : null;
+
+    /// <summary>
+    /// Returns the active DB that owns <paramref name="model"/>, or null
+    /// when the node is not part of the current tree (e.g. a stale model
+    /// from before the last <c>RefreshTree</c>).
+    /// </summary>
+    public ActiveDb? FindActiveDbForModel(MemberNode model) =>
+        _modelToDb.TryGetValue(model, out var db) ? db : null;
+
+    /// <summary>
+    /// Walks <see cref="RootMembers"/> for a node with the given
+    /// <paramref name="path"/>. In multi-DB sessions prefer
+    /// <see cref="FindNodeByPathInDb"/> — bare path lookup can hit any DB
+    /// that happens to share the path string.
+    /// </summary>
+    public MemberNodeViewModel? FindNodeByPath(string path)
+    {
+        foreach (var root in RootMembers)
+        {
+            var found = FindNodeByPathRecursive(root, path);
+            if (found != null) return found;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// DB-scoped variant of <see cref="FindNodeByPath"/>. Callers pass this
+    /// when member Paths can repeat across DBs (the stash holds the bare
+    /// member path, not "DbName.MemberPath") — without scoping, a
+    /// reactivate-additive would replay edits onto whichever DB happened
+    /// to be checked first.
+    ///
+    /// Strict: callers must only invoke this when the active set is in
+    /// multi-DB shape (i.e. after the State cascade has populated
+    /// <see cref="_dbToSynthetic"/> for <paramref name="owner"/>). If the
+    /// synthetic root isn't found, returns null — a future ordering bug
+    /// surfaces as "stashed edit dropped" instead of silently aliasing
+    /// onto another DB. (The diagnostic log call lives on the host;
+    /// the slice intentionally has no <c>Serilog</c> dependency.)
+    /// </summary>
+    public MemberNodeViewModel? FindNodeByPathInDb(string path, ActiveDb owner)
+    {
+        if (!_dbToSynthetic.TryGetValue(owner, out var synthetic))
+            return null;
+        foreach (var child in synthetic.Children)
+        {
+            var found = FindNodeByPathRecursive(child, path);
+            if (found != null) return found;
+        }
+        return null;
+    }
+
+    private static MemberNodeViewModel? FindNodeByPathRecursive(MemberNodeViewModel node, string path)
+    {
+        if (node.Path == path) return node;
+        foreach (var child in node.Children)
+        {
+            var found = FindNodeByPathRecursive(child, path);
+            if (found != null) return found;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

First half of #80 slice 7. Moves the tree-shape + flat-list +
expand/collapse state out of the 4,387-line `BulkChangeViewModel`
into a focused `MemberTreeViewModel`. Selection / scope / manual-
selection state stays on the host for slice **7b**.

### Why a split

The original slice 7 plan listed everything tree-and-selection
related as one ~900-LOC cut. The Explore surface map I ran before
implementation found six cross-cutting methods that read slice-8
(active-set) state, a ~70-line three-branch `UpdateManualSelection`
state machine, and ~50+ external test call sites. Splitting at
the tree-state / selection-state seam keeps each PR reviewable in
one sitting and bounds the blast radius if something regresses.

### What this PR moves

`MemberTreeViewModel` owns:

- `RootMembers` (`ObservableCollection<MemberNodeViewModel>`)
- `FlatMembers` + `IsRefreshing` flag (via internal `FlatTreeManager`)
- `ModelToVm` / `ModelToDb` / `DbToSynthetic` lookup dictionaries
  (public `IReadOnlyDictionary<,>` so host's pending-edit + multi-DB
  filter routing can keep reading them by key)
- `BuildRootMembersFromActiveDbs` — single-DB direct + multi-DB
  synthetic group shape, cross-PLC name-collision prefixing
- `RebuildFlatList(Action? insideRefreshScope)` — the callback runs
  after the flat-list rebuild but *while* `IsRefreshing` is still
  `true`, so the host can restore selection + raise
  `FlatListRefreshed` without re-entering `OnMemberSelected`
- `ToggleExpand` / `ExpandAllChildren` / `CollapseAllChildren`
- `ExpandAllCommand` / `CollapseAllCommand`
- `FindNodeByPath` / `FindNodeByPathInDb` / `FindVmByModel` /
  `FindActiveDbForModel`

### Cut decisions

- **Slice 8 (active-set) state stays on the host.** The tree slice
  reads it via injected `Func<IReadOnlyList<ActiveDb>>` +
  `Func<string> getCurrentPlcName` callbacks. When slice 8 lands
  these reduce to reading one composed VM with no signature change
  on the slice.
- **`SeedVmsFromStore` stays on the host.** Pending-edit replay
  after a tree rebuild needs the pending store + validator, both of
  which are host-owned. The slice fires a `RootsRebuilt` event and
  the host runs the seeding pass in `OnTreeRootsRebuilt`. Slice has
  zero coupling to the pending store.
- **`FindNodeByPathInDb`'s diagnostic warn-log stays on the host.**
  The slice intentionally has no `Serilog` dependency. Host wraps
  the slice call, logs on missing synthetic root, then delegates.
- **`RebuildFlatList` does not raise its own event.** The host's
  `RefreshFlatList` raises `FlatListRefreshed` itself inside the
  slice's `insideRefreshScope` callback, preserving the pre-PR
  ordering: save selection → rebuild flat list → restore selection →
  fire `FlatListRefreshed` (with `IsRefreshing == true` throughout).

### Numbers

- Host VM: **4,387 → 4,211 lines** (−176 net).
- New `MemberTreeViewModel.cs`: 388 lines.
- New `MemberTreeViewModelTests.cs`: 19 focused tests covering
  single vs multi-DB shape, cross-PLC collision prefixing,
  `RootsRebuilt` event, lookup eviction on rebuild, subscribe
  callback per minted VM, `FindVm` / `FindActiveDb` /
  `FindNodeByPath` / `FindNodeByPathInDb` (with cross-DB
  disambiguation), `RebuildFlatList` re-entry guard, `IsRefreshing`
  scope, `ToggleExpand`, `ExpandAll` / `CollapseAll` commands.
- Six existing test files + DevLauncher `CaptureScript` rewired to
  `vm.Tree.RootMembers` / `vm.Tree.FlatMembers`.
- XAML rebinds: `{Binding ExpandAllCommand}` →
  `{Binding Tree.ExpandAllCommand}`, `{Binding CollapseAllCommand}`
  → `{Binding Tree.CollapseAllCommand}`, `{Binding FlatMembers}` →
  `{Binding Tree.FlatMembers}`.
- Code-behind: `vm.IsRefreshing` → `vm.Tree.IsRefreshing`,
  `vm.FlatMembers` → `vm.Tree.FlatMembers`, `vm.ExpandAllChildren` →
  `vm.Tree.ExpandAllChildren`, `vm.CollapseAllChildren` →
  `vm.Tree.CollapseAllChildren`.

### What's coming in 7b

- `_selectedFlatMember` + `SelectedFlatMember`
- `_selectedScope` + `SelectedScope`
- `AvailableScopes`
- `_manualSelectedPaths` + `IsManualMode` + `ManualSelectionCount`
  + `UpdateManualSelection` + `ClearManualSelectionCommand`
- `OnMemberSelected` + scope analysis routing

## Test plan

- [ ] CI `Build & Test (V20, net48)` green — includes 19 new
      `MemberTreeViewModelTests`
- [ ] CI `Build (V21, net48)` green
- [ ] Existing host VM tests (regression / invariant / multi-DB /
      db-switcher) still pass with new `vm.Tree.*` binding paths
- [ ] Manual smoke (not blocking): open dialog in TIA Portal V20,
      switch DBs, exercise expand-all / collapse-all, multi-select,
      Apply — verifies the tree rebuild + selection restore seam
      still behaves under the cascade

Refs #80.

https://claude.ai/code/session_0168J7dK7tApviBaDquX6gUd

---
_Generated by [Claude Code](https://claude.ai/code/session_0168J7dK7tApviBaDquX6gUd)_