### PR TITLE
refactor(#80): extract SelectionScopeViewModel slice (slice 7b)

### DIFF
--- a/src/BlockParam.DevLauncher/CaptureScript.cs
+++ b/src/BlockParam.DevLauncher/CaptureScript.cs
@@ -305,23 +305,23 @@ public static class SceneApplier
                 // SelectedFlatMember requires the node to be in the flat list;
                 // RefreshFlatList above guarantees that.
                 var flat = vm.Tree.FlatMembers.FirstOrDefault(m => m.Path == node.Path);
-                vm.SelectedFlatMember = flat ?? node;
+                vm.Selection.SelectedFlatMember = flat ?? node;
             }
         }
 
         if (scene.Scope != null)
         {
-            var scope = vm.AvailableScopes.FirstOrDefault(s => s.AncestorPath == scene.Scope);
+            var scope = vm.Selection.AvailableScopes.FirstOrDefault(s => s.AncestorPath == scene.Scope);
             if (scope == null)
             {
                 Serilog.Log.Warning(
                     "Scene {Id}: scope path not found: '{Path}'. Available: {Avail}",
                     scene.Id, scene.Scope,
-                    string.Join(", ", vm.AvailableScopes.Select(s => $"'{s.AncestorPath}'")));
+                    string.Join(", ", vm.Selection.AvailableScopes.Select(s => $"'{s.AncestorPath}'")));
             }
             else
             {
-                vm.SelectedScope = scope;
+                vm.Selection.SelectedScope = scope;
             }
         }
 
@@ -511,8 +511,8 @@ public static class SceneApplier
         vm.Inspector.IsInspectorCollapsed = false;
         foreach (var root in vm.Tree.RootMembers)
             CollapseRecursive(root);
-        vm.SelectedFlatMember = null;
-        vm.SelectedScope = null;
+        vm.Selection.SelectedFlatMember = null;
+        vm.Selection.SelectedScope = null;
         vm.Filter.SearchQuery = "";
         // Reset NewValue without tripping the user-touched flag so the next
         // scene's member selection can still drive the normal prefill path.

--- a/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
@@ -581,7 +581,7 @@ public class BulkChangeViewModelInvariantTests
         env.Vm.AllActiveDbs[0].Info.Name.Should().Be("NestedStructDB");
         env.Vm.Selection.ManualSelectedPaths.Should().BeEmpty(
             "removing the anchor must drop its manually-selected leaves " +
-            "(RebuildAfterActiveSetChanged line 1449 _manualSelectedPaths.Clear)");
+            "(RebuildAfterActiveSetChanged calls Selection.ClearManualPaths)");
         env.Vm.Selection.IsManualMode.Should().BeFalse("0 manual paths → not in manual mode");
 
         // Now the second half: select 2 leaves in the survivor (now flat tree).

--- a/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
@@ -571,18 +571,18 @@ public class BulkChangeViewModelInvariantTests
             added: anchorLeaves,
             removed: System.Array.Empty<MemberNodeViewModel>(),
             isFilterRehydration: false);
-        env.Vm.IsManualMode.Should().BeTrue("setup: 2 leaves selected → manual mode");
-        env.Vm.ManualSelectionCount.Should().Be(2);
+        env.Vm.Selection.IsManualMode.Should().BeTrue("setup: 2 leaves selected → manual mode");
+        env.Vm.Selection.ManualSelectionCount.Should().Be(2);
 
         var anchorDbManual = env.Vm.AllActiveDbs.First(d => d.Info.Name == "FlatDB");
         env.Vm.RequestRemoveActiveDb(anchorDbManual);
 
         env.Vm.AllActiveDbs.Should().HaveCount(1);
         env.Vm.AllActiveDbs[0].Info.Name.Should().Be("NestedStructDB");
-        env.Vm.ManualSelectedPaths.Should().BeEmpty(
+        env.Vm.Selection.ManualSelectedPaths.Should().BeEmpty(
             "removing the anchor must drop its manually-selected leaves " +
             "(RebuildAfterActiveSetChanged line 1449 _manualSelectedPaths.Clear)");
-        env.Vm.IsManualMode.Should().BeFalse("0 manual paths → not in manual mode");
+        env.Vm.Selection.IsManualMode.Should().BeFalse("0 manual paths → not in manual mode");
 
         // Now the second half: select 2 leaves in the survivor (now flat tree).
         var peerLeaves = env.Vm.Tree.RootMembers
@@ -596,10 +596,10 @@ public class BulkChangeViewModelInvariantTests
             removed: System.Array.Empty<MemberNodeViewModel>(),
             isFilterRehydration: false);
 
-        env.Vm.IsManualMode.Should().BeTrue("now 2 leaves selected in B");
-        env.Vm.ManualSelectionCount.Should().Be(2,
+        env.Vm.Selection.IsManualMode.Should().BeTrue("now 2 leaves selected in B");
+        env.Vm.Selection.ManualSelectionCount.Should().Be(2,
             "B's count is 2, not 4 — A's old selections did not bleed back in");
-        env.Vm.ManualSelectedPaths.Should().BeEquivalentTo(peerLeaves,
+        env.Vm.Selection.ManualSelectedPaths.Should().BeEquivalentTo(peerLeaves,
             "ManualSelectedPaths holds B's nodes only — none of A's nodes survived");
         env.Mbx.AskYesNoCancelCallCount.Should().Be(0, "no pending edits → no prompt");
         AssertInvariants(env.Vm);
@@ -860,7 +860,7 @@ public class BulkChangeViewModelInvariantTests
         // selection's preview lingered after the 3-way Cancel cleared the
         // selection. ComputeBulkPreview's hasInput check enforces this; if
         // a transition path forgets to call it, the stale rows survive.
-        if (!vm.HasScope && !vm.IsManualMode)
+        if (!vm.Selection.HasScope && !vm.Selection.IsManualMode)
         {
             vm.BulkPreview.Entries.Should().BeEmpty(
                 "invariant 7: BulkPreview must be empty when no scope is " +
@@ -877,7 +877,7 @@ public class BulkChangeViewModelInvariantTests
             .ToList();
         orphanedPreview.Should().BeEmpty(
             "invariant 8a: BulkPreview drops nodes whose DB left the active set");
-        var orphanedManual = vm.ManualSelectedPaths
+        var orphanedManual = vm.Selection.ManualSelectedPaths
             .Where(n => !reachableNodes.Contains(n))
             .Select(n => n.Path)
             .ToList();
@@ -896,7 +896,7 @@ public class BulkChangeViewModelInvariantTests
         // reports NewValue=="", the bug is downstream (XAML binding /
         // dialog code-behind), not VM state — needs a manual / WPF-level
         // walkthrough to catch.
-        if (!vm.HasSelection && !vm.IsManualMode)
+        if (!vm.Selection.HasSelection && !vm.Selection.IsManualMode)
         {
             vm.NewValue.Should().BeEmpty(
                 "invariant 9: NewValue must be empty when nothing is " +

--- a/src/BlockParam.Tests/BulkChangeViewModelMultiDbTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelMultiDbTests.cs
@@ -440,9 +440,9 @@ public class BulkChangeViewModelMultiDbTests
             removed: System.Array.Empty<MemberNodeViewModel>(),
             isFilterRehydration: false);
 
-        vm.ManualSelectedPaths.Should().Contain(focusedLeaf,
+        vm.Selection.ManualSelectedPaths.Should().Contain(focusedLeaf,
             "focused-DB selection routes to its own VM reference");
-        vm.ManualSelectedPaths.Should().Contain(peerLeaf,
+        vm.Selection.ManualSelectedPaths.Should().Contain(peerLeaf,
             "peer-DB selection is a distinct entry, not aliased on path");
     }
 

--- a/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
@@ -320,11 +320,11 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         vm.RefreshFlatList();
 
         var leaf = vm.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
-        vm.SelectedFlatMember = leaf;
+        vm.Selection.SelectedFlatMember = leaf;
 
         // Pick the broadest scope (all 4 ModuleId instances)
-        var scope = vm.AvailableScopes.OrderByDescending(s => s.MatchCount).First();
-        vm.SelectedScope = scope;
+        var scope = vm.Selection.AvailableScopes.OrderByDescending(s => s.MatchCount).First();
+        vm.Selection.SelectedScope = scope;
 
         // NewValue is empty — no input → no preview
         vm.NewValue = "";
@@ -350,11 +350,11 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         vm.RefreshFlatList();
 
         var leaf = vm.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
-        vm.SelectedFlatMember = leaf;
+        vm.Selection.SelectedFlatMember = leaf;
 
-        var scope = vm.AvailableScopes.OrderByDescending(s => s.MatchCount).First();
+        var scope = vm.Selection.AvailableScopes.OrderByDescending(s => s.MatchCount).First();
         scope.MatchCount.Should().Be(4, "fixture has 4 ModuleId leaves");
-        vm.SelectedScope = scope;
+        vm.Selection.SelectedScope = scope;
 
         // All 4 already hold "42" — none would change
         vm.NewValue = "42";
@@ -396,9 +396,9 @@ public class BulkChangeViewModelRegressionTests : IDisposable
 
         // Now set up bulk scope
         var leaf = moduleLeaves[1]; // pick a different leaf so SelectedFlatMember isn't the pending one
-        vm.SelectedFlatMember = moduleLeaves[0]; // need to select one to populate scopes
-        var scope = vm.AvailableScopes.OrderByDescending(s => s.MatchCount).First();
-        vm.SelectedScope = scope;
+        vm.Selection.SelectedFlatMember = moduleLeaves[0]; // need to select one to populate scopes
+        var scope = vm.Selection.AvailableScopes.OrderByDescending(s => s.MatchCount).First();
+        vm.Selection.SelectedScope = scope;
 
         vm.NewValue = "99";
         vm.FlushPendingHighlighting();
@@ -425,9 +425,9 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
         vm.RefreshFlatList();
 
-        vm.SelectedFlatMember = vm.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
-        var scope = vm.AvailableScopes.OrderByDescending(s => s.MatchCount).First();
-        vm.SelectedScope = scope;
+        vm.Selection.SelectedFlatMember = vm.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
+        var scope = vm.Selection.AvailableScopes.OrderByDescending(s => s.MatchCount).First();
+        vm.Selection.SelectedScope = scope;
 
         // Homogeneous: all ModuleId start at "42"
         vm.NewValue = "85";
@@ -463,7 +463,7 @@ public class BulkChangeViewModelRegressionTests : IDisposable
             added: new[] { speed, enable },
             removed: System.Array.Empty<MemberNodeViewModel>(),
             isFilterRehydration: false);
-        vm2.IsManualMode.Should().BeTrue();
+        vm2.Selection.IsManualMode.Should().BeTrue();
 
         vm2.NewValue = "ON";
         vm2.FlushPendingHighlighting();
@@ -500,10 +500,10 @@ public class BulkChangeViewModelRegressionTests : IDisposable
             removed: System.Array.Empty<MemberNodeViewModel>(),
             isFilterRehydration: false);
 
-        vm.IsManualMode.Should().BeTrue("2 leaves selected → manual mode");
-        vm.ManualSelectionCount.Should().Be(2);
-        vm.SelectedScope.Should().BeNull("manual mode clears the scope dropdown");
-        vm.AvailableScopes.Should().BeEmpty("manual mode clears available scopes");
+        vm.Selection.IsManualMode.Should().BeTrue("2 leaves selected → manual mode");
+        vm.Selection.ManualSelectionCount.Should().Be(2);
+        vm.Selection.SelectedScope.Should().BeNull("manual mode clears the scope dropdown");
+        vm.Selection.AvailableScopes.Should().BeEmpty("manual mode clears available scopes");
     }
 
     /// <summary>
@@ -549,7 +549,7 @@ public class BulkChangeViewModelRegressionTests : IDisposable
             removed: System.Array.Empty<MemberNodeViewModel>(),
             isFilterRehydration: false);
 
-        vm2.IsManualMode.Should().BeTrue();
+        vm2.Selection.IsManualMode.Should().BeTrue();
         vm2.IsSelectionTypeHomogeneous.Should().BeTrue(
             "2 Int leaves → all same datatype → homogeneous");
 
@@ -564,13 +564,13 @@ public class BulkChangeViewModelRegressionTests : IDisposable
 
         vm2.IsSelectionTypeHomogeneous.Should().BeFalse(
             "Int + Bool → mixed datatypes → not homogeneous");
-        vm2.ManualSelectionSummary.Should().Contain("2",
+        vm2.Selection.ManualSelectionSummary.Should().Contain("2",
             "ManualSelectionSummary (Dialog_ManualSelectionMixed) must contain the distinct datatype count (2)");
         // Dialog_ManualSelectionMixed = "{0} selected — {1} datatypes" (en) / "{0} ausgewählt — {1} Datentypen" (de)
         // SPEC AMBIGUITY: The exact phrase "datatypes" vs "Datentypen" depends on the OS culture.
         // We assert the format key is used by checking the count "2" appears (which is culture-neutral)
         // and that ManualSelectionSummary is distinct from the homogeneous format (which contains a datatype name).
-        vm2.ManualSelectionSummary.Should().NotContain("Int",
+        vm2.Selection.ManualSelectionSummary.Should().NotContain("Int",
             "ManualSelectionSummary in mixed mode must use Dialog_ManualSelectionMixed, " +
             "not Dialog_ManualSelectionSummary which names the single datatype");
 
@@ -595,13 +595,13 @@ public class BulkChangeViewModelRegressionTests : IDisposable
             removed: System.Array.Empty<MemberNodeViewModel>(),
             isFilterRehydration: false);
 
-        vm.IsManualMode.Should().BeTrue("setup: manual mode");
+        vm.Selection.IsManualMode.Should().BeTrue("setup: manual mode");
         vm.NewValue = "ON";
 
         vm.ClearManualSelectionCommand.Execute(null);
 
-        vm.ManualSelectionCount.Should().Be(0, "Clear wipes all selected leaves");
-        vm.IsManualMode.Should().BeFalse("0 selected → not in manual mode");
+        vm.Selection.ManualSelectionCount.Should().Be(0, "Clear wipes all selected leaves");
+        vm.Selection.IsManualMode.Should().BeFalse("0 selected → not in manual mode");
         vm.NewValue.Should().BeEmpty("Clear resets NewValue to empty");
     }
 
@@ -720,7 +720,7 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
         vm.RefreshFlatList();
         var leaf = vm.Tree.FlatMembers.First(m => m.IsLeaf);
-        vm.SelectedFlatMember = leaf;
+        vm.Selection.SelectedFlatMember = leaf;
 
         // Confirm starting state: ShowConstants=false → Suggestions empty
         vm.ShowConstants.Should().BeFalse("no rule forces ShowConstants on");
@@ -775,7 +775,7 @@ public class BulkChangeViewModelRegressionTests : IDisposable
 
         FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
         vm.RefreshFlatList();
-        vm.SelectedFlatMember = vm.Tree.FlatMembers.First(m => m.IsLeaf);
+        vm.Selection.SelectedFlatMember = vm.Tree.FlatMembers.First(m => m.IsLeaf);
 
         // Force ShowConstants on to populate _suggestions
         vm.ShowConstants = true;
@@ -854,9 +854,9 @@ public class BulkChangeViewModelRegressionTests : IDisposable
 
         // Select a ModuleId leaf (child of Msg_CommError) and pick the broadest scope
         var leaf = vm.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
-        vm.SelectedFlatMember = leaf;
-        vm.AvailableScopes.Should().NotBeEmpty("ModuleId has repeated occurrences → scope available");
-        vm.SelectedScope = vm.AvailableScopes.OrderByDescending(s => s.MatchCount).First();
+        vm.Selection.SelectedFlatMember = leaf;
+        vm.Selection.AvailableScopes.Should().NotBeEmpty("ModuleId has repeated occurrences → scope available");
+        vm.Selection.SelectedScope = vm.Selection.AvailableScopes.OrderByDescending(s => s.MatchCount).First();
 
         vm.NewValue = "99"; // a different value triggers ComputeBulkPreview
         vm.FlushPendingHighlighting(); // runs UpdateHighlighting → UpdateCommentPreviews
@@ -876,10 +876,10 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         var vm2 = CreateUdtVm(); // no rules
         FlatTreeManager.ExpandAll(vm2.Tree.RootMembers);
         vm2.RefreshFlatList();
-        vm2.SelectedFlatMember = vm2.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
-        if (vm2.AvailableScopes.Count > 0)
+        vm2.Selection.SelectedFlatMember = vm2.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
+        if (vm2.Selection.AvailableScopes.Count > 0)
         {
-            vm2.SelectedScope = vm2.AvailableScopes.First();
+            vm2.Selection.SelectedScope = vm2.Selection.AvailableScopes.First();
             vm2.NewValue = "99";
             vm2.FlushPendingHighlighting();
         }
@@ -937,8 +937,8 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         // test 14. The scope cascade populates PreviewComment on the
         // Msg_CommError parents.
         var leaf = vm.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
-        vm.SelectedFlatMember = leaf;
-        vm.SelectedScope = vm.AvailableScopes.OrderByDescending(s => s.MatchCount).First();
+        vm.Selection.SelectedFlatMember = leaf;
+        vm.Selection.SelectedScope = vm.Selection.AvailableScopes.OrderByDescending(s => s.MatchCount).First();
         vm.NewValue = "99";
         vm.FlushPendingHighlighting();
 

--- a/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
@@ -550,7 +550,7 @@ public class BulkChangeViewModelRegressionTests : IDisposable
             isFilterRehydration: false);
 
         vm2.Selection.IsManualMode.Should().BeTrue();
-        vm2.IsSelectionTypeHomogeneous.Should().BeTrue(
+        vm2.Selection.IsSelectionTypeHomogeneous.Should().BeTrue(
             "2 Int leaves → all same datatype → homogeneous");
 
         // Add a Bool leaf — breaks homogeneity
@@ -562,7 +562,7 @@ public class BulkChangeViewModelRegressionTests : IDisposable
             removed: System.Array.Empty<MemberNodeViewModel>(),
             isFilterRehydration: false);
 
-        vm2.IsSelectionTypeHomogeneous.Should().BeFalse(
+        vm2.Selection.IsSelectionTypeHomogeneous.Should().BeFalse(
             "Int + Bool → mixed datatypes → not homogeneous");
         vm2.Selection.ManualSelectionSummary.Should().Contain("2",
             "ManualSelectionSummary (Dialog_ManualSelectionMixed) must contain the distinct datatype count (2)");

--- a/src/BlockParam.Tests/BulkChangeViewModelTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelTests.cs
@@ -167,10 +167,10 @@ public class BulkChangeViewModelTests : IDisposable
 
         // Fixture has 4 ModuleId leaves, all already at "42".
         var moduleId = vm.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
-        vm.SelectedFlatMember = moduleId;
+        vm.Selection.SelectedFlatMember = moduleId;
 
-        var dbScope = vm.AvailableScopes.First(s => s.MatchCount == 4);
-        vm.SelectedScope = dbScope;
+        var dbScope = vm.Selection.AvailableScopes.First(s => s.MatchCount == 4);
+        vm.Selection.SelectedScope = dbScope;
 
         vm.NewValue = "42"; // matches every selected member — 0 would change
         vm.SetButtonText.Should().Be("Set 0 in 'UdtInstancesDB'",
@@ -202,7 +202,7 @@ public class BulkChangeViewModelTests : IDisposable
         var picks = moduleIds.Concat(new[] { messageId }).ToList();
 
         vm.UpdateManualSelection(picks, Array.Empty<MemberNodeViewModel>(), false);
-        vm.IsManualMode.Should().BeTrue();
+        vm.Selection.IsManualMode.Should().BeTrue();
 
         // Type "42": three ModuleIds already match, the MessageId ("101") doesn't.
         // Only 1 member would actually change.

--- a/src/BlockParam.Tests/SelectionScopeViewModelTests.cs
+++ b/src/BlockParam.Tests/SelectionScopeViewModelTests.cs
@@ -301,11 +301,13 @@ public class SelectionScopeViewModelTests
     [Fact]
     public void OnNodeSelected_ReEntry_IsSilentlyIgnored()
     {
-        // Re-entrancy guard: when OnNodeSelected sets a peer node's
-        // IsSelected = false, that node's SelectedChanged event fires
-        // and the host's wiring (`SelectedChanged += Selection.OnNodeSelected`)
-        // would re-route back into OnNodeSelected. The _inSelectionCascade
-        // flag prevents the recursive body from running on the inner call.
+        // Re-entrancy guard: a recursive call to OnNodeSelected mid-cascade
+        // must short-circuit instead of repeating the deselection walk.
+        //
+        // (Production wiring only fires `MemberNodeViewModel.SelectedChanged`
+        // on false→true transitions, so the cascade's `IsSelected = false`
+        // writes don't naturally re-route into OnNodeSelected. We simulate
+        // the re-entry directly to verify the guard.)
         var (vm, tree, _) = BuildWithMultiDb();
         var leafA = tree.RootMembers[0].AllDescendants().First(n => n.IsLeaf);
         var leafB = tree.RootMembers[1].AllDescendants().First(n => n.IsLeaf);
@@ -313,29 +315,26 @@ public class SelectionScopeViewModelTests
         leafA.IsSelected = true;
         leafB.IsSelected = true;
 
-        int innerCallsBlockedByGuard = 0;
-        // When leafA's IsSelected flips to false during the outer cascade,
-        // its SelectedChanged event fires. Simulate the host's wiring by
-        // routing back into OnNodeSelected from the handler.
-        leafA.SelectedChanged += node =>
-        {
-            // The guard inside vm.OnNodeSelected should short-circuit on
-            // re-entry. Count how often it was reached at all.
-            innerCallsBlockedByGuard++;
-            vm.OnNodeSelected(node);
-        };
-
-        // Outer call deselects leafA, which fires the recursive handler.
-        // Without the guard this would either stack-overflow or wipe leafB.
+        // Outer cascade for leafB also calls OnNodeSelected with a different
+        // node from within. The guard must prevent the inner call from
+        // touching state again.
         vm.OnNodeSelected(leafB);
 
-        leafA.IsSelected.Should().BeFalse("outer cascade must still complete");
+        // Verify the cascade itself worked even with the re-entry-ready setup.
+        leafA.IsSelected.Should().BeFalse(
+            "outer cascade deselected leafA — the guard didn't block the first walk");
         leafB.IsSelected.Should().BeTrue(
-            "leafB is the justSelected node — must not be touched by the cascade " +
-            "(neither outer nor any recursive re-entry that the guard short-circuited)");
-        innerCallsBlockedByGuard.Should().Be(1,
-            "the handler fired exactly once when leafA was deselected; the guard " +
-            "stopped that re-entry from looping further");
+            "leafB is the justSelected node — never touched by the cascade");
+
+        // Now force a re-entrant call after the first cascade completes.
+        // The flag is back to false here, so this is just a second outer
+        // cascade — confirms `_inSelectionCascade` resets in the finally block.
+        leafB.IsSelected = false; // setup: nothing selected
+        leafA.IsSelected = true;
+        var act = () => vm.OnNodeSelected(leafA);
+        act.Should().NotThrow(
+            "_inSelectionCascade must be reset by the finally block after the " +
+            "first cascade — a second outer call must not see a stale `true` flag");
     }
 
     // ─────────────────────────────────────────────────────────────────────

--- a/src/BlockParam.Tests/SelectionScopeViewModelTests.cs
+++ b/src/BlockParam.Tests/SelectionScopeViewModelTests.cs
@@ -141,6 +141,63 @@ public class SelectionScopeViewModelTests
         changedProps.Should().Contain(nameof(SelectionScopeViewModel.CanEdit));
     }
 
+    /// <summary>
+    /// SetSelectedScopeSilent uses SetProperty&lt;T&gt; which short-circuits when
+    /// the value is unchanged. Pre-PR the host raised PropertyChanged for
+    /// SelectedScope / HasScope / CanEdit unconditionally — this test locks
+    /// the new contract: a null→null silent set must raise NOTHING. If you
+    /// ever decide to revert to the unconditional pattern, flip this test's
+    /// expectations rather than letting it silently drift.
+    /// </summary>
+    [Fact]
+    public void SetSelectedScopeSilent_NullOnNull_IsCompletelyQuiet()
+    {
+        var (vm, _, _) = Build();
+        vm.SelectedScope.Should().BeNull("setup: starts null");
+
+        var scopeChangedFires = 0;
+        var changedProps = new List<string?>();
+        vm.ScopeChanged += () => scopeChangedFires++;
+        vm.PropertyChanged += (_, e) => changedProps.Add(e.PropertyName);
+
+        vm.SetSelectedScopeSilent(null);
+
+        scopeChangedFires.Should().Be(0);
+        changedProps.Should().BeEmpty(
+            "null→null is a no-op — SetProperty short-circuits on equality. " +
+            "If we ever decide bindings need an explicit nudge here, the " +
+            "fix is in the slice, not in callers paying twice for nothing.");
+    }
+
+    /// <summary>
+    /// <see cref="SelectedFlatMember"/> short-circuits while
+    /// <see cref="MemberTreeViewModel.IsRefreshing"/> is true — verified by
+    /// <see cref="SelectedFlatMember_SetterSuppressed_WhenTreeIsRefreshing"/>.
+    /// <see cref="SelectedScope"/> does NOT have the same guard. That's
+    /// intentional: <c>RefreshTree</c> assigns <c>SelectedScope</c> while
+    /// inside the flat-list rebuild scope (to restore the user's prior
+    /// scope after Apply), and gating it would silently drop the restore.
+    /// Negative test so an "unhelpful symmetry" fix doesn't ship.
+    /// </summary>
+    [Fact]
+    public void SelectedScope_Setter_NotGated_OnTreeIsRefreshing()
+    {
+        var (vm, tree, _) = BuildWithSingleDb();
+        var scope = new ScopeLevel("root", "Root", 1, Array.Empty<MemberNode>());
+        vm.AvailableScopes.Add(scope);
+
+        ScopeLevel? scopeInsideRefresh = null;
+        tree.RebuildFlatList(insideRefreshScope: () =>
+        {
+            vm.SelectedScope = scope;
+            scopeInsideRefresh = vm.SelectedScope;
+        });
+
+        scopeInsideRefresh.Should().BeSameAs(scope,
+            "assigning SelectedScope while Tree.IsRefreshing is true must take effect — " +
+            "RefreshTree depends on this for selection-restore");
+    }
+
     [Fact]
     public void HasScope_FalseWhenInManualMode_EvenIfSelectedScopeNonNull()
     {
@@ -301,13 +358,13 @@ public class SelectionScopeViewModelTests
     [Fact]
     public void OnNodeSelected_ReEntry_IsSilentlyIgnored()
     {
-        // Re-entrancy guard: a recursive call to OnNodeSelected mid-cascade
-        // must short-circuit instead of repeating the deselection walk.
-        //
-        // (Production wiring only fires `MemberNodeViewModel.SelectedChanged`
-        // on false→true transitions, so the cascade's `IsSelected = false`
-        // writes don't naturally re-route into OnNodeSelected. We simulate
-        // the re-entry directly to verify the guard.)
+        // Re-entrancy guard: while the cascade is walking the tree and
+        // deselecting peers, those nodes' PropertyChanged event fires
+        // (true→false transitions on IsSelected raise PropertyChanged via
+        // SetProperty, even though SelectedChanged stays gated to true→true).
+        // If a host wiring routes from PropertyChanged back into
+        // OnNodeSelected, the _inSelectionCascade flag must short-circuit
+        // the inner call.
         var (vm, tree, _) = BuildWithMultiDb();
         var leafA = tree.RootMembers[0].AllDescendants().First(n => n.IsLeaf);
         var leafB = tree.RootMembers[1].AllDescendants().First(n => n.IsLeaf);
@@ -315,26 +372,37 @@ public class SelectionScopeViewModelTests
         leafA.IsSelected = true;
         leafB.IsSelected = true;
 
-        // Outer cascade for leafB also calls OnNodeSelected with a different
-        // node from within. The guard must prevent the inner call from
-        // touching state again.
+        // Simulate a re-entry route: when leafA's IsSelected flips during
+        // the cascade, a listener calls OnNodeSelected again. The inner
+        // call must hit the guard and return immediately. The outer cascade
+        // must still complete and leafB must remain selected.
+        int reentrantCalls = 0;
+        bool reentrantSawCascadeFlag = false;
+        leafA.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName != nameof(MemberNodeViewModel.IsSelected)) return;
+            // Capture observable state *before* re-entering — the inner call
+            // must short-circuit on the cascade flag.
+            reentrantCalls++;
+            int leafBStateBefore = leafB.IsSelected ? 1 : 0;
+            vm.OnNodeSelected(leafA);
+            // If the guard didn't fire, the inner cascade would have walked
+            // the tree and deselected leafB. Capture the result.
+            reentrantSawCascadeFlag = leafB.IsSelected == (leafBStateBefore == 1);
+        };
+
         vm.OnNodeSelected(leafB);
 
-        // Verify the cascade itself worked even with the re-entry-ready setup.
-        leafA.IsSelected.Should().BeFalse(
-            "outer cascade deselected leafA — the guard didn't block the first walk");
+        leafA.IsSelected.Should().BeFalse("outer cascade deselected leafA");
         leafB.IsSelected.Should().BeTrue(
-            "leafB is the justSelected node — never touched by the cascade");
-
-        // Now force a re-entrant call after the first cascade completes.
-        // The flag is back to false here, so this is just a second outer
-        // cascade — confirms `_inSelectionCascade` resets in the finally block.
-        leafB.IsSelected = false; // setup: nothing selected
-        leafA.IsSelected = true;
-        var act = () => vm.OnNodeSelected(leafA);
-        act.Should().NotThrow(
-            "_inSelectionCascade must be reset by the finally block after the " +
-            "first cascade — a second outer call must not see a stale `true` flag");
+            "leafB is the outer call's justSelected — the guard prevented the " +
+            "inner re-entrant call from clearing it as a side effect");
+        reentrantCalls.Should().BeGreaterThan(0,
+            "PropertyChanged fires on true→false IsSelected transitions, so the " +
+            "re-entry path was actually exercised");
+        reentrantSawCascadeFlag.Should().BeTrue(
+            "the inner call must short-circuit on _inSelectionCascade==true " +
+            "(otherwise it would have walked the tree and deselected leafB)");
     }
 
     // ─────────────────────────────────────────────────────────────────────

--- a/src/BlockParam.Tests/SelectionScopeViewModelTests.cs
+++ b/src/BlockParam.Tests/SelectionScopeViewModelTests.cs
@@ -1,0 +1,379 @@
+using System.Collections.Generic;
+using System.Linq;
+using BlockParam.Models;
+using BlockParam.Services;
+using BlockParam.UI;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Focused tests for the selection + scope + manual-selection slice
+/// (#80 slice 7b).
+/// </summary>
+public class SelectionScopeViewModelTests
+{
+    [Fact]
+    public void Defaults_EmptySelectionAndScope()
+    {
+        var (vm, _, _) = Build();
+
+        vm.SelectedFlatMember.Should().BeNull();
+        vm.SelectedScope.Should().BeNull();
+        vm.AvailableScopes.Should().BeEmpty();
+        vm.ManualSelectedPaths.Should().BeEmpty();
+        vm.IsManualMode.Should().BeFalse();
+        vm.ManualSelectionCount.Should().Be(0);
+        vm.HasSelection.Should().BeFalse();
+        vm.HasScope.Should().BeFalse();
+        vm.CanEdit.Should().BeFalse();
+        vm.IsSelectionTypeHomogeneous.Should().BeTrue();
+        vm.ManualSelectionSummary.Should().BeEmpty();
+        vm.SelectedMemberDisplay.Should().NotBeNullOrEmpty(
+            "should show the localized 'click to select' placeholder when nothing is selected");
+    }
+
+    [Fact]
+    public void SelectedFlatMember_Setter_RaisesPropertyChangedAndMemberChangedEvent()
+    {
+        var (vm, tree, _) = BuildWithSingleDb();
+        var leafVm = tree.RootMembers.First(r => r.IsLeaf);
+
+        var memberChangedFires = new List<MemberNodeViewModel?>();
+        var changedProps = new List<string?>();
+        vm.MemberChanged += v => memberChangedFires.Add(v);
+        vm.PropertyChanged += (_, e) => changedProps.Add(e.PropertyName);
+
+        vm.SelectedFlatMember = leafVm;
+
+        memberChangedFires.Should().ContainSingle().Which.Should().BeSameAs(leafVm,
+            "the slice fires MemberChanged so the host can run OnMemberSelected");
+        changedProps.Should().Contain(nameof(SelectionScopeViewModel.SelectedFlatMember));
+        changedProps.Should().Contain(nameof(SelectionScopeViewModel.HasSelection));
+        changedProps.Should().Contain(nameof(SelectionScopeViewModel.SelectedMemberDisplay));
+    }
+
+    [Fact]
+    public void SelectedFlatMember_SetterSuppressed_WhenTreeIsRefreshing()
+    {
+        var (vm, tree, _) = BuildWithSingleDb();
+        var leafVm = tree.RootMembers.First(r => r.IsLeaf);
+
+        // Drive Tree into refreshing state and assign during the scope.
+        bool setterRanDuringRefresh = false;
+        tree.RebuildFlatList(insideRefreshScope: () =>
+        {
+            // Tree.IsRefreshing == true here. SelectedFlatMember setter
+            // must short-circuit (existing OnMemberSelected pipeline must
+            // not run on a half-refreshed flat list).
+            vm.SelectedFlatMember = leafVm;
+            setterRanDuringRefresh = true;
+        });
+
+        setterRanDuringRefresh.Should().BeTrue();
+        vm.SelectedFlatMember.Should().BeNull(
+            "the setter must be a no-op while Tree.IsRefreshing is true to avoid " +
+            "racing the flat-list rebuild");
+    }
+
+    [Fact]
+    public void SetSelectedFlatMemberSilent_RaisesPropertyChangedButNotMemberChanged()
+    {
+        var (vm, tree, _) = BuildWithSingleDb();
+        var leafVm = tree.RootMembers.First(r => r.IsLeaf);
+
+        var memberChangedFires = 0;
+        var changedProps = new List<string?>();
+        vm.MemberChanged += _ => memberChangedFires++;
+        vm.PropertyChanged += (_, e) => changedProps.Add(e.PropertyName);
+
+        vm.SetSelectedFlatMemberSilent(leafVm);
+
+        memberChangedFires.Should().Be(0,
+            "silent setter suppresses MemberChanged — host's RefreshTree / dispatcher " +
+            "re-sync paths already handled the side effects");
+        vm.SelectedFlatMember.Should().BeSameAs(leafVm);
+        changedProps.Should().Contain(nameof(SelectionScopeViewModel.SelectedFlatMember));
+        changedProps.Should().Contain(nameof(SelectionScopeViewModel.HasSelection));
+        changedProps.Should().Contain(nameof(SelectionScopeViewModel.SelectedMemberDisplay));
+    }
+
+    [Fact]
+    public void SelectedScope_Setter_RaisesPropertyChangedAndScopeChangedEvent()
+    {
+        var (vm, _, _) = Build();
+        var scope = new ScopeLevel("root", "Root", 1, Array.Empty<MemberNode>());
+        vm.AvailableScopes.Add(scope);
+
+        var scopeChangedFires = 0;
+        var changedProps = new List<string?>();
+        vm.ScopeChanged += () => scopeChangedFires++;
+        vm.PropertyChanged += (_, e) => changedProps.Add(e.PropertyName);
+
+        vm.SelectedScope = scope;
+
+        scopeChangedFires.Should().Be(1);
+        changedProps.Should().Contain(nameof(SelectionScopeViewModel.SelectedScope));
+        changedProps.Should().Contain(nameof(SelectionScopeViewModel.HasScope));
+        changedProps.Should().Contain(nameof(SelectionScopeViewModel.CanEdit));
+    }
+
+    [Fact]
+    public void SetSelectedScopeSilent_RaisesPropertyChangedButNotScopeChanged()
+    {
+        var (vm, _, _) = Build();
+        var scope = new ScopeLevel("root", "Root", 1, Array.Empty<MemberNode>());
+
+        var scopeChangedFires = 0;
+        var changedProps = new List<string?>();
+        vm.ScopeChanged += () => scopeChangedFires++;
+        vm.PropertyChanged += (_, e) => changedProps.Add(e.PropertyName);
+
+        vm.SetSelectedScopeSilent(scope);
+
+        scopeChangedFires.Should().Be(0,
+            "silent setter suppresses ScopeChanged so callers that re-fire " +
+            "UpdateHighlighting themselves don't double-run it");
+        vm.SelectedScope.Should().BeSameAs(scope);
+        changedProps.Should().Contain(nameof(SelectionScopeViewModel.SelectedScope));
+        changedProps.Should().Contain(nameof(SelectionScopeViewModel.HasScope));
+        changedProps.Should().Contain(nameof(SelectionScopeViewModel.CanEdit));
+    }
+
+    [Fact]
+    public void HasScope_FalseWhenInManualMode_EvenIfSelectedScopeNonNull()
+    {
+        var (vm, tree, _) = BuildWithSingleDb();
+        var leaves = tree.RootMembers.Where(r => r.IsLeaf).Take(2).ToList();
+        var scope = new ScopeLevel("root", "Root", 1, Array.Empty<MemberNode>());
+        vm.AvailableScopes.Add(scope);
+        vm.SetSelectedScopeSilent(scope);
+
+        vm.HasScope.Should().BeTrue("scope is set and we're not in manual mode yet");
+
+        // Enter manual mode (2 leaves).
+        vm.AddManualPath(leaves[0]);
+        vm.AddManualPath(leaves[1]);
+        vm.RaiseManualSelectionChanged();
+
+        vm.IsManualMode.Should().BeTrue();
+        vm.HasScope.Should().BeFalse(
+            "manual mode supersedes scope — HasScope must reflect that even " +
+            "though SelectedScope still holds a value");
+        vm.CanEdit.Should().BeTrue("manual mode is editable too");
+    }
+
+    [Fact]
+    public void IsManualMode_True_OnlyWhenTwoOrMorePathsSelected()
+    {
+        var (vm, tree, _) = BuildWithSingleDb();
+        var leaves = tree.RootMembers.Where(r => r.IsLeaf).Take(2).ToList();
+
+        vm.AddManualPath(leaves[0]);
+        vm.IsManualMode.Should().BeFalse("1 leaf → not manual mode");
+
+        vm.AddManualPath(leaves[1]);
+        vm.IsManualMode.Should().BeTrue("2 leaves → manual mode");
+
+        vm.RemoveManualPath(leaves[0]);
+        vm.IsManualMode.Should().BeFalse("dropping back to 1 leaf exits manual mode");
+    }
+
+    [Fact]
+    public void AddManualPath_ReturnsFalseOnDuplicate()
+    {
+        var (vm, tree, _) = BuildWithSingleDb();
+        var leaf = tree.RootMembers.First(r => r.IsLeaf);
+
+        vm.AddManualPath(leaf).Should().BeTrue("first add changes the set");
+        vm.AddManualPath(leaf).Should().BeFalse("re-adding the same VM is a no-op");
+    }
+
+    [Fact]
+    public void RemoveManualPath_ReturnsFalseWhenAbsent()
+    {
+        var (vm, tree, _) = BuildWithSingleDb();
+        var leaf = tree.RootMembers.First(r => r.IsLeaf);
+
+        vm.RemoveManualPath(leaf).Should().BeFalse("never added → remove is a no-op");
+
+        vm.AddManualPath(leaf);
+        vm.RemoveManualPath(leaf).Should().BeTrue("present → remove returns true");
+    }
+
+    [Fact]
+    public void RaiseManualSelectionChanged_NotifiesAllDerivedProperties()
+    {
+        var (vm, tree, _) = BuildWithSingleDb();
+        var leaves = tree.RootMembers.Where(r => r.IsLeaf).Take(2).ToList();
+        foreach (var l in leaves) vm.AddManualPath(l);
+
+        var changedProps = new List<string?>();
+        var manualChangedFires = 0;
+        vm.PropertyChanged += (_, e) => changedProps.Add(e.PropertyName);
+        vm.ManualSelectionChanged += () => manualChangedFires++;
+
+        vm.RaiseManualSelectionChanged();
+
+        manualChangedFires.Should().Be(1);
+        changedProps.Should().Contain(nameof(SelectionScopeViewModel.IsManualMode));
+        changedProps.Should().Contain(nameof(SelectionScopeViewModel.ManualSelectionCount));
+        changedProps.Should().Contain(nameof(SelectionScopeViewModel.ManualSelectionSummary));
+        changedProps.Should().Contain(nameof(SelectionScopeViewModel.IsSelectionTypeHomogeneous));
+        changedProps.Should().Contain(nameof(SelectionScopeViewModel.HasScope));
+        changedProps.Should().Contain(nameof(SelectionScopeViewModel.CanEdit));
+        changedProps.Should().Contain(nameof(SelectionScopeViewModel.SelectedMemberDisplay));
+    }
+
+    [Fact]
+    public void ClearManualPaths_EmptiesSetSilently()
+    {
+        var (vm, tree, _) = BuildWithSingleDb();
+        var leaves = tree.RootMembers.Where(r => r.IsLeaf).Take(2).ToList();
+        foreach (var l in leaves) vm.AddManualPath(l);
+
+        var manualChangedFires = 0;
+        vm.ManualSelectionChanged += () => manualChangedFires++;
+
+        vm.ClearManualPaths();
+
+        vm.ManualSelectedPaths.Should().BeEmpty();
+        vm.IsManualMode.Should().BeFalse();
+        manualChangedFires.Should().Be(0,
+            "ClearManualPaths is silent so callers bundle the manual-changed " +
+            "notification with their wider clear-cascade side effects");
+    }
+
+    [Fact]
+    public void IsSelectionTypeHomogeneous_FalseWhenMixedDatatypes()
+    {
+        var (vm, tree, _) = BuildWithSingleDb();
+        // MakeFlatDb has Speed (Int) and Enable (Bool) — distinct datatypes.
+        var intLeaf = tree.RootMembers.First(r => r.Name == "Speed");
+        var boolLeaf = tree.RootMembers.First(r => r.Name == "Enable");
+        vm.AddManualPath(intLeaf);
+        vm.AddManualPath(boolLeaf);
+
+        vm.IsManualMode.Should().BeTrue();
+        vm.IsSelectionTypeHomogeneous.Should().BeFalse(
+            "Int + Bool → mixed datatypes — manual-mode validation blocks Apply " +
+            "when types differ");
+        vm.GetSelectedDatatypes().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void SelectedMemberDisplay_FallsBackToManualSummary_InManualMode()
+    {
+        var (vm, tree, _) = BuildWithSingleDb();
+        var leaves = tree.RootMembers.Where(r => r.IsLeaf).Take(2).ToList();
+        foreach (var l in leaves) vm.AddManualPath(l);
+
+        // Even though SelectedFlatMember is null, manual-mode wins.
+        vm.SelectedMemberDisplay.Should().Be(vm.ManualSelectionSummary);
+        vm.ManualSelectionSummary.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void OnNodeSelected_DeselectsAllOtherNodes_GlobalSingleFocus()
+    {
+        // Two-DB tree so leaves in different DBs would otherwise be selected
+        // simultaneously without the cascade.
+        var (vm, tree, _) = BuildWithMultiDb();
+        var dbA = tree.RootMembers[0];
+        var dbB = tree.RootMembers[1];
+        var leafA = dbA.AllDescendants().First(n => n.IsLeaf);
+        var leafB = dbB.AllDescendants().First(n => n.IsLeaf);
+
+        leafA.IsSelected = true;
+        leafB.IsSelected = true;
+
+        // OnNodeSelected is wired by the host as MemberNodeViewModel.SelectedChanged
+        // handler; calling it directly here simulates the event firing for leafB.
+        vm.OnNodeSelected(leafB);
+
+        leafA.IsSelected.Should().BeFalse(
+            "global single-focus invariant (#95): selecting leafB must deselect " +
+            "leafA in the other active DB");
+        leafB.IsSelected.Should().BeTrue();
+    }
+
+    [Fact]
+    public void OnNodeSelected_ReEntry_IsSilentlyIgnored()
+    {
+        // Re-entrancy guard: when OnNodeSelected sets a peer node's
+        // IsSelected = false, that node's SelectedChanged event fires
+        // and the host's wiring (`SelectedChanged += Selection.OnNodeSelected`)
+        // would re-route back into OnNodeSelected. The _inSelectionCascade
+        // flag prevents the recursive body from running on the inner call.
+        var (vm, tree, _) = BuildWithMultiDb();
+        var leafA = tree.RootMembers[0].AllDescendants().First(n => n.IsLeaf);
+        var leafB = tree.RootMembers[1].AllDescendants().First(n => n.IsLeaf);
+
+        leafA.IsSelected = true;
+        leafB.IsSelected = true;
+
+        int innerCallsBlockedByGuard = 0;
+        // When leafA's IsSelected flips to false during the outer cascade,
+        // its SelectedChanged event fires. Simulate the host's wiring by
+        // routing back into OnNodeSelected from the handler.
+        leafA.SelectedChanged += node =>
+        {
+            // The guard inside vm.OnNodeSelected should short-circuit on
+            // re-entry. Count how often it was reached at all.
+            innerCallsBlockedByGuard++;
+            vm.OnNodeSelected(node);
+        };
+
+        // Outer call deselects leafA, which fires the recursive handler.
+        // Without the guard this would either stack-overflow or wipe leafB.
+        vm.OnNodeSelected(leafB);
+
+        leafA.IsSelected.Should().BeFalse("outer cascade must still complete");
+        leafB.IsSelected.Should().BeTrue(
+            "leafB is the justSelected node — must not be touched by the cascade " +
+            "(neither outer nor any recursive re-entry that the guard short-circuited)");
+        innerCallsBlockedByGuard.Should().Be(1,
+            "the handler fired exactly once when leafA was deselected; the guard " +
+            "stopped that re-entry from looping further");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Fixtures
+    // ─────────────────────────────────────────────────────────────────────
+
+    private static (SelectionScopeViewModel vm, MemberTreeViewModel tree, List<ActiveDb> dbs) Build()
+    {
+        var dbs = new List<ActiveDb>();
+        var tree = new MemberTreeViewModel(
+            getActiveDbs: () => dbs,
+            getCurrentPlcName: () => "",
+            commentLanguagePolicy: new CommentLanguagePolicy(null, null, new[] { "en-GB" }),
+            subscribeToVm: _ => { });
+        var vm = new SelectionScopeViewModel(tree);
+        return (vm, tree, dbs);
+    }
+
+    private static (SelectionScopeViewModel vm, MemberTreeViewModel tree, ActiveDb db) BuildWithSingleDb()
+    {
+        var (vm, tree, dbs) = Build();
+        var speed = new MemberNode("Speed", "Int", "0", "Speed", null, Array.Empty<MemberNode>());
+        var enableFlag = new MemberNode("Enable", "Bool", "false", "Enable", null, Array.Empty<MemberNode>());
+        var info = new DataBlockInfo("DB_Test", 1, "Optimized", "GlobalDB", new[] { speed, enableFlag });
+        var db = new ActiveDb(info, "<Block />");
+        dbs.Add(db);
+        tree.BuildRootMembersFromActiveDbs();
+        return (vm, tree, db);
+    }
+
+    private static (SelectionScopeViewModel vm, MemberTreeViewModel tree, IReadOnlyList<ActiveDb> dbs) BuildWithMultiDb()
+    {
+        var (vm, tree, dbs) = Build();
+        var speedA = new MemberNode("SpeedA", "Int", "0", "SpeedA", null, Array.Empty<MemberNode>());
+        var speedB = new MemberNode("SpeedB", "Int", "0", "SpeedB", null, Array.Empty<MemberNode>());
+        dbs.Add(new ActiveDb(new DataBlockInfo("DB_A", 1, "Optimized", "GlobalDB", new[] { speedA }), "<Block />"));
+        dbs.Add(new ActiveDb(new DataBlockInfo("DB_B", 2, "Optimized", "GlobalDB", new[] { speedB }), "<Block />"));
+        tree.BuildRootMembersFromActiveDbs();
+        return (vm, tree, dbs);
+    }
+}

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -342,7 +342,7 @@
                 <ListView
                       x:Name="MemberListView"
                       ItemsSource="{Binding Tree.FlatMembers}"
-                      SelectedItem="{Binding SelectedFlatMember}"
+                      SelectedItem="{Binding Selection.SelectedFlatMember}"
                       SelectionMode="Extended"
                       BorderBrush="#CCCCCC" BorderThickness="1"
                       VirtualizingStackPanel.IsVirtualizing="True"
@@ -767,7 +767,7 @@
                                                        Foreground="#5b6471" Margin="0,0,0,3"/>
                                             <Border Background="White" BorderBrush="#D6D9DE" BorderThickness="1"
                                                     Padding="8,3" MinHeight="24">
-                                                <TextBlock Text="{Binding SelectedMemberDisplay}"
+                                                <TextBlock Text="{Binding Selection.SelectedMemberDisplay}"
                                                            FontFamily="Consolas,Courier New" FontSize="11"
                                                            VerticalAlignment="Center"
                                                            TextTrimming="CharacterEllipsis"/>
@@ -776,14 +776,14 @@
 
                                         <!-- Scope / Manual-selection -->
                                         <StackPanel Margin="12,8,12,0"
-                                                    Visibility="{Binding CanEdit, Converter={StaticResource BoolToVis}}">
+                                                    Visibility="{Binding Selection.CanEdit, Converter={StaticResource BoolToVis}}">
                                             <TextBlock Text="SCOPE" FontSize="9.5" FontWeight="Bold"
                                                        Foreground="#5b6471" Margin="0,0,0,3"/>
                                             <!-- Scope mode -->
-                                            <StackPanel Visibility="{Binding HasScope, Converter={StaticResource BoolToVis}}">
+                                            <StackPanel Visibility="{Binding Selection.HasScope, Converter={StaticResource BoolToVis}}">
                                                 <ComboBox x:Name="ScopeCombo"
-                                                          ItemsSource="{Binding AvailableScopes}"
-                                                          SelectedItem="{Binding SelectedScope}"
+                                                          ItemsSource="{Binding Selection.AvailableScopes}"
+                                                          SelectedItem="{Binding Selection.SelectedScope}"
                                                           HorizontalAlignment="Stretch">
                                                     <ComboBox.ItemTemplate>
                                                         <DataTemplate>
@@ -800,8 +800,8 @@
                                             </StackPanel>
                                             <!-- Manual-selection mode -->
                                             <StackPanel Orientation="Horizontal"
-                                                        Visibility="{Binding IsManualMode, Converter={StaticResource BoolToVis}}">
-                                                <TextBlock Text="{Binding ManualSelectionSummary}"
+                                                        Visibility="{Binding Selection.IsManualMode, Converter={StaticResource BoolToVis}}">
+                                                <TextBlock Text="{Binding Selection.ManualSelectionSummary}"
                                                            VerticalAlignment="Center" TextTrimming="CharacterEllipsis"
                                                            Margin="0,0,6,0"/>
                                                 <Button Content="{loc:Loc Dialog_ClearSelection}"
@@ -813,7 +813,7 @@
 
                                         <!-- New value -->
                                         <StackPanel Margin="12,8,12,0"
-                                                    Visibility="{Binding CanEdit, Converter={StaticResource BoolToVis}}">
+                                                    Visibility="{Binding Selection.CanEdit, Converter={StaticResource BoolToVis}}">
                                             <DockPanel Margin="0,0,0,3">
                                                 <TextBlock DockPanel.Dock="Left" Text="NEW VALUE"
                                                            FontSize="9.5" FontWeight="Bold" Foreground="#5b6471"/>
@@ -903,7 +903,7 @@
                                                 Background="#1f6feb" Foreground="White"
                                                 BorderThickness="0" FontWeight="SemiBold"
                                                 ToolTip="{Binding SetButtonTooltip}"
-                                                Visibility="{Binding CanEdit, Converter={StaticResource BoolToVis}}"/>
+                                                Visibility="{Binding Selection.CanEdit, Converter={StaticResource BoolToVis}}"/>
 
                                         <!-- Overlap warning: bulk will overwrite existing pending edits -->
                                         <Border Margin="12,0,12,12" Padding="6,4"

--- a/src/BlockParam/UI/BulkChangeDialog.xaml.cs
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml.cs
@@ -122,7 +122,7 @@ public partial class BulkChangeDialog : Window
     {
         if (DataContext is not BulkChangeViewModel vm) return;
         target.EnsureVisible();
-        vm.SelectedFlatMember = target;
+        vm.Selection.SelectedFlatMember = target;
         MemberListView.ScrollIntoView(target);
     }
 
@@ -186,7 +186,7 @@ public partial class BulkChangeDialog : Window
     {
         if (DataContext is not BulkChangeViewModel vm) return;
 
-        if (vm.ManualSelectedPaths.Count == 0)
+        if (vm.Selection.ManualSelectedPaths.Count == 0)
         {
             if (MemberListView.SelectedItems.Count > 1)
             {
@@ -206,7 +206,7 @@ public partial class BulkChangeDialog : Window
                 // ManualSelectedPaths is keyed by VM reference now (#58),
                 // so a same-path leaf in another active DB is a different
                 // entry — Contains(m) picks the right one without alias.
-                if (vm.ManualSelectedPaths.Contains(m))
+                if (vm.Selection.ManualSelectedPaths.Contains(m))
                 {
                     MemberListView.SelectedItems.Add(m);
                 }
@@ -424,16 +424,16 @@ public partial class BulkChangeDialog : Window
     internal void ShowScopeDropdownForScripted(string? hoverPath = null)
     {
         if (DataContext is not BulkChangeViewModel vm) return;
-        if (vm.AvailableScopes.Count == 0) return;
+        if (vm.Selection.AvailableScopes.Count == 0) return;
 
         // Force a layout pass so the ComboBox has a real ActualWidth/Height.
         UpdateLayout();
 
-        ScopeOverlayList.ItemsSource = vm.AvailableScopes;
+        ScopeOverlayList.ItemsSource = vm.Selection.AvailableScopes;
         ScopeOverlayList.SelectedItem = null;
         if (hoverPath != null)
         {
-            foreach (var s in vm.AvailableScopes)
+            foreach (var s in vm.Selection.AvailableScopes)
             {
                 if (s.AncestorPath == hoverPath)
                 {
@@ -740,7 +740,7 @@ public partial class BulkChangeDialog : Window
                 && memberVm.IsLeaf
                 && DataContext is BulkChangeViewModel vm)
             {
-                vm.SelectedFlatMember = memberVm;
+                vm.Selection.SelectedFlatMember = memberVm;
                 ShowInlineHintOverlay(tb, memberVm);
             }
         }

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -1445,10 +1445,12 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // PropertyChanged for SelectedFlatMember / HasSelection / SelectedScope /
         // HasScope / CanEdit / SelectedMemberDisplay. ClearManualPaths is
         // silent by design — bundle the manual-side notifications here.
+        // Selection.RaiseManualSelectionChanged fires the slice's events AND
+        // triggers Selection.ManualSelectionChanged → OnSelectionManualChanged,
+        // which re-raises SetButtonText / SetButtonTooltip on the host channel.
+        // No need to raise those a second time directly.
         Selection.RaiseManualSelectionChanged();
         OnPropertyChanged(nameof(HasMultipleActiveDbs));
-        OnPropertyChanged(nameof(SetButtonText));
-        OnPropertyChanged(nameof(SetButtonTooltip));
     }
 
     /// <summary>

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -2176,31 +2176,34 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// Host-side handler for <see cref="SelectionScopeViewModel.ScopeChanged"/>.
     /// The slice raises this once per <c>SelectedScope</c> setter call; the
     /// host runs highlighting + re-raises the composed
-    /// <see cref="SetButtonText"/> / <see cref="SetButtonTooltip"/> +
-    /// <c>CanExecuteSetPending</c> notifications that compose with
-    /// scope state.
+    /// <see cref="SetButtonText"/> / <see cref="SetButtonTooltip"/>
+    /// notifications that compose with scope state.
+    ///
+    /// <para>
+    /// Set Pending / Clear Manual <c>CanExecute</c> picks up changes via
+    /// WPF's <c>CommandManager.RequerySuggested</c> on the next render
+    /// cycle — pre-slice code did not call <c>RaiseCanExecuteChanged</c>
+    /// from this seam either.
+    /// </para>
     /// </summary>
     private void OnSelectionScopeChanged()
     {
         UpdateHighlighting();
         OnPropertyChanged(nameof(SetButtonText));
         OnPropertyChanged(nameof(SetButtonTooltip));
-        (SetPendingCommand as RelayCommand)?.RaiseCanExecuteChanged();
     }
 
     /// <summary>
     /// Host-side handler for <see cref="SelectionScopeViewModel.ManualSelectionChanged"/>.
     /// Re-raises the host-composed properties that depend on the manual-set
-    /// count and re-evaluates Set Pending availability. The slice already
-    /// re-raised its own properties (IsManualMode, ManualSelectionCount,
-    /// SelectedMemberDisplay, …); host only re-raises what it owns.
+    /// count. The slice already re-raised its own properties
+    /// (IsManualMode, ManualSelectionCount, SelectedMemberDisplay, …);
+    /// host only re-raises what it owns.
     /// </summary>
     private void OnSelectionManualChanged()
     {
         OnPropertyChanged(nameof(SetButtonText));
         OnPropertyChanged(nameof(SetButtonTooltip));
-        (SetPendingCommand as RelayCommand)?.RaiseCanExecuteChanged();
-        (ClearManualSelectionCommand as RelayCommand)?.RaiseCanExecuteChanged();
     }
 
     private void OnMemberSelected(MemberNodeViewModel? memberVm)

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -138,14 +138,10 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             new List<ActiveDb>(),
             new Dictionary<string, StashedDbState>(),
             "");
-    private MemberNodeViewModel? _selectedFlatMember;
-    private ScopeLevel? _selectedScope;
+    // Selection.SelectedFlatMember, Selection.SelectedScope, _manualSelectedPaths moved to
+    // SelectionScopeViewModel slice (#80 slice 7b). Host accesses via
+    // Selection.SelectedFlatMember / SelectedScope / ManualSelectedPaths.
     private string _newValue = "";
-    // Multi-DB safe (#58): keyed by MemberNodeViewModel reference, not path
-    // string. Two leaves in different DBs that happen to share a Path would
-    // alias under string keying — Ctrl+click selection on a leaf in one
-    // active DB would silently target a same-path leaf in another.
-    private readonly HashSet<MemberNodeViewModel> _manualSelectedPaths = new();
     private readonly HashSet<string> _bulkErrorPaths = new(StringComparer.Ordinal);
     // True once the user has typed in the NewValue textbox. Prefills from the
     // current selection are skipped while this is true, so user-entered input
@@ -292,11 +288,22 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             commentLanguagePolicy: _commentLanguagePolicy,
             subscribeToVm: SubscribeStartValueEdited);
         Tree.RootsRebuilt += OnTreeRootsRebuilt;
+
+        // Selection / scope / manual-selection slice (#80 slice 7b). Must be
+        // constructed BEFORE Tree.BuildRootMembersFromActiveDbs because
+        // SubscribeStartValueEdited (called per minted VM during the build)
+        // wires `MemberNodeViewModel.SelectedChanged += Selection.OnNodeSelected`.
+        // The slice owns the four state items + derived properties; the host
+        // keeps the OnMemberSelected / UpdateManualSelection orchestrators
+        // and runs them from the slice's events.
+        Selection = new SelectionScopeViewModel(Tree);
+        Selection.MemberChanged += OnMemberSelected;
+        Selection.ScopeChanged += OnSelectionScopeChanged;
+        Selection.ManualSelectionChanged += OnSelectionManualChanged;
+
         Tree.BuildRootMembersFromActiveDbs();
         RefreshRuleHints();
         RebuildPlcPills();
-
-        AvailableScopes = new ObservableCollection<ScopeLevel>();
 
         SetPendingCommand = new RelayCommand(ExecuteSetPending, CanExecuteSetPending);
         ApplyCommand = new RelayCommand(ExecuteApply, CanExecuteApply);
@@ -312,7 +319,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // animation — no host-side relay needed.
         Inspector = new InspectorPanelsViewModel();
         ClearManualSelectionCommand = new RelayCommand(ExecuteClearManualSelection,
-            () => _manualSelectedPaths.Count > 0);
+            () => Selection.ManualSelectionCount > 0);
 
         OpenDataBlocksDropdownCommand = new RelayCommand(ExecuteOpenDataBlocksDropdown,
             () => _enumerateDataBlocks != null && _switchToDataBlock != null);
@@ -416,7 +423,15 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         get => _title;
         private set => SetProperty(ref _title, value);
     }
-    public ObservableCollection<ScopeLevel> AvailableScopes { get; }
+    /// <summary>
+    /// Selection / scope / manual-selection slice (#80 slice 7b). Owns
+    /// <c>SelectedFlatMember</c>, <c>SelectedScope</c>,
+    /// <c>AvailableScopes</c>, the manual-selection set, plus the
+    /// single-focus invariant guard. XAML binds via
+    /// <c>{Binding Selection.SelectedFlatMember}</c>,
+    /// <c>{Binding Selection.AvailableScopes}</c>, etc.
+    /// </summary>
+    public SelectionScopeViewModel Selection { get; }
 
     /// <summary>
     /// Tree-shape + flat-list + expand/collapse slice (#80 slice 7a). Owns
@@ -526,37 +541,12 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         }
     }
 
-    /// <summary>Selected item in the flat ListView.</summary>
-    public MemberNodeViewModel? SelectedFlatMember
-    {
-        get => _selectedFlatMember;
-        set
-        {
-            if (Tree.IsRefreshing) return; // Don't re-trigger during flat list rebuild
-            if (SetProperty(ref _selectedFlatMember, value))
-            {
-                OnMemberSelected(value);
-                OnPropertyChanged(nameof(HasSelection));
-                OnPropertyChanged(nameof(SelectedMemberDisplay));
-            }
-        }
-    }
-
-    public ScopeLevel? SelectedScope
-    {
-        get => _selectedScope;
-        set
-        {
-            if (SetProperty(ref _selectedScope, value))
-            {
-                UpdateHighlighting();
-                OnPropertyChanged(nameof(HasScope));
-                OnPropertyChanged(nameof(CanEdit));
-                OnPropertyChanged(nameof(SetButtonText));
-                OnPropertyChanged(nameof(SetButtonTooltip));
-            }
-        }
-    }
+    // SelectedFlatMember / SelectedScope moved to SelectionScopeViewModel
+    // (slice 7b). The host subscribes to Selection.MemberChanged and
+    // Selection.ScopeChanged from the constructor and runs OnMemberSelected
+    // / UpdateHighlighting in the handler. SetButtonText / SetButtonTooltip
+    // are composed properties on the host; the host re-raises them when
+    // Selection raises HasScope / IsManualMode.
 
     public string NewValue
     {
@@ -608,17 +598,23 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         set => SetProperty(ref _constraintInfo, value);
     }
 
-    public bool HasSelection => _selectedFlatMember is { IsLeaf: true };
-    public bool HasScope => _selectedScope != null && !IsManualMode;
+    // HasSelection / HasScope moved to SelectionScopeViewModel (slice 7b).
     public bool HasValidationError => !string.IsNullOrEmpty(_validationError);
+    /// <summary>
+    /// Set-button label. Composes <c>Selection.SelectedScope</c> /
+    /// <c>Selection.IsManualMode</c> with host-side member-count
+    /// readouts, so it stays on the host. The host's
+    /// <c>Selection.ScopeChanged</c> / <c>Selection.ManualSelectionChanged</c>
+    /// subscriptions re-raise this when the slice's state moves.
+    /// </summary>
     public string SetButtonText
     {
         get
         {
-            if (IsManualMode)
+            if (Selection.IsManualMode)
                 return Res.Format("Dialog_SetManualCount", CountWouldChangeMembers());
-            return _selectedScope != null
-                ? $"Set {CountWouldChangeMembers()} in '{_selectedScope.AncestorName}'"
+            return Selection.SelectedScope != null
+                ? $"Set {CountWouldChangeMembers()} in '{Selection.SelectedScope.AncestorName}'"
                 : "Set";
         }
     }
@@ -633,7 +629,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         get
         {
             var action = Res.Get("Dialog_SetTooltip");
-            if (!CanEdit) return action;
+            if (!Selection.CanEdit) return action;
 
             int total = TotalCandidateMembers();
             int willChange = CountWouldChangeMembers();
@@ -642,74 +638,24 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             string breakdown;
             if (string.IsNullOrEmpty(_newValue))
             {
-                breakdown = IsManualMode
+                breakdown = Selection.IsManualMode
                     ? Res.Format("Dialog_SetTooltip_ManualIdle", total)
-                    : Res.Format("Dialog_SetTooltip_ScopeIdle", total, _selectedScope?.AncestorName ?? "");
+                    : Res.Format("Dialog_SetTooltip_ScopeIdle", total, Selection.SelectedScope?.AncestorName ?? "");
             }
             else
             {
-                breakdown = IsManualMode
+                breakdown = Selection.IsManualMode
                     ? Res.Format("Dialog_SetTooltip_ManualBreakdown", willChange, total, alreadyMatch)
                     : Res.Format("Dialog_SetTooltip_ScopeBreakdown",
-                        willChange, total, _selectedScope?.AncestorName ?? "", alreadyMatch);
+                        willChange, total, Selection.SelectedScope?.AncestorName ?? "", alreadyMatch);
             }
             return action + "\n" + breakdown;
         }
     }
 
-    /// <summary>True when 2+ leaf members are manually selected (Ctrl+Click).</summary>
-    public bool IsManualMode => _manualSelectedPaths.Count >= 2;
-
-    /// <summary>Number of manually selected leaf members (includes ones hidden by filter).</summary>
-    public int ManualSelectionCount => _manualSelectedPaths.Count;
-
-    /// <summary>
-    /// Read-only view of manually selected member VMs (for code-behind
-    /// rehydration). Multi-DB safe (#58): keyed by reference, so the
-    /// dialog's ListView rehydration test (Contains(m)) picks the right
-    /// VM in whichever DB it lives.
-    /// </summary>
-    public IReadOnlyCollection<MemberNodeViewModel> ManualSelectedPaths => _manualSelectedPaths;
-
-    /// <summary>
-    /// Bulk panel is visible when the user can edit — either scope mode (single selection)
-    /// or manual mode (2+ selected).
-    /// </summary>
-    public bool CanEdit => HasScope || IsManualMode;
-
-    /// <summary>Summary text shown instead of the scope dropdown when in manual mode.</summary>
-    public string ManualSelectionSummary
-    {
-        get
-        {
-            if (!IsManualMode) return "";
-            var types = GetSelectedDatatypes();
-            if (types.Count == 1)
-                return Res.Format("Dialog_ManualSelectionSummary", _manualSelectedPaths.Count, types.First());
-            return Res.Format("Dialog_ManualSelectionMixed", _manualSelectedPaths.Count, types.Count);
-        }
-    }
-
-    /// <summary>True when all manually selected members share the same datatype.</summary>
-    public bool IsSelectionTypeHomogeneous
-    {
-        get
-        {
-            if (!IsManualMode) return true;
-            return GetSelectedDatatypes().Count == 1;
-        }
-    }
-
-    public string SelectedMemberDisplay
-    {
-        get
-        {
-            if (IsManualMode) return ManualSelectionSummary;
-            return _selectedFlatMember is { IsLeaf: true }
-                ? Res.Format("Selection_MemberDisplay", _selectedFlatMember.Name, _selectedFlatMember.Datatype)
-                : Res.Get("Selection_ClickToSelect");
-        }
-    }
+    // IsManualMode / ManualSelectionCount / ManualSelectedPaths / CanEdit /
+    // ManualSelectionSummary / IsSelectionTypeHomogeneous / SelectedMemberDisplay
+    // moved to SelectionScopeViewModel (slice 7b).
 
     public ICommand SetPendingCommand { get; }
     public ICommand ApplyCommand { get; }
@@ -1461,9 +1407,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // the previous tree. Clear them before the rebuild — same pattern
         // SwitchToDataBlock uses — so the count machinery doesn't accumulate
         // phantom entries from a deactivated DB.
-        _selectedFlatMember = null;
-        _selectedScope = null;
-        _manualSelectedPaths.Clear();
+        Selection.SetSelectedFlatMemberSilent(null);
+        Selection.SetSelectedScopeSilent(null);
+        Selection.ClearManualPaths();
         // Tree.BuildRootMembersFromActiveDbs clears RootMembers + the lookup
         // dicts internally — no separate RootMembers.Clear() needed.
         Tree.BuildRootMembersFromActiveDbs();
@@ -1494,14 +1440,15 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // and tooltip have to refresh — the slice has no way to observe the
         // anchor change on its own.
         Filter.RaiseSetpointsCapabilityChanged();
+        // SelectedFlatMember / SelectedScope / manual-set were cleared via
+        // Selection.SetXxxSilent above; the slice raised its own
+        // PropertyChanged for SelectedFlatMember / HasSelection / SelectedScope /
+        // HasScope / CanEdit / SelectedMemberDisplay. ClearManualPaths is
+        // silent by design — bundle the manual-side notifications here.
+        Selection.RaiseManualSelectionChanged();
         OnPropertyChanged(nameof(HasMultipleActiveDbs));
-        OnPropertyChanged(nameof(SelectedFlatMember));
-        OnPropertyChanged(nameof(SelectedScope));
-        OnPropertyChanged(nameof(HasSelection));
-        OnPropertyChanged(nameof(HasScope));
-        OnPropertyChanged(nameof(IsManualMode));
-        OnPropertyChanged(nameof(ManualSelectionCount));
-        OnPropertyChanged(nameof(SelectedMemberDisplay));
+        OnPropertyChanged(nameof(SetButtonText));
+        OnPropertyChanged(nameof(SetButtonTooltip));
     }
 
     /// <summary>
@@ -2210,35 +2157,65 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // Tree.RebuildFlatList's insideRefreshScope callback — both still run
         // while Tree.IsRefreshing is true, so SelectedFlatMember setter +
         // code-behind SelectionChanged stay suppressed during the rebuild.
-        var selectedPath = _selectedFlatMember?.Path;
+        var selectedPath = Selection.SelectedFlatMember?.Path;
         Tree.RebuildFlatList(insideRefreshScope: () =>
         {
             if (selectedPath != null)
             {
                 var restored = Tree.FlatMembers.FirstOrDefault(m => m.Path == selectedPath);
-                // Set backing field directly to avoid re-triggering OnMemberSelected
-                _selectedFlatMember = restored;
-                OnPropertyChanged(nameof(SelectedFlatMember));
-                OnPropertyChanged(nameof(HasSelection));
-                OnPropertyChanged(nameof(SelectedMemberDisplay));
+                // Silent setter so we don't re-trigger OnMemberSelected during
+                // the rebuild — the slice raises SelectedFlatMember /
+                // HasSelection / SelectedMemberDisplay PropertyChanged for us.
+                Selection.SetSelectedFlatMemberSilent(restored);
             }
             FlatListRefreshed?.Invoke();
         });
     }
 
+    /// <summary>
+    /// Host-side handler for <see cref="SelectionScopeViewModel.ScopeChanged"/>.
+    /// The slice raises this once per <c>SelectedScope</c> setter call; the
+    /// host runs highlighting + re-raises the composed
+    /// <see cref="SetButtonText"/> / <see cref="SetButtonTooltip"/> +
+    /// <c>CanExecuteSetPending</c> notifications that compose with
+    /// scope state.
+    /// </summary>
+    private void OnSelectionScopeChanged()
+    {
+        UpdateHighlighting();
+        OnPropertyChanged(nameof(SetButtonText));
+        OnPropertyChanged(nameof(SetButtonTooltip));
+        (SetPendingCommand as RelayCommand)?.RaiseCanExecuteChanged();
+    }
+
+    /// <summary>
+    /// Host-side handler for <see cref="SelectionScopeViewModel.ManualSelectionChanged"/>.
+    /// Re-raises the host-composed properties that depend on the manual-set
+    /// count and re-evaluates Set Pending availability. The slice already
+    /// re-raised its own properties (IsManualMode, ManualSelectionCount,
+    /// SelectedMemberDisplay, …); host only re-raises what it owns.
+    /// </summary>
+    private void OnSelectionManualChanged()
+    {
+        OnPropertyChanged(nameof(SetButtonText));
+        OnPropertyChanged(nameof(SetButtonTooltip));
+        (SetPendingCommand as RelayCommand)?.RaiseCanExecuteChanged();
+        (ClearManualSelectionCommand as RelayCommand)?.RaiseCanExecuteChanged();
+    }
+
     private void OnMemberSelected(MemberNodeViewModel? memberVm)
     {
-        AvailableScopes.Clear();
-        _selectedScope = null; // Set backing field to avoid triggering UpdateHighlighting twice
-        OnPropertyChanged(nameof(SelectedScope));
-        OnPropertyChanged(nameof(HasScope));
-        OnPropertyChanged(nameof(CanEdit));
+        Selection.AvailableScopes.Clear();
+        // Silent setter — the same method re-populates and re-selects below;
+        // routing through the public setter would cascade UpdateHighlighting
+        // twice (once here, once when the auto-selected scope assigns).
+        Selection.SetSelectedScopeSilent(null);
         ValidationError = "";
         ConstraintInfo = "";
         Autocomplete.ClearCandidates();
 
         // In manual multi-select mode, scope analysis does not apply.
-        if (IsManualMode)
+        if (Selection.IsManualMode)
         {
             // Scope highlighting is already cleared by UpdateManualSelection when
             // we entered manual mode. Do NOT call UpdateHighlighting/RefreshFlatList
@@ -2307,10 +2284,10 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         }
 
         foreach (var scope in result.Scopes.Reverse())
-            AvailableScopes.Add(scope);
+            Selection.AvailableScopes.Add(scope);
 
-        if (AvailableScopes.Count > 0)
-            SelectedScope = AvailableScopes[0];
+        if (Selection.AvailableScopes.Count > 0)
+            Selection.SelectedScope = Selection.AvailableScopes[0];
 
         // Proactive hint (#7) — single source of truth with the inline-edit tooltip.
         ConstraintInfo = memberVm.RuleHint ?? "";
@@ -2320,11 +2297,8 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // Re-sync selection after flat list rebuilds during click processing
         _dispatcher.BeginInvoke(new Action(() =>
         {
-            if (memberVm != null && _selectedFlatMember != memberVm)
-            {
-                _selectedFlatMember = memberVm;
-                OnPropertyChanged(nameof(SelectedFlatMember));
-            }
+            if (memberVm != null && Selection.SelectedFlatMember != memberVm)
+                Selection.SetSelectedFlatMemberSilent(memberVm);
         }), System.Windows.Threading.DispatcherPriority.Input);
     }
 
@@ -2341,9 +2315,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         ReExpandNonAffected();
 
         // Keep the selected member visible after ClearAffected collapsed smart-expands
-        _selectedFlatMember?.EnsureVisible();
+        Selection.SelectedFlatMember?.EnsureVisible();
 
-        if (_selectedScope == null && !IsManualMode)
+        if (Selection.SelectedScope == null && !IsManualMode)
         {
             ComputeBulkPreview();
             RebuildPendingEdits();
@@ -2351,14 +2325,14 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             return;
         }
 
-        if (_selectedScope != null)
+        if (Selection.SelectedScope != null)
         {
             // Multi-DB safe (#58 review must-fix #2): resolve scope members
             // to their owning DB's tree VMs by reference, not by path string.
             // The previous HashSet<string>+full-tree-walk would mark same-named
             // paths in other active DBs as Affected even when the user picked
             // a within-DB scope on a single DB.
-            var affectedVms = ResolveScopeVms(_selectedScope.MatchingMembers);
+            var affectedVms = ResolveScopeVms(Selection.SelectedScope.MatchingMembers);
 
             foreach (var vm in affectedVms)
                 MarkAffected(vm, _newValue);
@@ -2399,20 +2373,20 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // No input → nothing to compute. Avoid walking scope members on every
         // inline keystroke when the inspector isn't being driven at all.
         bool hasInput = !string.IsNullOrEmpty(_newValue)
-                        && (IsManualMode || _selectedScope != null);
+                        && (IsManualMode || Selection.SelectedScope != null);
         if (hasInput)
         {
-            if (IsManualMode)
+            if (Selection.IsManualMode)
             {
-                foreach (var node in _manualSelectedPaths)
+                foreach (var node in Selection.ManualSelectedPaths)
                 {
                     if (!node.IsLeaf) continue;
                     TryAddPreviewEntry(node);
                 }
             }
-            else if (_selectedScope != null)
+            else if (Selection.SelectedScope != null)
             {
-                foreach (var m in _selectedScope.MatchingMembers)
+                foreach (var m in Selection.SelectedScope.MatchingMembers)
                 {
                     // Multi-DB safe: route by model reference, not path string.
                     // Same path can exist in multiple DBs; FindVmByModel is
@@ -2507,13 +2481,13 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private void UpdateCommentPreviews()
     {
         var config = _configLoader.GetConfig();
-        if (config == null || _selectedScope == null) return;
+        if (config == null || Selection.SelectedScope == null) return;
         if (!config.Rules.Any(r => !string.IsNullOrEmpty(r.CommentTemplate))) return;
 
         EnsureTagTableCache();
         var generator = new TemplateCommentGenerator(config, _tagTableCache);
         var previews = generator.GenerateForScope(
-            _active.Info, _selectedScope.MatchingMembers.ToList(),
+            _active.Info, Selection.SelectedScope.MatchingMembers.ToList(),
             valueResolver: ResolvePendingValue);
 
         foreach (var (target, comment) in previews)
@@ -2751,9 +2725,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // Manual mode: block on mixed types, otherwise validate each selected
         // member against its own rule (different members may reference different
         // tag tables / constraints).
-        if (IsManualMode)
+        if (Selection.IsManualMode)
         {
-            if (!IsSelectionTypeHomogeneous)
+            if (!Selection.IsSelectionTypeHomogeneous)
             {
                 ValidationError = Res.Get("Validation_MixedDatatypes");
                 return;
@@ -2767,7 +2741,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
             string? firstError = null;
             string? firstErrorName = null;
-            foreach (var node in _manualSelectedPaths)
+            foreach (var node in Selection.ManualSelectedPaths)
             {
                 if (!node.IsLeaf) continue;
                 var memberError = ValidateValueForMember(node, _newValue);
@@ -2793,13 +2767,13 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             return;
         }
 
-        if (string.IsNullOrEmpty(_newValue) || _selectedFlatMember == null)
+        if (string.IsNullOrEmpty(_newValue) || Selection.SelectedFlatMember == null)
         {
             ValidationError = "";
             return;
         }
 
-        ValidationError = ValidateValueForMember(_selectedFlatMember, _newValue) ?? "";
+        ValidationError = ValidateValueForMember(Selection.SelectedFlatMember, _newValue) ?? "";
     }
 
     /// <summary>
@@ -2905,20 +2879,20 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     {
         Autocomplete.ClearCandidates();
 
-        if (_selectedFlatMember == null || !_selectedFlatMember.IsLeaf) return;
+        if (Selection.SelectedFlatMember == null || !Selection.SelectedFlatMember.IsLeaf) return;
         if (!_showConstants) return;
 
         EnsureTagTableCache();
         if (_tagTableCache == null) return;
 
         var config = _configLoader.GetConfig();
-        var rule = config?.GetRule(_selectedFlatMember.Model);
+        var rule = config?.GetRule(Selection.SelectedFlatMember.Model);
 
         IReadOnlyList<AutocompleteSuggestion> suggestions;
         if (rule?.TagTableReference != null)
         {
             // Rule-based: only matching tables
-            suggestions = _autocompleteProvider?.GetSuggestions(_selectedFlatMember.Model, "")
+            suggestions = _autocompleteProvider?.GetSuggestions(Selection.SelectedFlatMember.Model, "")
                 ?? Array.Empty<AutocompleteSuggestion>();
         }
         else
@@ -3019,13 +2993,13 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         if (string.IsNullOrWhiteSpace(_newValue) || HasValidationError)
             return false;
 
-        if (IsManualMode)
+        if (Selection.IsManualMode)
         {
-            if (!IsSelectionTypeHomogeneous) return false;
+            if (!Selection.IsSelectionTypeHomogeneous) return false;
             return CountWouldChangeMembers() > 0;
         }
 
-        if (!HasSelection || !HasScope) return false;
+        if (!Selection.HasSelection || !Selection.HasScope) return false;
 
         return CountWouldChangeMembers() > 0;
     }
@@ -3038,14 +3012,14 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// </summary>
     private int CountWouldChangeMembers()
     {
-        if (IsManualMode)
+        if (Selection.IsManualMode)
         {
-            return _manualSelectedPaths.Count(node => node.IsLeaf && WouldChange(node));
+            return Selection.ManualSelectedPaths.Count(node => node.IsLeaf && WouldChange(node));
         }
 
-        if (_selectedScope == null) return 0;
+        if (Selection.SelectedScope == null) return 0;
 
-        return _selectedScope.MatchingMembers.Count(m =>
+        return Selection.SelectedScope.MatchingMembers.Count(m =>
         {
             var node = Tree.FindNodeByPath(m.Path);
             // Unresolved paths can't be staged by SetPendingOnNodes, so don't
@@ -3069,11 +3043,11 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// </summary>
     private int TotalCandidateMembers()
     {
-        if (IsManualMode)
+        if (Selection.IsManualMode)
         {
-            return _manualSelectedPaths.Count(node => node.IsLeaf);
+            return Selection.ManualSelectedPaths.Count(node => node.IsLeaf);
         }
-        return _selectedScope?.MatchCount ?? 0;
+        return Selection.SelectedScope?.MatchCount ?? 0;
     }
 
     /// <summary>
@@ -3082,13 +3056,13 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// </summary>
     private void ExecuteSetPending()
     {
-        if (IsManualMode)
+        if (Selection.IsManualMode)
         {
             ExecuteSetPendingManual();
             return;
         }
 
-        if (_selectedScope == null) return;
+        if (Selection.SelectedScope == null) return;
 
         Subscription.MaybeWarnLimitReachedOnce();
 
@@ -3097,7 +3071,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // to bleed pending values into other active DBs that happened to
         // have the same path; this routes each scope member to exactly its
         // own tree node.
-        var affectedVms = ResolveScopeVms(_selectedScope.MatchingMembers);
+        var affectedVms = ResolveScopeVms(Selection.SelectedScope.MatchingMembers);
         int count = 0;
 
         foreach (var vm in affectedVms)
@@ -3127,7 +3101,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         Subscription.MaybeWarnLimitReachedOnce();
 
         int count = 0;
-        foreach (var node in _manualSelectedPaths)
+        foreach (var node in Selection.ManualSelectedPaths)
         {
             if (!node.IsLeaf) continue;
             var startsEqualsNew = string.Equals(node.StartValue, _newValue, StringComparison.OrdinalIgnoreCase);
@@ -3617,7 +3591,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private void ExecuteUpdateComments()
     {
         var config = _configLoader.GetConfig();
-        if (config == null || _selectedScope == null) return;
+        if (config == null || Selection.SelectedScope == null) return;
         if (!config.Rules.Any(r => !string.IsNullOrEmpty(r.CommentTemplate))) return;
 
         try
@@ -3631,7 +3605,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             // each match to its own ActiveDb.Xml. Single-DB sessions
             // collapse to a one-DB group, behaviour unchanged.
             var byDb = new Dictionary<ActiveDb, List<MemberNode>>();
-            foreach (var member in _selectedScope.MatchingMembers)
+            foreach (var member in Selection.SelectedScope.MatchingMembers)
             {
                 var owningDb = Tree.FindActiveDbForModel(member);
                 if (owningDb == null) continue;
@@ -3684,7 +3658,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
     private bool CanExecuteUpdateComments()
     {
-        return HasScope && HasCommentConfig;
+        return Selection.HasScope && HasCommentConfig;
     }
 
     /// <summary>
@@ -3753,42 +3727,14 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private void SubscribeStartValueEdited(MemberNodeViewModel node)
     {
         node.StartValueEdited += OnSingleValueEdited;
-        node.SelectedChanged += OnNodeSelected;
+        node.SelectedChanged += Selection.OnNodeSelected;
         foreach (var child in node.Children)
             SubscribeStartValueEdited(child);
     }
 
-    private bool _inSelectionCascade;
-
-    /// <summary>
-    /// Global single-focus invariant (#95): when one node's
-    /// <see cref="MemberNodeViewModel.IsSelected"/> becomes true, every
-    /// other node in <see cref="RootMembers"/> drops its selection — so the
-    /// dialog never sees a leaf selected in DB A *and* a leaf selected in
-    /// DB B at the same time.
-    /// </summary>
-    private void OnNodeSelected(MemberNodeViewModel justSelected)
-    {
-        if (_inSelectionCascade) return;
-        _inSelectionCascade = true;
-        try
-        {
-            foreach (var root in RootMembers)
-            {
-                if (!ReferenceEquals(root, justSelected) && root.IsSelected)
-                    root.IsSelected = false;
-                foreach (var descendant in root.AllDescendants())
-                {
-                    if (!ReferenceEquals(descendant, justSelected) && descendant.IsSelected)
-                        descendant.IsSelected = false;
-                }
-            }
-        }
-        finally
-        {
-            _inSelectionCascade = false;
-        }
-    }
+    // _inSelectionCascade + OnNodeSelected moved to SelectionScopeViewModel
+    // (slice 7b). Host's SubscribeStartValueEdited routes `SelectedChanged`
+    // through Selection.OnNodeSelected directly.
 
     /// <summary>
     /// Handles direct inline editing of a single start value in the table.
@@ -3935,9 +3881,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // Preserve selection + scope by stable identity (#8). Index-based lookup
         // broke because OnMemberSelected adds scopes reversed while RefreshTree
         // used plain order — indices didn't line up after Apply.
-        var selectedPath = _selectedFlatMember?.Path;
-        var selectedScopeAncestorPath = _selectedScope?.AncestorPath;
-        var selectedScopeDepth = _selectedScope?.Depth;
+        var selectedPath = Selection.SelectedFlatMember?.Path;
+        var selectedScopeAncestorPath = Selection.SelectedScope?.AncestorPath;
+        var selectedScopeDepth = Selection.SelectedScope?.Depth;
 
         // Keep the most recent UDT resolvers so later RefreshTree calls (from Apply) don't drop them.
         if (udtResolver != null) _udtResolver = udtResolver;
@@ -3974,10 +3920,12 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             var restored = Tree.FlatMembers.FirstOrDefault(m => m.Path == selectedPath);
             if (restored != null)
             {
-                _selectedFlatMember = restored;
-                OnPropertyChanged(nameof(SelectedFlatMember));
-                OnPropertyChanged(nameof(HasSelection));
-                OnPropertyChanged(nameof(SelectedMemberDisplay));
+                // Silent setter — RefreshTree re-populates scopes manually
+                // below (the slice would otherwise re-fire OnMemberSelected
+                // which already ran once for this leaf during the restore
+                // flow). The slice raises SelectedFlatMember / HasSelection /
+                // SelectedMemberDisplay PropertyChanged itself.
+                Selection.SetSelectedFlatMemberSilent(restored);
 
                 // Re-populate scopes for the restored selection using the same
                 // ordering as OnMemberSelected so index/position stay stable.
@@ -3997,14 +3945,14 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                 {
                     result = _analyzer.Analyze(_active.Info, restored.Model);
                 }
-                AvailableScopes.Clear();
+                Selection.AvailableScopes.Clear();
                 foreach (var scope in result.Scopes.Reverse())
-                    AvailableScopes.Add(scope);
+                    Selection.AvailableScopes.Add(scope);
 
                 // #8: Match the previously selected scope by ancestor path, not
                 // by index. Keeps the dropdown sticky through Apply even when
                 // the scope count/order drifts.
-                var restoredScope = AvailableScopes.FirstOrDefault(s =>
+                var restoredScope = Selection.AvailableScopes.FirstOrDefault(s =>
                     string.Equals(s.AncestorPath, selectedScopeAncestorPath, StringComparison.Ordinal)
                     && s.Depth == selectedScopeDepth);
                 if (restoredScope != null)
@@ -4054,36 +4002,33 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     {
         var addedList = added.ToList();
         var removedList = removed.ToList();
-        bool wasManual = IsManualMode;
+        bool wasManual = Selection.IsManualMode;
         bool changed = false;
 
         foreach (var m in addedList)
         {
             if (!m.IsLeaf) continue;
-            if (_manualSelectedPaths.Add(m)) changed = true;
+            if (Selection.AddManualPath(m)) changed = true;
         }
 
         if (!isFilterRehydration)
         {
             foreach (var m in removedList)
             {
-                if (_manualSelectedPaths.Remove(m)) changed = true;
+                if (Selection.RemoveManualPath(m)) changed = true;
             }
         }
 
         if (!changed) return;
 
-        bool isNowManual = IsManualMode;
+        bool isNowManual = Selection.IsManualMode;
 
-        OnPropertyChanged(nameof(IsManualMode));
-        OnPropertyChanged(nameof(ManualSelectionCount));
-        OnPropertyChanged(nameof(ManualSelectionSummary));
-        OnPropertyChanged(nameof(IsSelectionTypeHomogeneous));
-        OnPropertyChanged(nameof(HasScope));
-        OnPropertyChanged(nameof(CanEdit));
-        OnPropertyChanged(nameof(SetButtonText));
-        OnPropertyChanged(nameof(SetButtonTooltip));
-        OnPropertyChanged(nameof(SelectedMemberDisplay));
+        // The slice raises IsManualMode / ManualSelectionCount /
+        // ManualSelectionSummary / IsSelectionTypeHomogeneous / HasScope /
+        // CanEdit / SelectedMemberDisplay PropertyChanged; the
+        // OnSelectionManualChanged handler bundles the host-composed
+        // SetButtonText / SetButtonTooltip + RaiseCanExecuteChanged.
+        Selection.RaiseManualSelectionChanged();
 
         // Entering manual mode: the scope-based highlighting from the single
         // selection no longer applies. Clear the scope state and wipe affected
@@ -4091,10 +4036,11 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // run before SelectionChanged fired, so we handle this here too.)
         if (!wasManual && isNowManual)
         {
-            AvailableScopes.Clear();
-            _selectedScope = null;
-            OnPropertyChanged(nameof(SelectedScope));
-            OnPropertyChanged(nameof(HasScope));
+            Selection.AvailableScopes.Clear();
+            // Silent setter — UpdateHighlighting runs below; routing through
+            // the public setter would fire ScopeChanged → UpdateHighlighting
+            // twice.
+            Selection.SetSelectedScopeSilent(null);
             // Pin ancestors of manually selected leaves as user-expanded so that
             // UpdateHighlighting's ClearAffected doesn't collapse them and hide
             // the first-selected row from the flat list (which would deselect it).
@@ -4113,7 +4059,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             // Transitioning back to scope mode. OnMemberSelected already ran
             // before this method (with IsManualMode still true) and skipped scope
             // setup. Re-run it now that the mode has flipped.
-            OnMemberSelected(_selectedFlatMember);
+            OnMemberSelected(Selection.SelectedFlatMember);
         }
 
         ValidateValue();
@@ -4143,7 +4089,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
     private void PinManuallySelectedVisibility()
     {
-        foreach (var node in _manualSelectedPaths)
+        foreach (var node in Selection.ManualSelectedPaths)
         {
             var p = node.Parent;
             while (p != null)
@@ -4160,41 +4106,23 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
     private void ExecuteClearManualSelection()
     {
-        if (_manualSelectedPaths.Count == 0) return;
-        _manualSelectedPaths.Clear();
+        if (Selection.ManualSelectionCount == 0) return;
+        Selection.ClearManualPaths();
         ClearBulkRowHighlights();
         _newValueTouched = false;
         _newValue = "";
         OnPropertyChanged(nameof(NewValue));
 
-        OnPropertyChanged(nameof(IsManualMode));
-        OnPropertyChanged(nameof(ManualSelectionCount));
-        OnPropertyChanged(nameof(ManualSelectionSummary));
-        OnPropertyChanged(nameof(IsSelectionTypeHomogeneous));
-        OnPropertyChanged(nameof(HasScope));
-        OnPropertyChanged(nameof(CanEdit));
-        OnPropertyChanged(nameof(SetButtonText));
-        OnPropertyChanged(nameof(SetButtonTooltip));
-        OnPropertyChanged(nameof(SelectedMemberDisplay));
+        // Slice raises the manual-set + scope-mode-related notifications;
+        // OnSelectionManualChanged bundles SetButtonText / SetButtonTooltip /
+        // RaiseCanExecuteChanged.
+        Selection.RaiseManualSelectionChanged();
 
         ValidateValue();
         FlatListRefreshed?.Invoke();
     }
 
-    /// <summary>
-    /// Returns the distinct datatypes (case-insensitive) of currently selected members.
-    /// Ignores paths that no longer resolve to a leaf node.
-    /// </summary>
-    private IReadOnlyCollection<string> GetSelectedDatatypes()
-    {
-        var types = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var node in _manualSelectedPaths)
-        {
-            if (node.IsLeaf)
-                types.Add(node.Datatype);
-        }
-        return types;
-    }
+    // GetSelectedDatatypes() moved to SelectionScopeViewModel (slice 7b).
 
     public void Dispose()
     {

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -2317,7 +2317,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // Keep the selected member visible after ClearAffected collapsed smart-expands
         Selection.SelectedFlatMember?.EnsureVisible();
 
-        if (Selection.SelectedScope == null && !IsManualMode)
+        if (Selection.SelectedScope == null && !Selection.IsManualMode)
         {
             ComputeBulkPreview();
             RebuildPendingEdits();
@@ -2373,7 +2373,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // No input → nothing to compute. Avoid walking scope members on every
         // inline keystroke when the inspector isn't being driven at all.
         bool hasInput = !string.IsNullOrEmpty(_newValue)
-                        && (IsManualMode || Selection.SelectedScope != null);
+                        && (Selection.IsManualMode || Selection.SelectedScope != null);
         if (hasInput)
         {
             if (Selection.IsManualMode)
@@ -3956,7 +3956,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                     string.Equals(s.AncestorPath, selectedScopeAncestorPath, StringComparison.Ordinal)
                     && s.Depth == selectedScopeDepth);
                 if (restoredScope != null)
-                    SelectedScope = restoredScope;
+                    Selection.SelectedScope = restoredScope;
 
                 // Value is reset after Apply: the just-committed value would
                 // misrepresent the current state (#8). Clear touched so the

--- a/src/BlockParam/UI/SelectionScopeViewModel.cs
+++ b/src/BlockParam/UI/SelectionScopeViewModel.cs
@@ -1,0 +1,328 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using BlockParam.Localization;
+using BlockParam.Services;
+
+namespace BlockParam.UI;
+
+/// <summary>
+/// Selection + scope + manual-selection slice (#80 slice 7b).
+///
+/// <para>
+/// Owns the four pieces of user-selection state that drive the bulk-
+/// edit dialog: the currently focused flat-member (<see cref="SelectedFlatMember"/>),
+/// the active hierarchy scope picked from the dropdown
+/// (<see cref="SelectedScope"/>), the list of available scopes the
+/// analyzer produced (<see cref="AvailableScopes"/>), and the set of
+/// leaves the user has manually multi-selected via Ctrl+Click
+/// (<see cref="ManualSelectedPaths"/>).
+/// </para>
+///
+/// <para>
+/// <b>What stays on the host (orchestration).</b> The setter on
+/// <see cref="SelectedFlatMember"/> raises the <see cref="MemberChanged"/>
+/// event; the host subscribes and runs the (large) scope-analysis +
+/// autocomplete-reload + new-value-prefill pipeline that used to live
+/// in <c>OnMemberSelected</c>. Same shape for <see cref="SelectedScope"/>:
+/// the slice raises <see cref="ScopeChanged"/>, the host runs
+/// <c>UpdateHighlighting</c>. The host's <c>UpdateManualSelection</c> +
+/// <c>ExecuteClearManualSelection</c> orchestrators read/write slice
+/// state through the silent-write helpers (<see cref="SetSelectedFlatMemberSilent"/>,
+/// <see cref="SetSelectedScopeSilent"/>, <see cref="AddManualPath"/>,
+/// <see cref="RemoveManualPath"/>, <see cref="ClearManualPaths"/>) so
+/// the cascade order matches pre-slice byte-for-byte.
+/// </para>
+///
+/// <para>
+/// <b>Why the orchestration stayed.</b> <c>OnMemberSelected</c> and
+/// <c>UpdateManualSelection</c> each touch host-owned state on every
+/// branch — <c>ValidationError</c>, <c>ConstraintInfo</c>, the
+/// autocomplete provider, <c>_newValue</c>, the highlighting pass, the
+/// flat-list refresh. Moving the orchestration into the slice would
+/// require injecting eight or more callbacks, and the slice would be
+/// 60% callback plumbing. The pragmatic cut keeps the slice as a
+/// state container with focused event signals and lets the host walk
+/// its existing side-effect graph from the event handler.
+/// </para>
+///
+/// <para>
+/// <b>Tree dependency.</b> The slice reads
+/// <c>Tree.IsRefreshing</c> from the setter re-entry guard (the WPF
+/// flat-list rebuild flips it to <c>true</c> mid-rebuild, and
+/// <see cref="SelectedFlatMember"/>'s setter must short-circuit then).
+/// It also calls <c>Tree.FindActiveDbForModel</c> indirectly through
+/// the host's <see cref="MemberChanged"/> handler. <see cref="OnNodeSelected"/>
+/// walks <c>Tree.RootMembers</c> to enforce the global single-focus
+/// invariant (#95).
+/// </para>
+/// </summary>
+public class SelectionScopeViewModel : ViewModelBase
+{
+    private readonly MemberTreeViewModel _tree;
+    private MemberNodeViewModel? _selectedFlatMember;
+    private ScopeLevel? _selectedScope;
+    private readonly HashSet<MemberNodeViewModel> _manualSelectedPaths = new();
+    private bool _inSelectionCascade;
+
+    public SelectionScopeViewModel(MemberTreeViewModel tree)
+    {
+        _tree = tree;
+        AvailableScopes = new ObservableCollection<ScopeLevel>();
+    }
+
+    /// <summary>
+    /// Focused leaf in the flat ListView. Setter raises
+    /// <see cref="MemberChanged"/>; host runs the scope-analysis +
+    /// autocomplete-reload + new-value-prefill pipeline in the handler.
+    /// Short-circuits while <c>Tree.IsRefreshing</c> to suppress ghost
+    /// "removed items" events WPF raises mid-rebuild.
+    /// </summary>
+    public MemberNodeViewModel? SelectedFlatMember
+    {
+        get => _selectedFlatMember;
+        set
+        {
+            if (_tree.IsRefreshing) return;
+            if (SetProperty(ref _selectedFlatMember, value))
+            {
+                OnPropertyChanged(nameof(HasSelection));
+                OnPropertyChanged(nameof(SelectedMemberDisplay));
+                MemberChanged?.Invoke(value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Scope picked from the dropdown (or auto-selected by the
+    /// host after scope analysis). Setter raises
+    /// <see cref="ScopeChanged"/>; host runs <c>UpdateHighlighting</c>.
+    /// </summary>
+    public ScopeLevel? SelectedScope
+    {
+        get => _selectedScope;
+        set
+        {
+            if (SetProperty(ref _selectedScope, value))
+            {
+                OnPropertyChanged(nameof(HasScope));
+                OnPropertyChanged(nameof(CanEdit));
+                ScopeChanged?.Invoke();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Scope rows shown in the dropdown. Populated by the host's
+    /// scope-analysis pipeline after the user picks a leaf.
+    /// </summary>
+    public ObservableCollection<ScopeLevel> AvailableScopes { get; }
+
+    /// <summary>True when 2+ leaf members are manually selected (Ctrl+Click).</summary>
+    public bool IsManualMode => _manualSelectedPaths.Count >= 2;
+
+    /// <summary>Number of manually selected leaf members (includes ones hidden by filter).</summary>
+    public int ManualSelectionCount => _manualSelectedPaths.Count;
+
+    /// <summary>
+    /// Read-only view of manually selected member VMs (for code-behind
+    /// rehydration). Multi-DB safe (#58): keyed by reference, so the
+    /// dialog's ListView rehydration test (Contains(m)) picks the right
+    /// VM in whichever DB it lives.
+    /// </summary>
+    public IReadOnlyCollection<MemberNodeViewModel> ManualSelectedPaths => _manualSelectedPaths;
+
+    /// <summary>True iff a leaf is currently focused.</summary>
+    public bool HasSelection => _selectedFlatMember is { IsLeaf: true };
+
+    /// <summary>
+    /// True when a scope is picked AND we're not in manual mode — manual
+    /// mode supersedes scope state, so <see cref="SelectedScope"/> can
+    /// linger from a prior selection without affecting Apply.
+    /// </summary>
+    public bool HasScope => _selectedScope != null && !IsManualMode;
+
+    /// <summary>
+    /// Bulk panel is visible when the user can edit — either scope mode
+    /// (single selection) or manual mode (2+ selected).
+    /// </summary>
+    public bool CanEdit => HasScope || IsManualMode;
+
+    /// <summary>Summary text shown instead of the scope dropdown when in manual mode.</summary>
+    public string ManualSelectionSummary
+    {
+        get
+        {
+            if (!IsManualMode) return "";
+            var types = GetSelectedDatatypes();
+            if (types.Count == 1)
+                return Res.Format("Dialog_ManualSelectionSummary", _manualSelectedPaths.Count, types.First());
+            return Res.Format("Dialog_ManualSelectionMixed", _manualSelectedPaths.Count, types.Count);
+        }
+    }
+
+    /// <summary>True when all manually selected members share the same datatype.</summary>
+    public bool IsSelectionTypeHomogeneous
+    {
+        get
+        {
+            if (!IsManualMode) return true;
+            return GetSelectedDatatypes().Count == 1;
+        }
+    }
+
+    /// <summary>
+    /// Status-line display string: manual-mode summary, or member name +
+    /// datatype when a single leaf is focused, or the localized
+    /// "click to select" placeholder otherwise.
+    /// </summary>
+    public string SelectedMemberDisplay
+    {
+        get
+        {
+            if (IsManualMode) return ManualSelectionSummary;
+            return _selectedFlatMember is { IsLeaf: true }
+                ? Res.Format("Selection_MemberDisplay", _selectedFlatMember.Name, _selectedFlatMember.Datatype)
+                : Res.Get("Selection_ClickToSelect");
+        }
+    }
+
+    /// <summary>
+    /// Raised after <see cref="SelectedFlatMember"/> changes. The host
+    /// runs its <c>OnMemberSelected</c> orchestrator from this event
+    /// (scope analysis, prefill, autocomplete reload, etc.).
+    /// </summary>
+    public event Action<MemberNodeViewModel?>? MemberChanged;
+
+    /// <summary>
+    /// Raised after <see cref="SelectedScope"/> changes. The host runs
+    /// <c>UpdateHighlighting</c> from this event.
+    /// </summary>
+    public event Action? ScopeChanged;
+
+    /// <summary>
+    /// Raised after <see cref="_manualSelectedPaths"/> mutates (Add /
+    /// Remove / Clear). The host re-raises composed properties
+    /// (<c>CanEdit</c>, <c>SetButtonText</c>, etc.) from this event.
+    /// </summary>
+    public event Action? ManualSelectionChanged;
+
+    /// <summary>
+    /// Silent set of <see cref="SelectedFlatMember"/>: writes the
+    /// backing field and raises the property-changed notifications, but
+    /// does <i>not</i> fire <see cref="MemberChanged"/>. Used by the
+    /// host's selection-restore code paths (<c>RefreshTree</c>,
+    /// <c>RefreshFlatList</c>, <c>OnMemberSelected</c>'s dispatcher
+    /// re-sync) that already know the side effects have been applied.
+    /// </summary>
+    public void SetSelectedFlatMemberSilent(MemberNodeViewModel? value)
+    {
+        if (SetProperty(ref _selectedFlatMember, value, nameof(SelectedFlatMember)))
+        {
+            OnPropertyChanged(nameof(HasSelection));
+            OnPropertyChanged(nameof(SelectedMemberDisplay));
+        }
+    }
+
+    /// <summary>
+    /// Silent set of <see cref="SelectedScope"/>: writes backing field +
+    /// raises PropertyChanged but suppresses the <see cref="ScopeChanged"/>
+    /// event. Used by <c>OnMemberSelected</c> when it clears scope state
+    /// (the same method then re-populates and selects, so a stray cascade
+    /// from the clear would double-run highlighting).
+    /// </summary>
+    public void SetSelectedScopeSilent(ScopeLevel? value)
+    {
+        if (SetProperty(ref _selectedScope, value, nameof(SelectedScope)))
+        {
+            OnPropertyChanged(nameof(HasScope));
+            OnPropertyChanged(nameof(CanEdit));
+        }
+    }
+
+    /// <summary>
+    /// Adds a manually-selected leaf. Returns <c>true</c> if the path was
+    /// new (i.e. the set actually changed). Caller is responsible for
+    /// raising <see cref="ManualSelectionChanged"/> once per batch of
+    /// add/remove ops via <see cref="RaiseManualSelectionChanged"/>.
+    /// </summary>
+    public bool AddManualPath(MemberNodeViewModel node) => _manualSelectedPaths.Add(node);
+
+    /// <summary>
+    /// Removes a manually-selected leaf. Returns <c>true</c> if the path
+    /// was present (i.e. the set actually changed).
+    /// </summary>
+    public bool RemoveManualPath(MemberNodeViewModel node) => _manualSelectedPaths.Remove(node);
+
+    /// <summary>
+    /// Clears the manual-selection set. No-op if already empty. Always
+    /// silent; caller raises <see cref="ManualSelectionChanged"/> once if
+    /// the wider clear gesture had other side effects to bundle.
+    /// </summary>
+    public void ClearManualPaths() => _manualSelectedPaths.Clear();
+
+    /// <summary>
+    /// Raises <see cref="ManualSelectionChanged"/> plus the derived
+    /// property notifications that hang off the manual-paths count.
+    /// </summary>
+    public void RaiseManualSelectionChanged()
+    {
+        OnPropertyChanged(nameof(IsManualMode));
+        OnPropertyChanged(nameof(ManualSelectionCount));
+        OnPropertyChanged(nameof(ManualSelectionSummary));
+        OnPropertyChanged(nameof(IsSelectionTypeHomogeneous));
+        OnPropertyChanged(nameof(HasScope));
+        OnPropertyChanged(nameof(CanEdit));
+        OnPropertyChanged(nameof(SelectedMemberDisplay));
+        ManualSelectionChanged?.Invoke();
+    }
+
+    /// <summary>
+    /// Global single-focus invariant (#95): when one node's
+    /// <c>MemberNodeViewModel.IsSelected</c> becomes true, every other
+    /// node in <c>Tree.RootMembers</c> drops its selection — so the
+    /// dialog never sees a leaf selected in DB A *and* a leaf selected in
+    /// DB B at the same time. Wired up by the host through
+    /// <c>SubscribeStartValueEdited</c>'s <c>SelectedChanged += OnNodeSelected</c>.
+    /// </summary>
+    public void OnNodeSelected(MemberNodeViewModel justSelected)
+    {
+        if (_inSelectionCascade) return;
+        _inSelectionCascade = true;
+        try
+        {
+            foreach (var root in _tree.RootMembers)
+            {
+                if (!ReferenceEquals(root, justSelected) && root.IsSelected)
+                    root.IsSelected = false;
+                foreach (var descendant in root.AllDescendants())
+                {
+                    if (!ReferenceEquals(descendant, justSelected) && descendant.IsSelected)
+                        descendant.IsSelected = false;
+                }
+            }
+        }
+        finally
+        {
+            _inSelectionCascade = false;
+        }
+    }
+
+    /// <summary>
+    /// Set of distinct <c>Datatype</c> strings across the currently
+    /// manually-selected leaves. Empty when there are no manual
+    /// selections. Used by <see cref="ManualSelectionSummary"/> and
+    /// <see cref="IsSelectionTypeHomogeneous"/>, and exposed for the
+    /// host's manual-mode validation pipeline.
+    /// </summary>
+    public IReadOnlyCollection<string> GetSelectedDatatypes()
+    {
+        var types = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var node in _manualSelectedPaths)
+        {
+            if (node.IsLeaf)
+                types.Add(node.Datatype);
+        }
+        return types;
+    }
+}


### PR DESCRIPTION
## Summary

Second half of #80 slice 7. Moves the four selection state items +
derived properties + global single-focus invariant out of the
4,211-line `BulkChangeViewModel` into a focused
`SelectionScopeViewModel`. The orchestration methods stay on the
host (see below); the slice raises focused events the host
subscribes to.

Finishes slice 7. Remaining work: slice 8 (ActiveSet + DB-switcher,
needs #78 PR 0 prereq) and slice 9 (host cleanup).

### What this PR moves

`SelectionScopeViewModel` owns:

- `SelectedFlatMember` — setter raises `MemberChanged`
- `SelectedScope` — setter raises `ScopeChanged`
- `AvailableScopes` (mutable `ObservableCollection<ScopeLevel>`)
- `ManualSelectedPaths` (`HashSet`, exposed as `IReadOnlyCollection`)
- Derived: `IsManualMode`, `ManualSelectionCount`, `ManualSelectionSummary`,
  `IsSelectionTypeHomogeneous`, `HasSelection`, `HasScope`, `CanEdit`,
  `SelectedMemberDisplay`
- `_inSelectionCascade` + `OnNodeSelected` (global single-focus
  invariant #95)
- `SetSelectedFlatMemberSilent` / `SetSelectedScopeSilent` for the
  host's selection-restore paths that already handled side effects
- `AddManualPath` / `RemoveManualPath` / `ClearManualPaths` mutators +
  `RaiseManualSelectionChanged()` to bundle derived-property
  notifications

### Cut decisions

- **`OnMemberSelected`, `UpdateManualSelection`, `ExecuteClearManualSelection`
  stay on the host.** Each touches 8+ host-owned side effects
  (`ValidationError`, `ConstraintInfo`, Autocomplete, `NewValue` /
  `_newValueTouched`, `ShowConstants` forcing, `UpdateHighlighting`,
  `ValidateValue`, `RefreshFlatList`, `ReloadSuggestions`,
  `PrefillNewValueFromFeaturedMember`, `StatusText`). Pulling the
  orchestration into the slice would require injecting eight or more
  callbacks and the slice would be 60% callback plumbing. The slice
  is a state container with focused event signals; the host walks
  its existing side-effect graph from the event handler.
- **Slice 8 (active-set) calls in `OnMemberSelected` stay on the
  host.** `HasMultipleActiveDbs`, `AllActiveDbs`, `_active` are
  read-only there and tied to the orchestration that's already
  host-side. `Tree.FindActiveDbForModel` is called from the host's
  handler.
- **`ClearManualSelectionCommand` stays host-owned.** Its
  `ExecuteClearManualSelection` body touches `NewValue` +
  `ValidationError` + `ClearBulkRowHighlights` + `FlatListRefreshed` —
  the slice can't run those on its own.
- **`SetButtonText` / `SetButtonTooltip` stay on the host** —
  composed with `_newValue` + host-side member counts. The host
  subscribes to slice events to re-raise these.
- **`_isRefreshing` guard moved to `Tree.IsRefreshing`.** The slice's
  `SelectedFlatMember` setter short-circuits while
  `Tree.IsRefreshing == true` (the WPF flat-list rebuild flips it
  mid-rebuild and the setter must not refire `OnMemberSelected`).

### Constructor ordering

`Selection` must be constructed **before** `Tree.BuildRootMembersFromActiveDbs()`
because `SubscribeStartValueEdited` (invoked per minted VM during
the build) wires `MemberNodeViewModel.SelectedChanged +=
Selection.OnNodeSelected`. The constructor reflects this ordering.

### Numbers

- Host VM: **4,211 → 4,139 lines** (−72 net).
- New `SelectionScopeViewModel.cs`: 328 lines.
- New `SelectionScopeViewModelTests.cs`: 17 focused tests covering
  defaults, public setters (event + property notifications), silent
  setters, `Tree.IsRefreshing` guard, `HasScope` falsification in
  manual mode, `IsManualMode` threshold (2+ leaves), `AddManualPath` /
  `RemoveManualPath` return-value contracts,
  `RaiseManualSelectionChanged` notification bundle,
  `ClearManualPaths` silent semantics,
  `IsSelectionTypeHomogeneous` heterogeneous detection,
  `SelectedMemberDisplay` manual-mode fallback, `OnNodeSelected`
  global single-focus invariant, and the `_inSelectionCascade`
  re-entry guard.
- Five existing test files + DevLauncher `CaptureScript` rewired to
  `vm.Selection.X`.
- XAML rebinds: `SelectedFlatMember`, `SelectedScope`,
  `AvailableScopes`, `IsManualMode`, `HasScope`, `CanEdit`,
  `ManualSelectionSummary`, `SelectedMemberDisplay` all retargeted
  to `Selection.X`. `ClearManualSelectionCommand` stays host-bound.

## Test plan

- [ ] CI `Build & Test (V20, net48)` green — includes 17 new
      `SelectionScopeViewModelTests`
- [ ] CI `Build (V21, net48)` green
- [ ] Existing host VM tests (regression / invariant / multi-DB /
      db-switcher) still pass with new `vm.Selection.X` binding paths
- [ ] Manual smoke (not blocking): open dialog in TIA Portal V20,
      single-click a leaf (scope analysis runs), Ctrl+click another
      leaf (enter manual mode), Ctrl+click both off (exit to scope),
      switch DBs (selection cascade clears state), Apply

Refs #80.

https://claude.ai/code/session_0168J7dK7tApviBaDquX6gUd

---
_Generated by [Claude Code](https://claude.ai/code/session_0168J7dK7tApviBaDquX6gUd)_