### PR TITLE
refactor(#80): extract ActiveSetViewModel state container (slice 8a)

### DIFF
--- a/src/BlockParam.Tests/ActiveSetViewModelTests.cs
+++ b/src/BlockParam.Tests/ActiveSetViewModelTests.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using BlockParam.Models;
+using BlockParam.UI;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Focused tests for the active-set state container (#80 slice 8a).
+/// Slice 8a owns the <see cref="ActiveSetState"/> snapshot + the bound
+/// <c>StashedDbs</c> collection; mutators still live on the host VM.
+/// The contracts under test:
+///
+/// <list type="bullet">
+///   <item><c>SetState</c> swaps the snapshot and raises
+///       <c>StateChanged(old, new)</c> with the previous snapshot, not
+///       the new one twice.</item>
+///   <item><c>SetState</c> with a reference-equal snapshot is a no-op
+///       (no event, no StashedDbs churn).</item>
+///   <item><c>StashedDbs</c> mirror is rebuilt only when the
+///       <c>Stashes</c> dictionary reference changed, not on every
+///       SetState — so a Dbs-only mutation doesn't perturb the bound
+///       collection.</item>
+///   <item><c>StashedDbs</c> entries are sorted (FolderPath, DbName)
+///       so display order is stable across snapshot swaps.</item>
+///   <item><c>HasStashedDbs</c> tracks the mirror count and raises
+///       PropertyChanged when it flips.</item>
+/// </list>
+/// </summary>
+public class ActiveSetViewModelTests
+{
+    [Fact]
+    public void Constructor_NullInitial_Throws()
+    {
+        Action act = () => new ActiveSetViewModel(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_SeedsStateAndEmptyStashes()
+    {
+        var initial = StateWith(dbs: Db("Foo"));
+
+        var vm = new ActiveSetViewModel(initial);
+
+        vm.State.Should().BeSameAs(initial);
+        vm.StashedDbs.Should().BeEmpty();
+        vm.HasStashedDbs.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Constructor_SeedsStashesIntoBoundCollection()
+    {
+        var stash = Stash("DBa", "/a");
+        var initial = StateWith(dbs: Db("Anchor"), stashes: new Dictionary<string, StashedDbState>
+        {
+            ["k"] = stash,
+        });
+
+        var vm = new ActiveSetViewModel(initial);
+
+        vm.StashedDbs.Should().ContainSingle().Which.Should().BeSameAs(stash);
+        vm.HasStashedDbs.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SetState_RaisesStateChangedWithOldAndNew()
+    {
+        var old = StateWith(dbs: Db("A"));
+        var vm = new ActiveSetViewModel(old);
+        var next = StateWith(dbs: Db("A"), Db("B"));
+
+        (ActiveSetState? captOld, ActiveSetState? captNew) = (null, null);
+        vm.StateChanged += (o, n) => { captOld = o; captNew = n; };
+
+        vm.SetState(next);
+
+        captOld.Should().BeSameAs(old, "old snapshot is the one being replaced");
+        captNew.Should().BeSameAs(next);
+        vm.State.Should().BeSameAs(next);
+    }
+
+    [Fact]
+    public void SetState_SameReference_IsNoOp()
+    {
+        var snap = StateWith(dbs: Db("A"));
+        var vm = new ActiveSetViewModel(snap);
+        int events = 0;
+        vm.StateChanged += (_, _) => events++;
+
+        vm.SetState(snap);
+
+        events.Should().Be(0);
+    }
+
+    [Fact]
+    public void SetState_Null_Throws()
+    {
+        var vm = new ActiveSetViewModel(StateWith(dbs: Db("A")));
+
+        Action act = () => vm.SetState(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void SetState_DbsOnlyChange_DoesNotResyncStashedDbs()
+    {
+        // Same Stashes reference → mirror sync skipped (perf + stability:
+        // the inspector section's IsExpanded state survives Dbs-only
+        // changes like Add / Solo / Remove that don't touch stashes).
+        var stash = Stash("X");
+        var stashes = new Dictionary<string, StashedDbState> { ["k"] = stash };
+        var initial = StateWith(dbs: Db("A"), stashes: stashes);
+        var vm = new ActiveSetViewModel(initial);
+        var sentinel = vm.StashedDbs[0];
+
+        vm.SetState(initial.With(dbs: new[] { Db("A"), Db("B") }));
+
+        vm.StashedDbs.Should().HaveCount(1);
+        vm.StashedDbs[0].Should().BeSameAs(sentinel,
+            "Dbs-only change reuses the same StashedDbState instance");
+    }
+
+    [Fact]
+    public void SetState_StashesChanged_RebuildsBoundCollection()
+    {
+        var s1 = Stash("OldDb");
+        var initial = StateWith(dbs: Db("A"), stashes: new Dictionary<string, StashedDbState>
+        {
+            ["k1"] = s1,
+        });
+        var vm = new ActiveSetViewModel(initial);
+        var s2 = Stash("NewDb");
+
+        vm.SetState(initial.With(stashes: new Dictionary<string, StashedDbState>
+        {
+            ["k2"] = s2,
+        }));
+
+        vm.StashedDbs.Should().ContainSingle().Which.Should().BeSameAs(s2);
+    }
+
+    [Fact]
+    public void SetState_StashesSortedByFolderPathThenName()
+    {
+        var b = Stash("Beta", folder: "FolderA");
+        var a = Stash("Alpha", folder: "FolderA");
+        var z = Stash("Zeta", folder: "FolderB");
+
+        var initial = StateWith(dbs: Db("Anchor"), stashes: new Dictionary<string, StashedDbState>
+        {
+            ["k1"] = z,
+            ["k2"] = b,
+            ["k3"] = a,
+        });
+
+        var vm = new ActiveSetViewModel(initial);
+
+        vm.StashedDbs.Select(s => s.DbName).Should().Equal("Alpha", "Beta", "Zeta");
+    }
+
+    [Fact]
+    public void SetState_StashesAppearingFromEmpty_FlipsHasStashedDbsAndNotifies()
+    {
+        var vm = new ActiveSetViewModel(StateWith(dbs: Db("A")));
+        var raised = CapturePropertyChanges(vm);
+        var s = Stash("New");
+
+        vm.SetState(vm.State.With(stashes: new Dictionary<string, StashedDbState>
+        {
+            ["k"] = s,
+        }));
+
+        vm.HasStashedDbs.Should().BeTrue();
+        raised.Should().Contain(nameof(ActiveSetViewModel.HasStashedDbs));
+    }
+
+    [Fact]
+    public void SetState_StashesDisappearingToEmpty_FlipsHasStashedDbsAndNotifies()
+    {
+        var initial = StateWith(dbs: Db("A"), stashes: new Dictionary<string, StashedDbState>
+        {
+            ["k"] = Stash("X"),
+        });
+        var vm = new ActiveSetViewModel(initial);
+        var raised = CapturePropertyChanges(vm);
+
+        vm.SetState(initial.With(stashes: new Dictionary<string, StashedDbState>()));
+
+        vm.HasStashedDbs.Should().BeFalse();
+        raised.Should().Contain(nameof(ActiveSetViewModel.HasStashedDbs));
+    }
+
+    [Fact]
+    public void SetState_DbsOnlyChange_DoesNotRaiseHasStashedDbsPropertyChanged()
+    {
+        // Dbs-only swap shouldn't fire HasStashedDbs PropertyChanged — the
+        // mirror isn't re-synced, so the OnPropertyChanged inside the sync
+        // method never runs. Cheap check that the no-op path is honored.
+        var initial = StateWith(dbs: Db("A"), stashes: new Dictionary<string, StashedDbState>
+        {
+            ["k"] = Stash("X"),
+        });
+        var vm = new ActiveSetViewModel(initial);
+        var raised = CapturePropertyChanges(vm);
+
+        vm.SetState(initial.With(dbs: new[] { Db("A"), Db("B") }));
+
+        raised.Should().NotContain(nameof(ActiveSetViewModel.HasStashedDbs));
+    }
+
+    [Fact]
+    public void StashedDbs_CollectionInstanceIsStableAcrossSnapshots()
+    {
+        // XAML bindings hold the ObservableCollection reference — the slice
+        // mutates it in place via Clear() + Add() rather than replacing the
+        // collection. Guards against a future "set StashedDbs = new …()"
+        // regression that would silently break ItemsControl bindings.
+        var vm = new ActiveSetViewModel(StateWith(dbs: Db("A")));
+        var collection = vm.StashedDbs;
+
+        vm.SetState(vm.State.With(stashes: new Dictionary<string, StashedDbState>
+        {
+            ["k"] = Stash("S"),
+        }));
+
+        vm.StashedDbs.Should().BeSameAs(collection);
+    }
+
+    // --- helpers ---
+
+    private static ActiveSetState StateWith(
+        IEnumerable<ActiveDb> dbs,
+        IDictionary<string, StashedDbState>? stashes = null,
+        string anchorPlcName = "")
+        => new ActiveSetState(
+            dbs.ToList(),
+            stashes != null
+                ? new Dictionary<string, StashedDbState>(stashes)
+                : new Dictionary<string, StashedDbState>(),
+            anchorPlcName);
+
+    private static ActiveSetState StateWith(params ActiveDb[] dbs)
+        => StateWith((IEnumerable<ActiveDb>)dbs);
+
+    private static ActiveDb Db(string name, string plc = "")
+    {
+        var info = new DataBlockInfo(name, 1, "Optimized", "GlobalDB", Array.Empty<MemberNode>());
+        return new ActiveDb(info, $"<Block name='{name}' />", onApply: null, plcName: plc);
+    }
+
+    private static StashedDbState Stash(string name, string folder = "")
+    {
+        var summary = new DataBlockSummary(name, folder, plcName: "", number: 1);
+        return new StashedDbState(summary, Array.Empty<StashedEditEntry>());
+    }
+
+    private static List<string?> CapturePropertyChanges(INotifyPropertyChanged vm)
+    {
+        var raised = new List<string?>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        return raised;
+    }
+}

--- a/src/BlockParam.Tests/ActiveSetViewModelTests.cs
+++ b/src/BlockParam.Tests/ActiveSetViewModelTests.cs
@@ -44,7 +44,7 @@ public class ActiveSetViewModelTests
     [Fact]
     public void Constructor_SeedsStateAndEmptyStashes()
     {
-        var initial = StateWith(dbs: Db("Foo"));
+        var initial = Snap(Db("Foo"));
 
         var vm = new ActiveSetViewModel(initial);
 
@@ -57,7 +57,7 @@ public class ActiveSetViewModelTests
     public void Constructor_SeedsStashesIntoBoundCollection()
     {
         var stash = Stash("DBa", "/a");
-        var initial = StateWith(dbs: Db("Anchor"), stashes: new Dictionary<string, StashedDbState>
+        var initial = Snap(Db("Anchor"), stashes: new Dictionary<string, StashedDbState>
         {
             ["k"] = stash,
         });
@@ -71,9 +71,9 @@ public class ActiveSetViewModelTests
     [Fact]
     public void SetState_RaisesStateChangedWithOldAndNew()
     {
-        var old = StateWith(dbs: Db("A"));
+        var old = Snap(Db("A"));
         var vm = new ActiveSetViewModel(old);
-        var next = StateWith(dbs: Db("A"), Db("B"));
+        var next = Snap(Db("A"), Db("B"));
 
         (ActiveSetState? captOld, ActiveSetState? captNew) = (null, null);
         vm.StateChanged += (o, n) => { captOld = o; captNew = n; };
@@ -88,7 +88,7 @@ public class ActiveSetViewModelTests
     [Fact]
     public void SetState_SameReference_IsNoOp()
     {
-        var snap = StateWith(dbs: Db("A"));
+        var snap = Snap(Db("A"));
         var vm = new ActiveSetViewModel(snap);
         int events = 0;
         vm.StateChanged += (_, _) => events++;
@@ -101,7 +101,7 @@ public class ActiveSetViewModelTests
     [Fact]
     public void SetState_Null_Throws()
     {
-        var vm = new ActiveSetViewModel(StateWith(dbs: Db("A")));
+        var vm = new ActiveSetViewModel(Snap(Db("A")));
 
         Action act = () => vm.SetState(null!);
 
@@ -116,7 +116,7 @@ public class ActiveSetViewModelTests
         // changes like Add / Solo / Remove that don't touch stashes).
         var stash = Stash("X");
         var stashes = new Dictionary<string, StashedDbState> { ["k"] = stash };
-        var initial = StateWith(dbs: Db("A"), stashes: stashes);
+        var initial = Snap(Db("A"), stashes: stashes);
         var vm = new ActiveSetViewModel(initial);
         var sentinel = vm.StashedDbs[0];
 
@@ -131,7 +131,7 @@ public class ActiveSetViewModelTests
     public void SetState_StashesChanged_RebuildsBoundCollection()
     {
         var s1 = Stash("OldDb");
-        var initial = StateWith(dbs: Db("A"), stashes: new Dictionary<string, StashedDbState>
+        var initial = Snap(Db("A"), stashes: new Dictionary<string, StashedDbState>
         {
             ["k1"] = s1,
         });
@@ -153,7 +153,7 @@ public class ActiveSetViewModelTests
         var a = Stash("Alpha", folder: "FolderA");
         var z = Stash("Zeta", folder: "FolderB");
 
-        var initial = StateWith(dbs: Db("Anchor"), stashes: new Dictionary<string, StashedDbState>
+        var initial = Snap(Db("Anchor"), stashes: new Dictionary<string, StashedDbState>
         {
             ["k1"] = z,
             ["k2"] = b,
@@ -168,7 +168,7 @@ public class ActiveSetViewModelTests
     [Fact]
     public void SetState_StashesAppearingFromEmpty_FlipsHasStashedDbsAndNotifies()
     {
-        var vm = new ActiveSetViewModel(StateWith(dbs: Db("A")));
+        var vm = new ActiveSetViewModel(Snap(Db("A")));
         var raised = CapturePropertyChanges(vm);
         var s = Stash("New");
 
@@ -184,7 +184,7 @@ public class ActiveSetViewModelTests
     [Fact]
     public void SetState_StashesDisappearingToEmpty_FlipsHasStashedDbsAndNotifies()
     {
-        var initial = StateWith(dbs: Db("A"), stashes: new Dictionary<string, StashedDbState>
+        var initial = Snap(Db("A"), stashes: new Dictionary<string, StashedDbState>
         {
             ["k"] = Stash("X"),
         });
@@ -203,7 +203,7 @@ public class ActiveSetViewModelTests
         // Dbs-only swap shouldn't fire HasStashedDbs PropertyChanged — the
         // mirror isn't re-synced, so the OnPropertyChanged inside the sync
         // method never runs. Cheap check that the no-op path is honored.
-        var initial = StateWith(dbs: Db("A"), stashes: new Dictionary<string, StashedDbState>
+        var initial = Snap(Db("A"), stashes: new Dictionary<string, StashedDbState>
         {
             ["k"] = Stash("X"),
         });
@@ -222,7 +222,7 @@ public class ActiveSetViewModelTests
         // mutates it in place via Clear() + Add() rather than replacing the
         // collection. Guards against a future "set StashedDbs = new …()"
         // regression that would silently break ItemsControl bindings.
-        var vm = new ActiveSetViewModel(StateWith(dbs: Db("A")));
+        var vm = new ActiveSetViewModel(Snap(Db("A")));
         var collection = vm.StashedDbs;
 
         vm.SetState(vm.State.With(stashes: new Dictionary<string, StashedDbState>
@@ -235,19 +235,22 @@ public class ActiveSetViewModelTests
 
     // --- helpers ---
 
-    private static ActiveSetState StateWith(
-        IEnumerable<ActiveDb> dbs,
+    private static ActiveSetState Snap(
+        ActiveDb anchor,
         IDictionary<string, StashedDbState>? stashes = null,
         string anchorPlcName = "")
         => new ActiveSetState(
-            dbs.ToList(),
+            new[] { anchor },
             stashes != null
                 ? new Dictionary<string, StashedDbState>(stashes)
                 : new Dictionary<string, StashedDbState>(),
             anchorPlcName);
 
-    private static ActiveSetState StateWith(params ActiveDb[] dbs)
-        => StateWith((IEnumerable<ActiveDb>)dbs);
+    private static ActiveSetState Snap(params ActiveDb[] dbs)
+        => new ActiveSetState(
+            dbs,
+            new Dictionary<string, StashedDbState>(),
+            "");
 
     private static ActiveDb Db(string name, string plc = "")
     {

--- a/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using BlockParam.Config;
 using BlockParam.Licensing;
@@ -96,6 +98,35 @@ public class BulkChangeViewModelInvariantTests
         env.Vm.StashedDbs.Should().ContainSingle(s => s.DbName == "NestedStructDB");
         env.Mbx.AskYesNoCancelCallCount.Should().Be(1);
         AssertInvariants(env.Vm);
+    }
+
+    [Fact]
+    public void HasStashedDbs_PropertyChanged_FiresOnHostWhenStashFlipsFromEmpty()
+    {
+        // Slice 8a regression guard. The host's HasStashedDbs is a
+        // delegator over ActiveSet.HasStashedDbs; the slice raises its
+        // own PropertyChanged, and the host's constructor wires a
+        // forwarder lambda so external `vm.PropertyChanged` subscribers
+        // filtering on HasStashedDbs still see the notification. If a
+        // future slice-9 cleanup deletes the forwarder, vm.HasStashedDbs
+        // will still read correctly but bindings observing the host
+        // VM's PropertyChanged will silently stop repainting.
+        var env = new ActiveSetTestBuilder()
+            .WithAnchor("flat-db.xml")
+            .WithPeer("nested-struct-db.xml")
+            .WithPendingEditsOn("NestedStructDB", count: 1)
+            .WithPromptResults(YesNoCancelResult.No)
+            .Build();
+        var changedProps = new List<string?>();
+        ((INotifyPropertyChanged)env.Vm).PropertyChanged += (_, e) => changedProps.Add(e.PropertyName);
+
+        env.Vm.OpenDataBlocksDropdownCommand.Execute(null);
+        var peerRow = env.Vm.FilteredDataBlockItems.First(i => i.Name == "NestedStructDB");
+        peerRow.IsActive = false;
+
+        env.Vm.HasStashedDbs.Should().BeTrue("setup: stash created");
+        changedProps.Should().Contain(nameof(BulkChangeViewModel.HasStashedDbs),
+            "the binding cannot repaint without this notification on the host VM");
     }
 
     [Fact]

--- a/src/BlockParam/UI/ActiveSetState.cs
+++ b/src/BlockParam/UI/ActiveSetState.cs
@@ -5,12 +5,13 @@ namespace BlockParam.UI;
 /// <summary>
 /// Immutable snapshot of the dialog's active-DB set + interlocked state
 /// (#78). Every mutation that touches the active set, the per-DB stash
-/// dictionary, or the anchor PLC builds a new snapshot and assigns it
-/// to <see cref="BulkChangeViewModel.State"/>. The setter is the single
-/// source of cascade — <c>RebuildAfterActiveSetChanged</c> /
-/// <c>SyncStashedDbsCollection</c> / anchor-display refresh are only
-/// called from <c>OnActiveSetChanged</c>, so forgetting to refresh after
-/// a mutation is structurally impossible.
+/// dictionary, or the anchor PLC builds a new snapshot and installs it
+/// via <see cref="ActiveSetViewModel.SetState"/> (slice 8a). The slice
+/// re-mirrors <c>StashedDbs</c> internally and raises
+/// <see cref="ActiveSetViewModel.StateChanged"/>; the host's
+/// <c>HandleActiveSetStateChanged</c> runs the cross-slice cascade
+/// (<c>RebuildAfterActiveSetChanged</c> + anchor-display refresh), so
+/// forgetting to refresh after a mutation is structurally impossible.
 ///
 /// <para>
 /// Compound mutations (solo, reactivate-then-solo) build the new snapshot

--- a/src/BlockParam/UI/ActiveSetState.cs
+++ b/src/BlockParam/UI/ActiveSetState.cs
@@ -14,10 +14,12 @@ namespace BlockParam.UI;
 /// forgetting to refresh after a mutation is structurally impossible.
 ///
 /// <para>
-/// Compound mutations (solo, reactivate-then-solo) build the new snapshot
-/// in locals and assign once → exactly one cascade per user gesture,
-/// regardless of how many DBs were swapped in or out. Cancellation =
-/// don't assign; the dialog stays on the previous snapshot.
+/// Compound mutations (solo, reactivate-then-solo) build the new
+/// snapshot in locals and install once via
+/// <see cref="ActiveSetViewModel.SetState"/> → exactly one cascade
+/// per user gesture, regardless of how many DBs were swapped in or
+/// out. Cancellation = don't call SetState; the dialog stays on the
+/// previous snapshot.
 /// </para>
 ///
 /// <para>

--- a/src/BlockParam/UI/ActiveSetViewModel.cs
+++ b/src/BlockParam/UI/ActiveSetViewModel.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace BlockParam.UI;
+
+/// <summary>
+/// State container for the dialog's active-DB set (#80 slice 8a).
+/// Owns the <see cref="ActiveSetState"/> snapshot and the bound
+/// <see cref="StashedDbs"/> collection. Mutators (Add / Solo / Remove /
+/// Reactivate) still live on the host in 8a — they call
+/// <see cref="SetState"/> to swap snapshots. Slice 8b will move the
+/// mutators + DB-switcher + PlcPills in.
+///
+/// <para>
+/// <see cref="SetState"/> raises <see cref="StateChanged"/> with the
+/// (old, new) pair so the host's cross-slice cascade (tree rebuild,
+/// selection clear, filter pass, pill rebuild, anchor-display refresh)
+/// runs exactly once per snapshot change. <see cref="StashedDbs"/> is
+/// re-mirrored from the new snapshot internally — the host doesn't
+/// need a second copy.
+/// </para>
+/// </summary>
+public sealed class ActiveSetViewModel : ViewModelBase
+{
+    private ActiveSetState _state;
+
+    public ActiveSetViewModel(ActiveSetState initial)
+    {
+        _state = initial ?? throw new ArgumentNullException(nameof(initial));
+        StashedDbs = new ObservableCollection<StashedDbState>();
+        SyncStashedDbsCollection();
+    }
+
+    /// <summary>
+    /// Current snapshot. Read-only from outside; install a new one via
+    /// <see cref="SetState"/>.
+    /// </summary>
+    public ActiveSetState State => _state;
+
+    /// <summary>
+    /// Stash entries displayed in the inspector. Mirrors
+    /// <c>State.Stashes</c>, sorted by (FolderPath, DbName) for a
+    /// stable display order across snapshot swaps.
+    /// </summary>
+    public ObservableCollection<StashedDbState> StashedDbs { get; }
+
+    public bool HasStashedDbs => StashedDbs.Count > 0;
+
+    /// <summary>
+    /// Raised after a new snapshot is installed. (old, new) lets
+    /// subscribers diff with reference equality on <c>Dbs</c> /
+    /// <c>Stashes</c> to decide which cascade slices to run.
+    /// </summary>
+    public event Action<ActiveSetState, ActiveSetState>? StateChanged;
+
+    /// <summary>
+    /// Install a new snapshot. No-op when reference-equal to the current
+    /// one. Raises <see cref="StateChanged"/> only on actual change.
+    /// </summary>
+    public void SetState(ActiveSetState next)
+    {
+        if (next == null) throw new ArgumentNullException(nameof(next));
+        if (ReferenceEquals(_state, next)) return;
+
+        var old = _state;
+        _state = next;
+
+        if (!ReferenceEquals(old.Stashes, next.Stashes))
+            SyncStashedDbsCollection();
+
+        StateChanged?.Invoke(old, next);
+    }
+
+    private void SyncStashedDbsCollection()
+    {
+        StashedDbs.Clear();
+        foreach (var s in _state.Stashes.Values
+            .OrderBy(s => s.FolderPath, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(s => s.DbName, StringComparer.OrdinalIgnoreCase))
+        {
+            StashedDbs.Add(s);
+        }
+        OnPropertyChanged(nameof(HasStashedDbs));
+    }
+}

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -1296,8 +1296,8 @@
                                  Cancel prompt for the now-current DB first).
                                  ========================================================= -->
                             <ItemsControl x:Name="StashedDbsList"
-                                          ItemsSource="{Binding StashedDbs}"
-                                          Visibility="{Binding HasStashedDbs, Converter={StaticResource BoolToVis}}">
+                                          ItemsSource="{Binding ActiveSet.StashedDbs}"
+                                          Visibility="{Binding ActiveSet.HasStashedDbs, Converter={StaticResource BoolToVis}}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
                                         <StackPanel>

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -461,14 +461,18 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// pending edits (#59). Each entry renders as its own inspector section
     /// so the staged work stays visible across switches; clicking the section
     /// header switches back to that DB (running the same prompt again).
-    /// </summary>
-    /// <summary>
+    ///
+    /// <para>
     /// Delegator for <see cref="ActiveSetViewModel.StashedDbs"/> (slice 8a).
-    /// XAML still binds to <c>{Binding StashedDbs}</c> on the host; the
-    /// rebind to <c>ActiveSet.StashedDbs</c> ships in slice 9. The
-    /// underlying collection instance is stable — the slice mutates it
-    /// in place via <c>Clear()</c> + <c>Add()</c> — so the binding's
-    /// ItemsControl observes the same `INotifyCollectionChanged` source.
+    /// XAML rebound to <c>{Binding ActiveSet.StashedDbs}</c> in the same
+    /// PR; the host delegator stays for non-XAML readers
+    /// (<see cref="BulkChangeDialog"/> code-behind, tests, DevLauncher)
+    /// and is dropped in slice 9. The underlying collection instance is
+    /// stable — the slice mutates it in place via <c>Clear()</c> +
+    /// <c>Add()</c> — so any subscriber observing
+    /// <c>INotifyCollectionChanged</c> sees the same source across
+    /// snapshots.
+    /// </para>
     /// </summary>
     public ObservableCollection<StashedDbState> StashedDbs => ActiveSet.StashedDbs;
 

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -24,13 +24,18 @@ namespace BlockParam.UI;
 /// ListView/GridView.
 ///
 /// <para>
-/// <b>Active-set state model (#78).</b> The dialog's active DBs +
-/// per-DB pending-edit stashes + anchor PLC name are bundled into a
-/// single immutable <see cref="ActiveSetState"/> snapshot exposed via
-/// <see cref="State"/>. The setter is the one place that runs
-/// <c>RebuildAfterActiveSetChanged</c>, <c>SyncStashedDbsCollection</c>
-/// and the anchor-PLC display refresh — every mutation gesture funnels
-/// through it, so forgetting to refresh after a change is structurally
+/// <b>Active-set state model (#78, slice 8a).</b> The dialog's active
+/// DBs + per-DB pending-edit stashes + anchor PLC name are bundled
+/// into a single immutable <see cref="ActiveSetState"/> snapshot
+/// owned by the <see cref="ActiveSetViewModel"/> slice (exposed as
+/// <see cref="ActiveSet"/>). Mutators call
+/// <see cref="ActiveSetViewModel.SetState"/>; the slice raises
+/// <see cref="ActiveSetViewModel.StateChanged"/>, and the host's
+/// <see cref="HandleActiveSetStateChanged"/> runs the cross-slice
+/// cascade (<c>RebuildAfterActiveSetChanged</c> + anchor-PLC display
+/// refresh). <c>StashedDbs</c> sync now lives inside the slice, so
+/// every mutation gesture still funnels through a single point and
+/// forgetting to refresh after a change remains structurally
 /// impossible.
 /// </para>
 ///
@@ -119,17 +124,14 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     // keys dead) and on explicit DiscardAll.
     private readonly PendingEditStore _pendingEditStore = new();
 
-    // #78 snapshot: single immutable view of the active set + stashes +
-    // anchor PLC. The State setter is the one place that runs the cascade
-    // (RebuildAfterActiveSetChanged / SyncStashedDbsCollection / anchor
-    // PLC display) so every mutation gesture goes through one funnel.
-    // Single authoritative storage: every reader walks State.X directly
-    // (slice 8 PR 0 deleted the legacy backing fields).
-    private ActiveSetState _state =
-        new ActiveSetState(
-            new List<ActiveDb>(),
-            new Dictionary<string, StashedDbState>(),
-            "");
+    // Active-set state container (#80 slice 8a). Owns the ActiveSetState
+    // snapshot + the bound StashedDbs collection. Mutators (Add / Solo /
+    // Remove / Reactivate) still live on this VM in 8a — they call
+    // ActiveSet.SetState(...) to swap snapshots. Slice 8b moves them in.
+    // Host subscribes to ActiveSet.StateChanged (wired in constructor) to
+    // drive the cross-slice cascade (tree rebuild, selection clear,
+    // anchor display, title refresh).
+    public ActiveSetViewModel ActiveSet { get; }
     // Selection.SelectedFlatMember, Selection.SelectedScope, _manualSelectedPaths moved to
     // SelectionScopeViewModel slice (#80 slice 7b). Host accesses via
     // Selection.SelectedFlatMember / SelectedScope / ManualSelectedPaths.
@@ -186,19 +188,27 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         _projectLanguages = projectLanguages is { Count: > 0 } ? projectLanguages : new[] { "en-GB" };
         _commentLanguagePolicy = new CommentLanguagePolicy(editingLanguage, referenceLanguage, _projectLanguages);
 
-        // Seed the active-set snapshot first so everything below can read
-        // through State.X (slice 8 PR 0). Direct backing-field assignment —
-        // the State setter's cascade isn't safe to fire here because
-        // RootMembers / StashedDbs collections aren't constructed yet; the
-        // constructor's explicit BuildRootMembersFromActiveDbs /
-        // RebuildPlcPills calls below take its place for the initial build.
+        // Seed the active-set slice first so everything below can read
+        // through State.X / ActiveSet.X (slice 8a). Subscribe to
+        // StateChanged in the same step so any mutation that fires before
+        // the constructor's explicit BuildRootMembersFromActiveDbs /
+        // RebuildPlcPills calls below would still cascade correctly.
         var initialDbs = new List<ActiveDb> { new ActiveDb(dataBlockInfo, currentXml, onApply) };
         if (additionalActiveDbs != null)
             initialDbs.AddRange(additionalActiveDbs);
-        _state = new ActiveSetState(
+        ActiveSet = new ActiveSetViewModel(new ActiveSetState(
             initialDbs,
             new Dictionary<string, StashedDbState>(),
-            currentPlcName ?? "");
+            currentPlcName ?? ""));
+        ActiveSet.StateChanged += HandleActiveSetStateChanged;
+        ActiveSet.PropertyChanged += (_, e) =>
+        {
+            // Forward the slice's derived-property notifications to the
+            // host's delegating wrappers so XAML still bound to
+            // `{Binding HasStashedDbs}` repaints. Rebind in slice 9.
+            if (e.PropertyName == nameof(ActiveSetViewModel.HasStashedDbs))
+                OnPropertyChanged(nameof(HasStashedDbs));
+        };
 
         _analyzer = analyzer;
         _bulkChangeService = bulkChangeService;
@@ -267,7 +277,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // call sites mutate it directly to make moving it worth the churn
         // in this PR. The slice owns only the visible collections + badges.
         Pending = new PendingEditsViewModel(() => _pendingEditStore.Count);
-        StashedDbs = new ObservableCollection<StashedDbState>();
 
         // Tree-shape + flat-list + expand/collapse slice (#80 slice 7a).
         // Multi-DB workflow (#58): when more than one DB is active, every
@@ -348,44 +357,36 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
     /// <summary>
     /// Current snapshot of the active-DB set + interlocked state (#78).
-    /// Every mutation goes through the setter, which is the single point
-    /// that runs <see cref="RebuildAfterActiveSetChanged"/> /
-    /// <see cref="SyncStashedDbsCollection"/> / anchor-display refresh.
+    /// Delegator for <see cref="ActiveSet"/>.<see cref="ActiveSetViewModel.State"/>;
+    /// mutators call <see cref="ActiveSetViewModel.SetState"/> directly.
+    /// The host runs the cross-slice cascade
+    /// (<see cref="RebuildAfterActiveSetChanged"/> + anchor-display
+    /// refresh) via <see cref="HandleActiveSetStateChanged"/>, which is
+    /// subscribed to <see cref="ActiveSetViewModel.StateChanged"/> in
+    /// the constructor.
     /// </summary>
-    public ActiveSetState State
-    {
-        get => _state;
-        private set
-        {
-            if (ReferenceEquals(_state, value)) return;
-            var old = _state;
-            _state = value;
-
-            // CurrentPlcName / HasCurrentPlcName are derived from
-            // State.AnchorPlcName; re-raise them only on actual change.
-            if (!string.Equals(old.AnchorPlcName, value.AnchorPlcName, StringComparison.Ordinal))
-            {
-                OnPropertyChanged(nameof(CurrentPlcName));
-                OnPropertyChanged(nameof(HasCurrentPlcName));
-            }
-
-            OnActiveSetChanged(old, value);
-        }
-    }
+    public ActiveSetState State => ActiveSet.State;
 
     /// <summary>
-    /// Diff old vs new snapshot and run only the cascade slices that
-    /// actually changed. Reference equality on Dbs / Stashes works because
-    /// every mutator constructs fresh List / Dictionary instances —
+    /// Handler for <see cref="ActiveSetViewModel.StateChanged"/>. Diffs old
+    /// vs new snapshot and runs only the cascade slices that actually
+    /// changed. Reference equality on <c>Dbs</c> / <c>Stashes</c> works
+    /// because every mutator constructs fresh List / Dictionary instances —
     /// "same instance" implies "no change."
     /// </summary>
-    private void OnActiveSetChanged(ActiveSetState old, ActiveSetState now)
+    private void HandleActiveSetStateChanged(ActiveSetState old, ActiveSetState now)
     {
+        // CurrentPlcName / HasCurrentPlcName are derived from
+        // State.AnchorPlcName; re-raise them only on actual change.
+        if (!string.Equals(old.AnchorPlcName, now.AnchorPlcName, StringComparison.Ordinal))
+        {
+            OnPropertyChanged(nameof(CurrentPlcName));
+            OnPropertyChanged(nameof(HasCurrentPlcName));
+        }
+
         bool dbsChanged = !ReferenceEquals(old.Dbs, now.Dbs);
-        bool stashesChanged = !ReferenceEquals(old.Stashes, now.Stashes);
 
         if (dbsChanged) RebuildAfterActiveSetChanged();
-        if (stashesChanged) SyncStashedDbsCollection();
         OnPropertyChanged(nameof(HasMultipleActiveDbs));
 
         // #91 — every cascade that changes the active set must refresh the
@@ -461,9 +462,17 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// so the staged work stays visible across switches; clicking the section
     /// header switches back to that DB (running the same prompt again).
     /// </summary>
-    public ObservableCollection<StashedDbState> StashedDbs { get; }
+    /// <summary>
+    /// Delegator for <see cref="ActiveSetViewModel.StashedDbs"/> (slice 8a).
+    /// XAML still binds to <c>{Binding StashedDbs}</c> on the host; the
+    /// rebind to <c>ActiveSet.StashedDbs</c> ships in slice 9. The
+    /// underlying collection instance is stable — the slice mutates it
+    /// in place via <c>Clear()</c> + <c>Add()</c> — so the binding's
+    /// ItemsControl observes the same `INotifyCollectionChanged` source.
+    /// </summary>
+    public ObservableCollection<StashedDbState> StashedDbs => ActiveSet.StashedDbs;
 
-    public bool HasStashedDbs => StashedDbs.Count > 0;
+    public bool HasStashedDbs => ActiveSet.HasStashedDbs;
 
     public event Action? RequestClose;
 
@@ -1140,7 +1149,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             RefreshFilteredDataBlockItemsActiveState();
             return;
         }
-        State = State.With(dbs: State.Dbs.Concat(new[] { built }).ToList());
+        ActiveSet.SetState(State.With(dbs: State.Dbs.Concat(new[] { built }).ToList()));
         Log.Information("DB enabled via dropdown: {Name}", built.Info.Name);
     }
 
@@ -1201,7 +1210,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             return;
         }
 
-        State = next;
+        ActiveSet.SetState(next);
         IsDataBlocksDropdownOpen = false;
     }
 
@@ -1224,7 +1233,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             return;
         }
 
-        State = ComposeRemoveOthers(State, target);
+        ActiveSet.SetState(ComposeRemoveOthers(State, target));
     }
 
     /// <summary>
@@ -1329,7 +1338,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             next = next.With(stashes: stashesNew);
         }
 
-        State = next;
+        ActiveSet.SetState(next);
 
         // Replay the stash edits onto the now-final live tree. Runs after
         // State assignment so the cascade has already rebuilt RootMembers
@@ -1358,9 +1367,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         var stashesNew = State.Stashes.ToDictionary(kv => kv.Key, kv => kv.Value);
         stashesNew.Remove(StashKey(summary));
-        State = State.With(
+        ActiveSet.SetState(State.With(
             dbs: State.Dbs.Concat(new[] { built }).ToList(),
-            stashes: stashesNew);
+            stashes: stashesNew));
 
         // Multi-DB shape after additive add — scope the path lookup to the
         // just-added DB's subtree so peer DBs with colliding member paths
@@ -1508,7 +1517,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     {
         var built = BuildActiveDbFromSummary(summary);
         if (built == null) return;
-        State = State.With(dbs: State.Dbs.Concat(new[] { built }).ToList());
+        ActiveSet.SetState(State.With(dbs: State.Dbs.Concat(new[] { built }).ToList()));
         Log.Information("DB enabled via dropdown: {Name}", built.Info.Name);
     }
 
@@ -1693,7 +1702,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     {
         var next = TryComputeRemove(State, db);
         if (next == null) return false;
-        State = next;
+        ActiveSet.SetState(next);
         return true;
     }
 
@@ -1932,18 +1941,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         return (restored, dropped);
     }
 
-    /// <summary>Mirrors the dictionary into the bound <see cref="StashedDbs"/> collection.</summary>
-    private void SyncStashedDbsCollection()
-    {
-        StashedDbs.Clear();
-        foreach (var state in State.Stashes.Values
-            .OrderBy(s => s.FolderPath, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(s => s.DbName, StringComparer.OrdinalIgnoreCase))
-        {
-            StashedDbs.Add(state);
-        }
-        OnPropertyChanged(nameof(HasStashedDbs));
-    }
+    // SyncStashedDbsCollection moved to ActiveSetViewModel (#80 slice 8a);
+    // ActiveSet.SetState mirrors State.Stashes into the bound collection
+    // automatically on every snapshot change.
 
     /// <summary>
     /// Inspector-panel expand/collapse state (#80 slice 1).


### PR DESCRIPTION
## Summary

First half of slice 8 from #80 (the user picked the 8a + 8b split
to keep each PR's review surface focused — slice 8 was flagged as
high-risk, ~700–900 LOC moving). Slice 8a extracts only the
**state container**: snapshot storage + bound `StashedDbs`
collection + the `StateChanged` event. Mutators (Add/Solo/Remove/
Reactivate/TryComputeRemove) stay on the host for now. Slice 8b
will move them + DB-switcher + PlcPills.

### What moves to `ActiveSetViewModel` (new, ~85 LOC)

- `ActiveSetState _state` snapshot field + `State` read-only property.
- `StashedDbs` ObservableCollection — mirrors `State.Stashes`,
  sorted by (FolderPath, DbName) for stable display order across
  snapshot swaps.
- `SyncStashedDbsCollection` (private to the slice).
- `HasStashedDbs` property + PropertyChanged.
- **`StateChanged(old, new)` event** — the cross-slice cascade hook.

### Host changes

- New `public ActiveSetViewModel ActiveSet { get; }`, constructed
  right after `_dispatcher` / `_projectLanguages` /
  `_commentLanguagePolicy` with the same initial snapshot the old
  `_state` seed used.
- Constructor subscribes to `ActiveSet.StateChanged` →
  `HandleActiveSetStateChanged` (renamed from `OnActiveSetChanged`),
  which now also re-raises `CurrentPlcName` / `HasCurrentPlcName`
  on anchor-PLC changes (previously done inline in the State setter).
- Constructor forwards `ActiveSet.PropertyChanged(HasStashedDbs)` to
  the host's `HasStashedDbs` delegator so any external subscriber
  filtering host PropertyChanged on that name still sees notifies
  during the 8a transition (rebound in slice 9).
- `State` is now a delegator: `=> ActiveSet.State`. The setter is
  gone — 7 mutator sites switched from `State = ...` to
  `ActiveSet.SetState(...)`.
- `StashedDbs` / `HasStashedDbs` are delegators (`=> ActiveSet.X`).
  The bound collection instance is stable across snapshots — the
  slice mutates it in place via `Clear()` + `Add()`, not by
  replacing the collection.
- Host's `SyncStashedDbsCollection` removed; slice owns the mirror.
- Stash-sync from `OnActiveSetChanged` removed (slice does it
  internally when `State.Stashes` reference changes).

### XAML

- `{Binding StashedDbs}` → `{Binding ActiveSet.StashedDbs}`
- `{Binding HasStashedDbs}` → `{Binding ActiveSet.HasStashedDbs}`

(Same XAML-rebind pattern slices 1–7 followed; the host delegators
remain so the ~107 test/launcher sites that touch this surface
don't churn until slice 9.)

### Tests

New `ActiveSetViewModelTests` (12 facts). The contracts under test:

- `SetState` swaps the snapshot and raises `StateChanged(old, new)`
  with the **previous** snapshot, not the new one twice.
- `SetState` with a reference-equal snapshot is a no-op (no event,
  no `StashedDbs` churn).
- `StashedDbs` mirror is rebuilt **only** when the `Stashes`
  dictionary reference changed — a Dbs-only mutation (Add / Solo /
  Remove without stash impact) doesn't perturb the bound
  collection or fire `HasStashedDbs` PropertyChanged.
- `StashedDbs` entries sorted (FolderPath, DbName) so display order
  is stable across snapshot swaps.
- `HasStashedDbs` tracks the mirror count and raises
  PropertyChanged when it flips empty ↔ non-empty.
- `StashedDbs` collection **instance** is stable across snapshots
  (guards against a future "set StashedDbs = new …()" regression
  that would silently break ItemsControl bindings).

### Numbers

- New slice file: **87 LOC** (`ActiveSetViewModel.cs`).
- New tests: **270 LOC** (`ActiveSetViewModelTests.cs`).
- Host: **4,131 → 4,131 LOC**. Delegators offset the deletions —
  the structural win is that state + sync now lives in a focused
  87-LOC class with its own test surface, not buried 350 lines into
  a 4,131-line god class.

### Next

Slice 8b moves the mutators (`AddActiveDb*` / `SoloActiveDb` /
`RequestRemoveActiveDb` / `TryComputeRemove` / `ReactivateStashed*`)
+ DB-switcher (`IsDataBlocksDropdownOpen`, `FilteredDataBlocks`,
the 4 commands) + `PlcPills` (`RebuildPlcPills`, `LoadDbsForPlcAsync`,
`GetActiveItemsForPlc`) into the slice. Host becomes a thin
orchestrator. Slice 9 then drops the delegators.

## Test plan

- [ ] CI `Build & Test (V20, net48)` green — includes the new
      `ActiveSetViewModelTests`
- [ ] CI `Build (V21, net48)` green
- [ ] All existing host VM tests (regression / invariant / multi-DB /
      db-switcher / 7a / 7b) pass unchanged — host delegators keep
      `vm.State` / `vm.StashedDbs` / `vm.HasStashedDbs` working

Refs #80.

https://claude.ai/code/session_0168J7dK7tApviBaDquX6gUd

---
_Generated by [Claude Code](https://claude.ai/code/session_0168J7dK7tApviBaDquX6gUd)_