### PR TITLE
refactor(#80): extract ActiveSetViewModel mutators + DB-switcher + PlcPills (slice 8b)

### DIFF
--- a/src/BlockParam.Tests/ActiveSetViewModelMutatorTests.cs
+++ b/src/BlockParam.Tests/ActiveSetViewModelMutatorTests.cs
@@ -1,0 +1,509 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BlockParam.Models;
+using BlockParam.UI;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Focused tests for the active-set mutators that moved off the host VM
+/// into <see cref="ActiveSetViewModel"/> in #80 slice 8b. The slice now
+/// owns:
+///
+/// <list type="bullet">
+///   <item>Add / Solo / Remove / Reactivate mutator paths;</item>
+///   <item>DB-switcher dropdown state + commands;</item>
+///   <item>PLC-pill row + rebuild + "+ PLC" affordance state.</item>
+/// </list>
+///
+/// Host-side side effects (apply-in-place on remove, replay stashed edits
+/// onto the live tree) are still host territory — they're wired through
+/// callbacks. These tests stub those callbacks with NSubstitute / inline
+/// delegates so the snapshot composition can be exercised in isolation.
+///
+/// The slice-8a tests in <see cref="ActiveSetViewModelTests"/> use the
+/// no-arg-ish <c>new ActiveSetViewModel(initial)</c> ctor and validate
+/// the snapshot-container contract; this file uses the richer ctor and
+/// validates the mutators. Both ctors share the same state container.
+/// </summary>
+public class ActiveSetViewModelMutatorTests
+{
+    [Fact]
+    public void AddActiveDbFromSummary_AppendsBuiltDbAndRaisesStateChanged()
+    {
+        var anchor = Db("Anchor");
+        var added = Db("Added");
+        var harness = new Harness(Snap(anchor))
+            .WithBuildActiveDbForSummary(s => string.Equals(s.Name, "Added") ? added : null);
+
+        ActiveSetState? captOld = null, captNew = null;
+        harness.Vm.StateChanged += (o, n) => { captOld = o; captNew = n; };
+
+        harness.Vm.AddActiveDbFromSummary(new DataBlockSummary("Added", ""));
+
+        captOld.Should().NotBeNull();
+        captNew.Should().NotBeNull();
+        captNew!.Dbs.Should().HaveCount(2);
+        captNew.Dbs.Last().Should().BeSameAs(added);
+        harness.Vm.State.Dbs.Should().HaveCount(2);
+        harness.Vm.HasMultipleActiveDbs.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AddActiveDbFromSummary_BuilderReturnsNull_NoStateChange()
+    {
+        var anchor = Db("Anchor");
+        var harness = new Harness(Snap(anchor))
+            .WithBuildActiveDbForSummary(_ => null);
+
+        int events = 0;
+        harness.Vm.StateChanged += (_, _) => events++;
+
+        harness.Vm.AddActiveDbFromSummary(new DataBlockSummary("NotBuildable", ""));
+
+        events.Should().Be(0);
+        harness.Vm.State.Dbs.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void SoloActiveDb_TargetAlreadyActive_PrunesPeers()
+    {
+        var a = Db("A");
+        var b = Db("B");
+        var c = Db("C");
+        var harness = new Harness(Snap(a, b, c));
+
+        // No pending edits → PromptForPendingEditsOnRemove takes the NoEdits
+        // fast path and no message-box call is needed.
+        harness.Vm.SoloActiveDb(new DataBlockSummary("B", ""));
+
+        harness.Vm.State.Dbs.Should().ContainSingle().Which.Should().BeSameAs(b);
+    }
+
+    [Fact]
+    public void SoloActiveDb_TargetNotInSet_BuildsThenSolos()
+    {
+        var a = Db("A");
+        var b = Db("B");
+        var harness = new Harness(Snap(a))
+            .WithBuildActiveDbForSummary(s => string.Equals(s.Name, "B") ? b : null);
+
+        harness.Vm.SoloActiveDb(new DataBlockSummary("B", ""));
+
+        harness.Vm.State.Dbs.Should().ContainSingle().Which.Should().BeSameAs(b);
+    }
+
+    [Fact]
+    public void SoloActiveDbByReference_AlreadyOnly_NoOp()
+    {
+        var a = Db("A");
+        var harness = new Harness(Snap(a));
+        int events = 0;
+        harness.Vm.StateChanged += (_, _) => events++;
+
+        harness.Vm.SoloActiveDbByReference(a);
+
+        events.Should().Be(0);
+        harness.Vm.State.Dbs.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void RequestRemoveActiveDb_LastDb_Refused()
+    {
+        var a = Db("A");
+        var harness = new Harness(Snap(a));
+        int events = 0;
+        harness.Vm.StateChanged += (_, _) => events++;
+
+        harness.Vm.RequestRemoveActiveDb(a);
+
+        events.Should().Be(0);
+        harness.Vm.State.Dbs.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void RequestRemoveActiveDb_TwoDbs_NoPendingEdits_RemovesWithoutPrompt()
+    {
+        var a = Db("A");
+        var b = Db("B");
+        var mbx = Substitute.For<IMessageBoxService>();
+        var harness = new Harness(Snap(a, b)).WithMessageBox(mbx);
+
+        harness.Vm.RequestRemoveActiveDb(a);
+
+        harness.Vm.State.Dbs.Should().ContainSingle().Which.Should().BeSameAs(b);
+        // No prompt because no pending edits exist for the DB being removed.
+        mbx.DidNotReceive().AskApplyStashCancel(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public void RequestRemoveActiveDb_WithPendingEdits_PromptStash_InstallsSnapshotWithStash()
+    {
+        var a = Db("A");
+        var b = Db("B");
+        var node = new MemberNode(
+            name: "Leaf", datatype: "Int", startValue: "0", path: "Leaf",
+            parent: null, children: Array.Empty<MemberNode>());
+        var modelToDb = new Dictionary<MemberNode, ActiveDb> { [node] = a };
+        var store = new PendingEditStore();
+        store.Set(node, "42");
+
+        var mbx = Substitute.For<IMessageBoxService>();
+        mbx.AskApplyStashCancel(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(ApplyStashCancelResult.StashAndSwitch);
+
+        var harness = new Harness(Snap(a, b))
+            .WithMessageBox(mbx)
+            .WithPendingStore(store, () => modelToDb);
+
+        harness.Vm.RequestRemoveActiveDb(a);
+
+        mbx.Received(1).AskApplyStashCancel(Arg.Any<string>(), Arg.Any<string>());
+        harness.Vm.State.Dbs.Should().ContainSingle().Which.Should().BeSameAs(b);
+        harness.Vm.State.Stashes.Should().HaveCount(1);
+        harness.Vm.StashedDbs.Should().ContainSingle()
+            .Which.DbName.Should().Be("A");
+        // Store entries for the stashed DB are evicted so the live tree
+        // doesn't keep the stale pending state.
+        store.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void RequestRemoveActiveDb_WithPendingEdits_PromptApply_CallsTryApplyCallback()
+    {
+        var a = Db("A");
+        var b = Db("B");
+        var node = new MemberNode(
+            name: "Leaf", datatype: "Int", startValue: "0", path: "Leaf",
+            parent: null, children: Array.Empty<MemberNode>());
+        var modelToDb = new Dictionary<MemberNode, ActiveDb> { [node] = a };
+        var store = new PendingEditStore();
+        store.Set(node, "42");
+
+        var mbx = Substitute.For<IMessageBoxService>();
+        mbx.AskApplyStashCancel(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(ApplyStashCancelResult.ApplyAndSwitch);
+
+        var applyCallback = Substitute.For<Func<ActiveDb, bool>>();
+        applyCallback(a).Returns(true);
+
+        var harness = new Harness(Snap(a, b))
+            .WithMessageBox(mbx)
+            .WithPendingStore(store, () => modelToDb)
+            .WithTryApply(applyCallback);
+
+        harness.Vm.RequestRemoveActiveDb(a);
+
+        applyCallback.Received(1)(a);
+        harness.Vm.State.Dbs.Should().ContainSingle().Which.Should().BeSameAs(b);
+        harness.Vm.State.Stashes.Should().BeEmpty(
+            "Apply path commits + removes; no stash created");
+    }
+
+    [Fact]
+    public void RequestRemoveActiveDb_WithPendingEdits_PromptCancel_LeavesStateUntouched()
+    {
+        var a = Db("A");
+        var b = Db("B");
+        var node = new MemberNode(
+            name: "Leaf", datatype: "Int", startValue: "0", path: "Leaf",
+            parent: null, children: Array.Empty<MemberNode>());
+        var modelToDb = new Dictionary<MemberNode, ActiveDb> { [node] = a };
+        var store = new PendingEditStore();
+        store.Set(node, "42");
+
+        var mbx = Substitute.For<IMessageBoxService>();
+        mbx.AskApplyStashCancel(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(ApplyStashCancelResult.Cancel);
+
+        var harness = new Harness(Snap(a, b))
+            .WithMessageBox(mbx)
+            .WithPendingStore(store, () => modelToDb);
+
+        var originalSnap = harness.Vm.State;
+        int events = 0;
+        harness.Vm.StateChanged += (_, _) => events++;
+
+        harness.Vm.RequestRemoveActiveDb(a);
+
+        events.Should().Be(0);
+        harness.Vm.State.Should().BeSameAs(originalSnap);
+        store.Count.Should().Be(1, "Cancel path preserves pending edits");
+    }
+
+    [Fact]
+    public void ReactivateStashedDb_SingleActiveDb_NoPromptFires()
+    {
+        // current.Dbs.Count < 2 → additive/replace prompt is skipped.
+        var anchor = Db("Anchor");
+        var stashedDb = Db("Stashed");
+        var stash = Stash("Stashed");
+        var initial = new ActiveSetState(
+            new[] { anchor },
+            new Dictionary<string, StashedDbState> { [KeyFor(stash.Summary)] = stash },
+            "");
+
+        var mbx = Substitute.For<IMessageBoxService>();
+        var restoreCallback = Substitute.For<Func<StashedDbState, ActiveDb?, (int, int)>>();
+        restoreCallback(Arg.Any<StashedDbState>(), Arg.Any<ActiveDb?>()).Returns((0, 0));
+
+        var harness = new Harness(initial)
+            .WithMessageBox(mbx)
+            .WithBuildActiveDbForSummary(s => string.Equals(s.Name, "Stashed") ? stashedDb : null)
+            .WithRestoreStashOntoLive(restoreCallback);
+
+        harness.Vm.ReactivateStashedDb(stash);
+
+        mbx.DidNotReceive().AskAddOrReplace(Arg.Any<string>(), Arg.Any<string>());
+        // Replace branch with single active → fresh DB appended, anchor pruned
+        // (no pending edits → NoEdits fast path), stash popped.
+        harness.Vm.State.Dbs.Should().ContainSingle().Which.Info.Name.Should().Be("Stashed");
+        harness.Vm.State.Stashes.Should().BeEmpty();
+        restoreCallback.Received(1)(stash, Arg.Any<ActiveDb?>());
+    }
+
+    [Fact]
+    public void ReactivateStashedDb_TwoActiveDbs_AddDecision_AppendsKeepsAll()
+    {
+        var anchor = Db("Anchor");
+        var peer = Db("Peer");
+        var stashedDb = Db("Stashed");
+        var stash = Stash("Stashed");
+        var initial = new ActiveSetState(
+            new[] { anchor, peer },
+            new Dictionary<string, StashedDbState> { [KeyFor(stash.Summary)] = stash },
+            "");
+
+        var mbx = Substitute.For<IMessageBoxService>();
+        mbx.AskAddOrReplace(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(AddOrReplaceResult.Add);
+
+        var restoreCallback = Substitute.For<Func<StashedDbState, ActiveDb?, (int, int)>>();
+        restoreCallback(Arg.Any<StashedDbState>(), Arg.Any<ActiveDb?>()).Returns((0, 0));
+
+        var harness = new Harness(initial)
+            .WithMessageBox(mbx)
+            .WithBuildActiveDbForSummary(s => string.Equals(s.Name, "Stashed") ? stashedDb : null)
+            .WithRestoreStashOntoLive(restoreCallback);
+
+        harness.Vm.ReactivateStashedDb(stash);
+
+        mbx.Received(1).AskAddOrReplace(Arg.Any<string>(), Arg.Any<string>());
+        harness.Vm.State.Dbs.Select(d => d.Info.Name)
+            .Should().BeEquivalentTo(new[] { "Anchor", "Peer", "Stashed" });
+        harness.Vm.State.Stashes.Should().BeEmpty();
+        // Scoped restore: the additive branch hands the just-built DB so peer
+        // DBs with colliding member paths don't absorb the stashed edits.
+        restoreCallback.Received(1)(stash, stashedDb);
+    }
+
+    [Fact]
+    public void ReactivateStashedDb_TwoActiveDbs_CancelDecision_NoStateChange()
+    {
+        var anchor = Db("Anchor");
+        var peer = Db("Peer");
+        var stash = Stash("Stashed");
+        var initial = new ActiveSetState(
+            new[] { anchor, peer },
+            new Dictionary<string, StashedDbState> { [KeyFor(stash.Summary)] = stash },
+            "");
+
+        var mbx = Substitute.For<IMessageBoxService>();
+        mbx.AskAddOrReplace(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(AddOrReplaceResult.Cancel);
+
+        var harness = new Harness(initial).WithMessageBox(mbx);
+        var originalSnap = harness.Vm.State;
+        int events = 0;
+        harness.Vm.StateChanged += (_, _) => events++;
+
+        harness.Vm.ReactivateStashedDb(stash);
+
+        events.Should().Be(0);
+        harness.Vm.State.Should().BeSameAs(originalSnap);
+    }
+
+    [Fact]
+    public void DataBlockSwitcher_OpenDropdown_LoadsAndFiltersAvailableList()
+    {
+        var available = new[]
+        {
+            new DataBlockSummary("Alpha", ""),
+            new DataBlockSummary("Beta", ""),
+        };
+        var harness = new Harness(Snap(Db("Anchor")))
+            .WithEnumerateDataBlocks(() => available)
+            .WithSwitchToDataBlock(_ => "<Block/>");
+
+        harness.Vm.OpenDataBlocksDropdownCommand.Execute(null);
+
+        harness.Vm.IsDataBlocksDropdownOpen.Should().BeTrue();
+        harness.Vm.FilteredDataBlocks.Should().HaveCount(2);
+        harness.Vm.HasDataBlockSwitcher.Should().BeTrue();
+    }
+
+    [Fact]
+    public void DataBlockSwitcher_FilterText_FiltersList()
+    {
+        var available = new[]
+        {
+            new DataBlockSummary("DB_Sensors", ""),
+            new DataBlockSummary("DB_Valves", ""),
+        };
+        var harness = new Harness(Snap(Db("Anchor")))
+            .WithEnumerateDataBlocks(() => available)
+            .WithSwitchToDataBlock(_ => "<Block/>");
+
+        harness.Vm.OpenDataBlocksDropdownCommand.Execute(null);
+        harness.Vm.DataBlockSearchText = "Sensors";
+
+        harness.Vm.FilteredDataBlocks.Should().ContainSingle()
+            .Which.Name.Should().Be("DB_Sensors");
+    }
+
+    [Fact]
+    public void DataBlockSwitcher_Refresh_ReEnumeratesAndCachesAgain()
+    {
+        int callCount = 0;
+        var harness = new Harness(Snap(Db("Anchor")))
+            .WithEnumerateDataBlocks(() =>
+            {
+                callCount++;
+                return new[] { new DataBlockSummary("X", "") };
+            })
+            .WithSwitchToDataBlock(_ => "<Block/>");
+
+        harness.Vm.OpenDataBlocksDropdownCommand.Execute(null);
+        harness.Vm.OpenDataBlocksDropdownCommand.Execute(null); // cache hit
+        callCount.Should().Be(1);
+
+        harness.Vm.RefreshDataBlocksCommand.Execute(null);
+        callCount.Should().Be(2, "Refresh forces re-enumeration");
+    }
+
+    [Fact]
+    public void PlcPills_RebuildAfterSetState_OnePillPerActivePlc()
+    {
+        var anchor = Db("DB_A", plc: "PLC_1");
+        var peer = Db("DB_B", plc: "PLC_2");
+        var harness = new Harness(new ActiveSetState(
+            new[] { anchor, peer },
+            new Dictionary<string, StashedDbState>(),
+            anchorPlcName: "PLC_1"));
+
+        harness.Vm.RebuildPlcPills();
+
+        harness.Vm.PlcPills.Should().HaveCount(2);
+        harness.Vm.PlcPills.Select(p => p.PlcName)
+            .Should().BeEquivalentTo(new[] { "PLC_1", "PLC_2" });
+    }
+
+    [Fact]
+    public void NoIsSameSummaryReferenceInSlice()
+    {
+        // Dead-code guard: the helper had zero callers in src/ and is dropped
+        // in this slice. Catches a future re-introduction (and points the
+        // author at this test for the rationale).
+        var sliceSource = System.IO.File.ReadAllText(
+            System.IO.Path.Combine(
+                FindRepoRoot(),
+                "src", "BlockParam", "UI", "ActiveSetViewModel.cs"));
+        sliceSource.Should().NotContain("IsSameSummary");
+    }
+
+    private static string FindRepoRoot()
+    {
+        // Tests run from BlockParam.Tests\bin\<config>\<tfm>; the repo root
+        // is up four levels. Walk up looking for the .csproj marker so the
+        // test stays robust across CI vs local layouts.
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 10 && dir != null; i++)
+        {
+            if (System.IO.File.Exists(System.IO.Path.Combine(dir, "BlockParam.sln")))
+                return dir;
+            dir = System.IO.Path.GetDirectoryName(dir);
+        }
+        throw new InvalidOperationException("Could not locate repo root from " + AppContext.BaseDirectory);
+    }
+
+    // ---------- helpers ----------
+
+    private static ActiveSetState Snap(params ActiveDb[] dbs)
+        => new ActiveSetState(
+            dbs,
+            new Dictionary<string, StashedDbState>(),
+            "");
+
+    private static ActiveDb Db(string name, string plc = "")
+    {
+        var info = new DataBlockInfo(name, 1, "Optimized", "GlobalDB", Array.Empty<MemberNode>());
+        return new ActiveDb(info, $"<Block name='{name}' />", onApply: null, plcName: plc);
+    }
+
+    private static StashedDbState Stash(string name, string folder = "")
+    {
+        var summary = new DataBlockSummary(name, folder, plcName: "", number: 1);
+        return new StashedDbState(summary, Array.Empty<StashedEditEntry>());
+    }
+
+    /// <summary>
+    /// Mirrors <c>ActiveSetViewModel.StashKey</c> (kept private). The
+    /// stash dictionary key the slice computes for a summary is
+    /// <c>{PlcName}{FolderPath}{Name}</c>. Tests that
+    /// pre-populate a stash entry by key need this so the slice can find
+    /// + pop the entry on <c>ReactivateStashedDb</c>.
+    /// </summary>
+    private static string KeyFor(DataBlockSummary s) =>
+        $"{s.PlcName}{s.FolderPath}{s.Name}";
+
+    /// <summary>
+    /// Builder-style harness so each test only wires the callbacks it needs.
+    /// Default config = pure state-container behavior (matches slice 8a).
+    /// Each <c>WithX</c> call rewires the slice with a richer set of deps
+    /// — the slice has no mutator state outside <see cref="ActiveSetState"/>,
+    /// so reconstructing per gesture is cheap and keeps the tests focused.
+    /// </summary>
+    private class Harness
+    {
+        private readonly ActiveSetState _initial;
+        private IMessageBoxService? _messageBox;
+        private PendingEditStore? _pendingEditStore;
+        private Func<IReadOnlyDictionary<MemberNode, ActiveDb>>? _getModelToDb;
+        private Func<DataBlockSummary, ActiveDb?>? _build;
+        private Func<IReadOnlyList<DataBlockSummary>>? _enumerate;
+        private Func<DataBlockSummary, string>? _switch;
+        private Func<ActiveDb, bool>? _tryApply;
+        private Func<StashedDbState, ActiveDb?, (int, int)>? _restore;
+        private ActiveSetViewModel? _vm;
+
+        public Harness(ActiveSetState initial) { _initial = initial; }
+
+        public ActiveSetViewModel Vm => _vm ??= new ActiveSetViewModel(
+            _initial,
+            messageBox: _messageBox,
+            pendingEditStore: _pendingEditStore,
+            getModelToDb: _getModelToDb,
+            getStartValueForNode: _ => null,
+            buildActiveDbForSummary: _build,
+            enumerateDataBlocks: _enumerate,
+            switchToDataBlock: _switch,
+            tryApplyActiveDbInPlace: _tryApply,
+            restoreStashOntoLive: _restore,
+            setStatus: _ => { },
+            getPendingCount: () => _pendingEditStore?.Count ?? 0,
+            dispatcher: null);
+
+        public Harness WithMessageBox(IMessageBoxService mbx) { _messageBox = mbx; return this; }
+        public Harness WithPendingStore(PendingEditStore store, Func<IReadOnlyDictionary<MemberNode, ActiveDb>> getModelToDb)
+        { _pendingEditStore = store; _getModelToDb = getModelToDb; return this; }
+        public Harness WithBuildActiveDbForSummary(Func<DataBlockSummary, ActiveDb?> build) { _build = build; return this; }
+        public Harness WithEnumerateDataBlocks(Func<IReadOnlyList<DataBlockSummary>> enumerate) { _enumerate = enumerate; return this; }
+        public Harness WithSwitchToDataBlock(Func<DataBlockSummary, string> sw) { _switch = sw; return this; }
+        public Harness WithTryApply(Func<ActiveDb, bool> tryApply) { _tryApply = tryApply; return this; }
+        public Harness WithRestoreStashOntoLive(Func<StashedDbState, ActiveDb?, (int, int)> restore) { _restore = restore; return this; }
+    }
+}

--- a/src/BlockParam/UI/ActiveSetViewModel.cs
+++ b/src/BlockParam/UI/ActiveSetViewModel.cs
@@ -2,16 +2,21 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using System.Windows.Threading;
+using BlockParam.Diagnostics;
+using BlockParam.Localization;
+using BlockParam.Models;
+using BlockParam.Services;
 
 namespace BlockParam.UI;
 
 /// <summary>
-/// State container for the dialog's active-DB set (#80 slice 8a).
-/// Owns the <see cref="ActiveSetState"/> snapshot and the bound
-/// <see cref="StashedDbs"/> collection. Mutators (Add / Solo / Remove /
-/// Reactivate) still live on the host in 8a — they call
-/// <see cref="SetState"/> to swap snapshots. Slice 8b will move the
-/// mutators + DB-switcher + PlcPills in.
+/// State container + mutators for the dialog's active-DB set
+/// (#80 slices 8a + 8b). Owns the <see cref="ActiveSetState"/> snapshot,
+/// the bound <see cref="StashedDbs"/> collection, the DB-switcher
+/// dropdown state, and the PLC-pill row.
 ///
 /// <para>
 /// <see cref="SetState"/> raises <see cref="StateChanged"/> with the
@@ -21,16 +26,135 @@ namespace BlockParam.UI;
 /// re-mirrored from the new snapshot internally — the host doesn't
 /// need a second copy.
 /// </para>
+///
+/// <para>
+/// Mutators (Add / Solo / Remove / Reactivate) compose the next
+/// snapshot in locals and assign once via <see cref="SetState"/>:
+/// exactly one cascade per user gesture regardless of how many DBs
+/// were swapped in or out. Operations with host-side side effects
+/// (Apply-in-place on remove, replay stashed edits onto the live tree)
+/// run through caller-supplied callbacks (<see cref="_tryApplyActiveDbInPlace"/>,
+/// <see cref="_restoreStashOntoLive"/>) so the slice never reaches
+/// into the host's <c>_writer</c> / <c>Tree</c> / <c>Subscription</c>.
+/// </para>
 /// </summary>
 public sealed class ActiveSetViewModel : ViewModelBase
 {
     private ActiveSetState _state;
 
+    // --- Optional dependencies (8b). All-null defaults keep the legacy
+    // ActiveSetViewModel(initial) ctor (used by slice-8a tests) working
+    // with reduced functionality: mutators that need a missing dep throw
+    // a clear InvalidOperationException, never NRE silently.
+    private readonly IMessageBoxService? _messageBox;
+    private readonly PendingEditStore? _pendingEditStore;
+    private readonly Func<IReadOnlyDictionary<MemberNode, ActiveDb>>? _getModelToDb;
+    private readonly Func<MemberNode, string?>? _getStartValueForNode;
+    private readonly Func<DataBlockSummary, ActiveDb?>? _buildActiveDbForSummary;
+    private readonly Func<IReadOnlyList<DataBlockSummary>>? _enumerateDataBlocks;
+    private readonly Func<DataBlockSummary, string>? _switchToDataBlock;
+    private readonly Func<ActiveDb, bool>? _tryApplyActiveDbInPlace;
+    private readonly Func<StashedDbState, ActiveDb?, (int restored, int dropped)>? _restoreStashOntoLive;
+    private readonly Action<string>? _setStatus;
+    private readonly Func<int>? _getPendingCount;
+
+    // --- DB-switcher dropdown state (#59) ---
+    private IReadOnlyList<DataBlockSummary>? _availableDataBlocks;
+    private IReadOnlyList<DataBlockSummary> _filteredDataBlocks = Array.Empty<DataBlockSummary>();
+    private IReadOnlyList<DataBlockListItem> _filteredDataBlockItems = Array.Empty<DataBlockListItem>();
+    private string _dataBlockSearchText = "";
+    private bool _isDataBlocksDropdownOpen;
+    private bool _isLoadingDataBlocks;
+
+    // --- Pill-row state ---
+    private readonly HashSet<string> _extraPillPlcs = new(StringComparer.Ordinal);
+    // Re-entrancy guard: when the cascade rewrites SelectedDbs on each pill,
+    // the pill fires SelectionChanged → OnPillSelectionChanged. Without the
+    // guard we'd enter AddActiveDbToSet / RemoveActiveDb for every item in
+    // the selection sync, spiraling into multiple cascades.
+    private bool _syncingPillSelection;
+    private bool _isAddDbPopupOpen;
+
+    /// <summary>
+    /// Legacy state-only constructor preserved for the slice-8a tests. The
+    /// slice operates as a pure snapshot container with no mutator wiring;
+    /// any call to a mutator method that needs an unwired dep throws
+    /// <see cref="InvalidOperationException"/>.
+    /// </summary>
     public ActiveSetViewModel(ActiveSetState initial)
+        : this(initial,
+            messageBox: null,
+            pendingEditStore: null,
+            getModelToDb: null,
+            getStartValueForNode: null,
+            buildActiveDbForSummary: null,
+            enumerateDataBlocks: null,
+            switchToDataBlock: null,
+            tryApplyActiveDbInPlace: null,
+            restoreStashOntoLive: null,
+            setStatus: null,
+            getPendingCount: null,
+            dispatcher: null)
+    {
+    }
+
+    /// <summary>
+    /// Full constructor. Host VM wires every callback; tests pass only
+    /// the dependencies their scenario needs and rely on the no-op /
+    /// throw defaults for the rest.
+    /// </summary>
+    public ActiveSetViewModel(
+        ActiveSetState initial,
+        IMessageBoxService? messageBox,
+        PendingEditStore? pendingEditStore,
+        Func<IReadOnlyDictionary<MemberNode, ActiveDb>>? getModelToDb,
+        Func<MemberNode, string?>? getStartValueForNode,
+        Func<DataBlockSummary, ActiveDb?>? buildActiveDbForSummary,
+        Func<IReadOnlyList<DataBlockSummary>>? enumerateDataBlocks,
+        Func<DataBlockSummary, string>? switchToDataBlock,
+        Func<ActiveDb, bool>? tryApplyActiveDbInPlace,
+        Func<StashedDbState, ActiveDb?, (int restored, int dropped)>? restoreStashOntoLive,
+        Action<string>? setStatus,
+        Func<int>? getPendingCount,
+        Dispatcher? dispatcher)
     {
         _state = initial ?? throw new ArgumentNullException(nameof(initial));
         StashedDbs = new ObservableCollection<StashedDbState>();
         SyncStashedDbsCollection();
+
+        _messageBox = messageBox;
+        _pendingEditStore = pendingEditStore;
+        _getModelToDb = getModelToDb;
+        _getStartValueForNode = getStartValueForNode;
+        _buildActiveDbForSummary = buildActiveDbForSummary;
+        _enumerateDataBlocks = enumerateDataBlocks;
+        _switchToDataBlock = switchToDataBlock;
+        _tryApplyActiveDbInPlace = tryApplyActiveDbInPlace;
+        _restoreStashOntoLive = restoreStashOntoLive;
+        _setStatus = setStatus;
+        _getPendingCount = getPendingCount;
+        _ = dispatcher; // reserved for LoadDbsForPlcAsync continuation if it ever goes off-thread
+
+        PlcPills = new ObservableCollection<PlcPillViewModel>();
+
+        OpenDataBlocksDropdownCommand = new RelayCommand(ExecuteOpenDataBlocksDropdown,
+            () => _enumerateDataBlocks != null && _switchToDataBlock != null);
+        CloseDataBlocksDropdownCommand = new RelayCommand(() =>
+        {
+            IsDataBlocksDropdownOpen = false;
+        });
+        RefreshDataBlocksCommand = new RelayCommand(ExecuteRefreshDataBlocks,
+            () => _enumerateDataBlocks != null && !_isLoadingDataBlocks);
+        SwitchToStashedDbCommand = new RelayCommand(parameter =>
+        {
+            // Peer model: clicking a stashed-DB header re-activates that DB
+            // by adding it back to the active set, then restoring its stash
+            // edits. The previous anchor stays — the user can remove it
+            // themselves if desired. Overwriting the anchor in place would
+            // destroy the user's other active DBs, which the legacy
+            // SwitchToDataBlock path did under the old single-DB model.
+            if (parameter is StashedDbState stash) ReactivateStashedDb(stash);
+        });
     }
 
     /// <summary>
@@ -47,6 +171,9 @@ public sealed class ActiveSetViewModel : ViewModelBase
     public ObservableCollection<StashedDbState> StashedDbs { get; }
 
     public bool HasStashedDbs => StashedDbs.Count > 0;
+
+    /// <summary>True when more than one DB is active in this session (#58).</summary>
+    public bool HasMultipleActiveDbs => _state.Dbs.Count > 1;
 
     /// <summary>
     /// Raised after a new snapshot is installed. (old, new) lets
@@ -70,6 +197,9 @@ public sealed class ActiveSetViewModel : ViewModelBase
         if (!ReferenceEquals(old.Stashes, next.Stashes))
             SyncStashedDbsCollection();
 
+        if (!ReferenceEquals(old.Dbs, next.Dbs))
+            OnPropertyChanged(nameof(HasMultipleActiveDbs));
+
         StateChanged?.Invoke(old, next);
     }
 
@@ -84,4 +214,937 @@ public sealed class ActiveSetViewModel : ViewModelBase
         }
         OnPropertyChanged(nameof(HasStashedDbs));
     }
+
+    // ===== DB-switcher dropdown (#59) =========================================
+
+    public ICommand OpenDataBlocksDropdownCommand { get; }
+    public ICommand CloseDataBlocksDropdownCommand { get; }
+    public ICommand RefreshDataBlocksCommand { get; }
+    public ICommand SwitchToStashedDbCommand { get; }
+
+    /// <summary>
+    /// True when the host wired up DB enumeration + switching callbacks.
+    /// The dropdown chevron / popup are hidden in tests + DevLauncher runs
+    /// where no project is available.
+    /// </summary>
+    public bool HasDataBlockSwitcher =>
+        _enumerateDataBlocks != null && _switchToDataBlock != null;
+
+    public bool IsDataBlocksDropdownOpen
+    {
+        get => _isDataBlocksDropdownOpen;
+        set => SetProperty(ref _isDataBlocksDropdownOpen, value);
+    }
+
+    public bool IsLoadingDataBlocks
+    {
+        get => _isLoadingDataBlocks;
+        private set
+        {
+            if (SetProperty(ref _isLoadingDataBlocks, value))
+                OnPropertyChanged(nameof(ShowEmptyDataBlocksMessage));
+        }
+    }
+
+    /// <summary>Filtered, alphabetised list shown inside the dropdown.</summary>
+    public IReadOnlyList<DataBlockSummary> FilteredDataBlocks
+    {
+        get => _filteredDataBlocks;
+        private set
+        {
+            if (SetProperty(ref _filteredDataBlocks, value))
+            {
+                OnPropertyChanged(nameof(ShowEmptyDataBlocksMessage));
+                RebuildFilteredDataBlockItems();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Multi-select dropdown rows (#58). Same membership and order as
+    /// <see cref="FilteredDataBlocks"/>; each row wraps the summary with a
+    /// transient IsActive flag that two-way binds to its checkbox.
+    /// </summary>
+    public IReadOnlyList<DataBlockListItem> FilteredDataBlockItems
+    {
+        get => _filteredDataBlockItems;
+        private set => SetProperty(ref _filteredDataBlockItems, value);
+    }
+
+    /// <summary>Type-to-filter text for the dropdown's search box.</summary>
+    public string DataBlockSearchText
+    {
+        get => _dataBlockSearchText;
+        set
+        {
+            if (SetProperty(ref _dataBlockSearchText, value))
+                ApplyDataBlockFilter();
+        }
+    }
+
+    /// <summary>True when enumeration is settled but the filter matches nothing.</summary>
+    public bool ShowEmptyDataBlocksMessage =>
+        !_isLoadingDataBlocks
+        && _availableDataBlocks != null
+        && _filteredDataBlocks.Count == 0;
+
+    private void ExecuteOpenDataBlocksDropdown()
+    {
+        if (_availableDataBlocks == null)
+            LoadAvailableDataBlocks(force: false);
+
+        ApplyDataBlockFilter();
+        IsDataBlocksDropdownOpen = true;
+    }
+
+    private void ExecuteRefreshDataBlocks()
+    {
+        LoadAvailableDataBlocks(force: true);
+        ApplyDataBlockFilter();
+    }
+
+    private void LoadAvailableDataBlocks(bool force)
+    {
+        if (_enumerateDataBlocks == null) return;
+        if (!force && _availableDataBlocks != null) return;
+
+        IsLoadingDataBlocks = true;
+        try
+        {
+            // Enumeration runs on the UI thread today: TIA Openness calls
+            // must originate from the same thread that owns the project.
+            // The visible spinner + the dialog's scoped scope keep this OK
+            // for typical project sizes; if it ever bites we'd move the
+            // enumeration onto a background task with a marshalled call.
+            _availableDataBlocks = DataBlockListFilter.Sort(_enumerateDataBlocks());
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "DB enumeration failed");
+            _availableDataBlocks = Array.Empty<DataBlockSummary>();
+            _setStatus?.Invoke(Res.Format("Status_DbEnumFailed", ex.Message));
+        }
+        finally
+        {
+            IsLoadingDataBlocks = false;
+        }
+    }
+
+    private void ApplyDataBlockFilter()
+    {
+        var source = _availableDataBlocks ?? (IReadOnlyList<DataBlockSummary>)Array.Empty<DataBlockSummary>();
+        FilteredDataBlocks = DataBlockListFilter.Filter(source, _dataBlockSearchText);
+    }
+
+    private void RebuildFilteredDataBlockItems()
+    {
+        var items = new List<DataBlockListItem>(_filteredDataBlocks.Count);
+        foreach (var summary in _filteredDataBlocks)
+        {
+            var (isActive, isAnchor) = GetActiveStatusFor(summary);
+            var item = new DataBlockListItem(summary, isActive, isAnchor);
+            item.ToggleRequested += OnDataBlockListItemToggled;
+            items.Add(item);
+        }
+        FilteredDataBlockItems = items;
+    }
+
+    /// <summary>
+    /// True/false pair for a row: (isActive: in the dialog's active set,
+    /// isAnchor: index 0 of the active set, used as the UI's display
+    /// anchor). isAnchor carries no privilege over removability — it just
+    /// tells the row template whether to render the anchor decoration.
+    /// </summary>
+    private (bool isActive, bool isAnchor) GetActiveStatusFor(DataBlockSummary summary)
+    {
+        // Match on (Name, PlcName) — multi-PLC projects can host two DBs
+        // with the same name on different PLCs (#58 review must-fix #4).
+        // For index 0 the PLC name comes from State.AnchorPlcName (display
+        // state); for the rest we read each ActiveDb.PlcName directly.
+        for (int i = 0; i < _state.Dbs.Count; i++)
+        {
+            var db = _state.Dbs[i];
+            var plc = i == 0 ? _state.AnchorPlcName : db.PlcName;
+            if (string.Equals(db.Info.Name, summary.Name, StringComparison.Ordinal)
+                && string.Equals(plc, summary.PlcName, StringComparison.Ordinal))
+                return (true, i == 0);
+        }
+        return (false, false);
+    }
+
+    /// <summary>
+    /// Pushes the current active-set state back into every existing row so
+    /// checkboxes stay accurate after the user toggles one (which mutates
+    /// the active set but doesn't rebuild the list).
+    /// </summary>
+    private void RefreshFilteredDataBlockItemsActiveState()
+    {
+        foreach (var item in _filteredDataBlockItems)
+        {
+            var (isActive, isAnchor) = GetActiveStatusFor(item.Summary);
+            item.SyncFrom(isActive, isAnchor);
+        }
+    }
+
+    private void OnDataBlockListItemToggled(DataBlockListItem item)
+    {
+        // The IsActive setter has already flipped to the new value. Peer
+        // model: checked → add to active set; unchecked → remove from active
+        // set, with the same Apply / Stash / Cancel prompt regardless of
+        // whether the row is the current anchor. The active set must keep
+        // at least one DB — refuse the last uncheck. Both branches funnel
+        // through State, so the cascade fires exactly once per toggle (#78).
+        var (wasActive, _) = GetActiveStatusFor(item.Summary);
+        bool wantActive = item.IsActive;
+        Log.Information(
+            "[gesture] Dropdown row {Name} {Direction} (was={WasActive} now={WantActive}) | {State}",
+            item.Name,
+            wantActive ? "CHECKED" : "UNCHECKED",
+            wasActive, wantActive, SnapshotState());
+
+        if (wantActive && !wasActive)
+        {
+            AddActiveDbToSet(item);
+        }
+        else if (!wantActive && wasActive)
+        {
+            if (_state.Dbs.Count <= 1)
+            {
+                Log.Information(
+                    "Refusing to remove {Name} — at least one DB must stay active",
+                    item.Name);
+                // Snap the row checkbox back into sync with the unchanged
+                // active set — the cascade only fires when State actually
+                // changes, so we have to nudge the dropdown rows here.
+                RefreshFilteredDataBlockItemsActiveState();
+            }
+            else
+            {
+                var match = FindActiveDb(item.Summary);
+                if (match != null) RemoveActiveDb(match);
+                else RefreshFilteredDataBlockItemsActiveState();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Pure-add path: append the dropdown-checked DB to the active set.
+    /// PendingEditStore (9814a6e) seeds pending values onto fresh VMs
+    /// after the rebuild, so the previously-required Apply/Stash/Cancel
+    /// rescue prompt on every other active DB is unnecessary — adding
+    /// a peer never destroys an in-progress edit (#93).
+    /// </summary>
+    private void AddActiveDbToSet(DataBlockListItem item)
+    {
+        var built = BuildActiveDbFromSummary(item.Summary);
+        if (built == null)
+        {
+            RefreshFilteredDataBlockItemsActiveState();
+            return;
+        }
+        SetState(_state.With(dbs: _state.Dbs.Concat(new[] { built }).ToList()));
+        Log.Information("DB enabled via dropdown: {Name}", built.Info.Name);
+    }
+
+    // ===== Pill row =========================================================
+
+    /// <summary>
+    /// One pill per PLC that has at least one active DB. Replaces the old
+    /// chip row + DbSwitcherButton / DbSwitcherPopup in the dialog toolbar.
+    /// Rebuilt by <see cref="RebuildPlcPills"/> whenever the active set changes.
+    /// </summary>
+    public ObservableCollection<PlcPillViewModel> PlcPills { get; }
+
+    /// <summary>
+    /// PLC names present in the project but not yet represented in the
+    /// pill row. Drives the "+ PLC" popup's item list and the
+    /// <see cref="CanAddPlc"/> visibility gate.
+    /// </summary>
+    public IReadOnlyList<string> InactiveProjectPlcs
+    {
+        get
+        {
+            if (!HasDataBlockSwitcher) return Array.Empty<string>();
+            LoadAvailableDataBlocks(force: false);
+            var projectDbs = _availableDataBlocks;
+            if (projectDbs == null || projectDbs.Count == 0)
+                return Array.Empty<string>();
+
+            var rowPlcs = new HashSet<string>(
+                PlcPills.Select(p => p.PlcName ?? ""), StringComparer.Ordinal);
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            var result = new List<string>();
+            foreach (var db in projectDbs)
+            {
+                var plc = db.PlcName ?? "";
+                if (rowPlcs.Contains(plc)) continue;
+                if (!seen.Add(plc)) continue;
+                result.Add(plc);
+            }
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// True when at least one project PLC is not yet in the row. Bound
+    /// to the "+ PLC" button's Visibility.
+    /// </summary>
+    public bool CanAddPlc => InactiveProjectPlcs.Count > 0;
+
+    public bool IsAddDbPopupOpen
+    {
+        get => _isAddDbPopupOpen;
+        set => SetProperty(ref _isAddDbPopupOpen, value);
+    }
+
+    /// <summary>
+    /// Adds <paramref name="plcName"/> to the row as an empty pill. The
+    /// new pill loads its DB list lazily on first popup open, same as the
+    /// active-set-derived pills. No-op if the PLC isn't a current candidate
+    /// (already in row, or not present in the project's DB list at all) —
+    /// this keeps <see cref="_extraPillPlcs"/> from accumulating stale
+    /// names if the click stream races a project mutation.
+    /// </summary>
+    public void AddPlcToRow(string plcName)
+    {
+        if (string.IsNullOrEmpty(plcName)) return;
+        if (!InactiveProjectPlcs.Contains(plcName, StringComparer.Ordinal)) return;
+        _extraPillPlcs.Add(plcName);
+        RebuildPlcPills();
+        OnPropertyChanged(nameof(InactiveProjectPlcs));
+    }
+
+    /// <summary>
+    /// Rebuilds <see cref="PlcPills"/> from the current snapshot. Called
+    /// on every active-set change by the host's cascade subscriber.
+    /// </summary>
+    public void RebuildPlcPills()
+    {
+        // Unsubscribe old pills before clearing.
+        foreach (var pill in PlcPills)
+            pill.SelectionChanged -= OnPillSelectionChanged;
+        PlcPills.Clear();
+
+        // Prune _extraPillPlcs of names that no longer correspond to any
+        // project PLC. Without this, a manually-added pill survives even
+        // after its PLC disappears from the project (e.g., after a
+        // refresh), and the orphan stays in the row indefinitely.
+        if (_extraPillPlcs.Count > 0 && _availableDataBlocks != null)
+        {
+            var projectPlcs = new HashSet<string>(
+                _availableDataBlocks.Select(d => d.PlcName ?? ""),
+                StringComparer.Ordinal);
+            _extraPillPlcs.RemoveWhere(p => !projectPlcs.Contains(p));
+        }
+
+        var newPills = PlcPillGroupsService.Build(
+            _state.Dbs,
+            _state.AnchorPlcName,
+            loadDbsForPlc: LoadDbsForPlcAsync,
+            extraPlcs: _extraPillPlcs);
+
+        foreach (var pill in newPills)
+        {
+            pill.SelectionChanged += OnPillSelectionChanged;
+            PlcPills.Add(pill);
+        }
+
+        // Pill row just changed — re-evaluate the inactive-PLCs list so
+        // the "+ PLC" popup and its button visibility stay in sync.
+        OnPropertyChanged(nameof(InactiveProjectPlcs));
+        OnPropertyChanged(nameof(CanAddPlc));
+    }
+
+    private void OnPillSelectionChanged(object? sender, PillSelectionChangedEventArgs e)
+    {
+        if (_syncingPillSelection) return;
+        _syncingPillSelection = true;
+        try
+        {
+            foreach (var summary in e.Added)
+            {
+                if (!GetActiveStatusFor(summary).isActive)
+                    AddActiveDbFromSummary(summary);
+            }
+            foreach (var summary in e.Removed)
+            {
+                if (_state.Dbs.Count <= 1)
+                {
+                    Log.Information(
+                        "Refusing pill remove on {Name} — at least one DB must stay active",
+                        summary.Name);
+                    // Snap pill selection back so the UI doesn't show a deselected last DB.
+                    if (sender is PlcPillViewModel pill)
+                    {
+                        var activeItems = GetActiveItemsForPlc(pill);
+                        pill.SyncSelectedDbs(activeItems);
+                    }
+                    return;
+                }
+                var match = FindActiveDb(summary);
+                if (match != null) RemoveActiveDb(match);
+            }
+        }
+        finally
+        {
+            _syncingPillSelection = false;
+        }
+    }
+
+    private IReadOnlyList<DataBlockListItem> GetActiveItemsForPlc(PlcPillViewModel pill)
+    {
+        var result = new List<DataBlockListItem>();
+        for (int i = 0; i < _state.Dbs.Count; i++)
+        {
+            var db = _state.Dbs[i];
+            var plc = (i == 0 ? _state.AnchorPlcName : db.PlcName) ?? "";
+            if (!string.Equals(plc, pill.PlcName, StringComparison.Ordinal)) continue;
+            result.Add(new DataBlockListItem(
+                new DataBlockSummary(db.Info.Name, "", plcName: plc, number: db.Info.Number),
+                isActive: true,
+                isAnchor: i == 0));
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Lazy-loads the available DB list for a specific PLC. Called by each
+    /// <see cref="PlcPillViewModel"/> on first popup open.
+    ///
+    /// Reuses the same <see cref="_availableDataBlocks"/> cache that
+    /// <see cref="RefreshDataBlocksCommand"/> populates, then filters to the
+    /// requested PLC so each pill only shows its own DBs.
+    ///
+    /// Returns on the calling (UI) thread since <see cref="LoadAvailableDataBlocks"/>
+    /// already runs synchronously on the UI thread.
+    /// </summary>
+    internal Task<IReadOnlyList<DataBlockListItem>> LoadDbsForPlcAsync(string plcName)
+    {
+        if (_enumerateDataBlocks == null)
+            return Task.FromResult<IReadOnlyList<DataBlockListItem>>(Array.Empty<DataBlockListItem>());
+
+        LoadAvailableDataBlocks(force: false);
+
+        var source = _availableDataBlocks ?? Array.Empty<DataBlockSummary>();
+        var filtered = string.IsNullOrEmpty(plcName)
+            ? source
+            : source.Where(s => string.Equals(s.PlcName, plcName, StringComparison.Ordinal)).ToList();
+
+        var items = filtered
+            .Select(s =>
+            {
+                var (isActive, isAnchor) = GetActiveStatusFor(s);
+                var item = new DataBlockListItem(s, isActive, isAnchor);
+                item.ToggleRequested += OnDataBlockListItemToggled;
+                return item;
+            })
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<DataBlockListItem>>(items);
+    }
+
+    // ===== Mutators ==========================================================
+
+    /// <summary>
+    /// Refuses the last-DB removal (matches the pill last-uncheck rule)
+    /// and routes everything else through the existing
+    /// <see cref="RemoveActiveDb"/> path so the stash / Apply prompt fires
+    /// for DBs with pending edits. Internal so tests can drive gestures
+    /// without going through chip / pill UI objects.
+    /// </summary>
+    public void RequestRemoveActiveDb(ActiveDb db)
+    {
+        Log.Information(
+            "[gesture] PillRemove on {Name} | {State}", db.Info.Name, SnapshotState());
+        if (_state.Dbs.Count <= 1)
+        {
+            Log.Information(
+                "Refusing pill removal on {Name} — at least one DB must stay active",
+                db.Info.Name);
+            return;
+        }
+        RemoveActiveDb(db);
+    }
+
+    /// <summary>
+    /// One-line dump of the gesture-relevant VM state for log breadcrumbs.
+    /// Reads the bound collections so the log matches what the user sees.
+    /// </summary>
+    private string SnapshotState() =>
+        $"active=[{string.Join(",", _state.Dbs.Select(d => d.Info.Name))}] " +
+        $"pending={_getPendingCount?.Invoke() ?? 0} stashed={StashedDbs.Count} " +
+        $"treeShape={(_state.Dbs.Count == 1 ? "single" : "multi")}";
+
+    /// <summary>
+    /// Solo gesture (#58 peer-mode): replace the active set with just the
+    /// target DB. Each dropped DB runs through the same Apply / Stash /
+    /// Cancel prompt RemoveActiveDb uses.
+    ///
+    /// Cancel semantics:
+    ///   • Target was already in the active set → partial-set behaviour
+    ///     (current matches user choices: silently-dropped DBs stay dropped,
+    ///     cancelled-on DBs stay, target stays).
+    ///   • Target was newly built (soloed from the dropdown without first
+    ///     checking it) → any cancel reverts the entire gesture so the
+    ///     freshly-built target is NOT silently added alongside the DB the
+    ///     user explicitly refused to drop. Without this, Solo+Cancel from a
+    ///     single-DB session quietly mutates the active set into multi-DB
+    ///     shape, triggering a tree rebuild that orphans pending edits on
+    ///     the original DB.
+    ///
+    /// Compound op (#78): builds the next snapshot in a local and commits
+    /// once at the end → exactly one cascade per gesture.
+    /// </summary>
+    public void SoloActiveDb(DataBlockSummary target)
+    {
+        var original = _state;
+        var current = original;
+        var targetDb = FindActiveDb(target);
+        bool targetWasNewlyBuilt = false;
+        if (targetDb == null)
+        {
+            // The user soloed a row that wasn't already checked — append it
+            // to the snapshot before pruning so the "leave only this one"
+            // invariant always holds.
+            var built = BuildActiveDbFromSummary(target);
+            if (built == null)
+            {
+                IsDataBlocksDropdownOpen = false;
+                return;
+            }
+            current = current.With(dbs: current.Dbs.Concat(new[] { built }).ToList());
+            targetDb = built;
+            targetWasNewlyBuilt = true;
+        }
+
+        var next = ComposeRemoveOthers(current, targetDb);
+
+        // If we just appended a fresh target and the prune loop bailed
+        // (next still carries DBs other than target), drop the whole
+        // composition: the user's Cancel applies to the entire gesture.
+        if (targetWasNewlyBuilt && next.Dbs.Count > 1)
+        {
+            Log.Information(
+                "Solo+Cancel reverted: target {Name} was newly built and a " +
+                "prune cancelled — restoring original active set",
+                target.Name);
+            IsDataBlocksDropdownOpen = false;
+            return;
+        }
+
+        SetState(next);
+        IsDataBlocksDropdownOpen = false;
+    }
+
+    /// <summary>
+    /// Reference-based variant of <see cref="SoloActiveDb"/>. Originally
+    /// called from the chip body click; surviving as a public seam used by
+    /// tests and (in future) any "solo this DB" pill affordance. Same
+    /// prompts on every dropped DB with pending edits; if the user cancels
+    /// mid-solo, the remaining drops are skipped and the active set is
+    /// whatever survived.
+    /// </summary>
+    public void SoloActiveDbByReference(ActiveDb target)
+    {
+        Log.Information(
+            "[gesture] SoloByReference → {Name} | {State}",
+            target.Info.Name, SnapshotState());
+        if (_state.Dbs.Count <= 1)
+        {
+            // Already the only active DB — there's nothing to solo away.
+            return;
+        }
+
+        SetState(ComposeRemoveOthers(_state, target));
+    }
+
+    /// <summary>
+    /// Composes the snapshot that results from removing every DB in
+    /// <paramref name="current"/> except <paramref name="target"/>. Walks
+    /// the others in storage order, calling <see cref="TryComputeRemove"/>
+    /// for each (which prompts on pending edits). If the user cancels mid-
+    /// loop, returns the partial composition so the active set ends up as
+    /// whatever survived. Caller assigns the result to <see cref="State"/>.
+    /// </summary>
+    private ActiveSetState ComposeRemoveOthers(ActiveSetState current, ActiveDb target)
+    {
+        var next = current;
+        foreach (var db in current.Dbs.Where(d => !ReferenceEquals(d, target)).ToList())
+        {
+            var step = TryComputeRemove(next, db);
+            if (step == null)
+            {
+                Log.Information(
+                    "Solo cancelled at {Name} — leaving partial set", db.Info.Name);
+                break;
+            }
+            next = step;
+        }
+        return next;
+    }
+
+    /// <summary>
+    /// Inspector path: re-add a previously-stashed DB back into the active
+    /// set, drop the others (with the same Apply / Stash / Cancel prompt
+    /// every remove uses), pop the stash entry, and replay its edits onto
+    /// the live tree. One snapshot is composed across all of these and
+    /// committed once → exactly one cascade. The pending-value replay
+    /// runs after the State assignment so it lands on the freshly-built
+    /// tree, not on VMs the cascade is about to discard.
+    /// </summary>
+    public void ReactivateStashedDb(StashedDbState stash)
+    {
+        Log.Information(
+            "[gesture] Stash header click → reactivate {Name} | {State}",
+            stash.DbName, SnapshotState());
+        var summary = stash.Summary;
+        var current = _state;
+        var target = FindActiveDb(summary);
+
+        // #92 — When the user has ≥2 active DBs and clicks a stash header,
+        // ask whether they want to *add* the stashed DB to the current
+        // session (additive) or *replace* the active set with it (the
+        // legacy single-DB behaviour). Single-DB sessions skip the prompt:
+        // there's nothing to "replace away" so the gesture is unambiguous
+        // and goes through the additive branch implicitly via the existing
+        // append-then-prune flow below (which becomes a no-op prune when
+        // current has only one DB == target).
+        if (current.Dbs.Count >= 2)
+        {
+            if (_messageBox == null)
+                throw new InvalidOperationException(
+                    "ReactivateStashedDb requires a messageBox dependency");
+            var decision = _messageBox.AskAddOrReplace(
+                Res.Format("Reactivate_AdditiveOrReplace_Text", summary.Name),
+                Res.Get("Reactivate_AdditiveOrReplace_Title"));
+            if (decision == AddOrReplaceResult.Cancel)
+            {
+                Log.Information("Reactivate cancelled by user for {Name}", summary.Name);
+                return;
+            }
+            if (decision == AddOrReplaceResult.Add)
+            {
+                ReactivateStashedDbAdditive(stash);
+                return;
+            }
+            // Replace falls through to the Replace path below.
+        }
+
+        if (target == null)
+        {
+            var built = BuildActiveDbFromSummary(summary);
+            if (built == null) return;
+            current = current.With(dbs: current.Dbs.Concat(new[] { built }).ToList());
+            target = built;
+        }
+
+        var next = ComposeRemoveOthers(current, target);
+
+        // Pop the stash entry inside the same snapshot so the cascade
+        // sees stashes-changed once. Other DBs that got stashed during
+        // ComposeRemoveOthers (peer with pending edits, user picked Stash)
+        // stay in next.Stashes — only the reactivated DB's entry is popped.
+        var stashKey = StashKey(summary);
+        if (next.Stashes.ContainsKey(stashKey))
+        {
+            var stashesNew = next.Stashes.ToDictionary(kv => kv.Key, kv => kv.Value);
+            stashesNew.Remove(stashKey);
+            next = next.With(stashes: stashesNew);
+        }
+
+        SetState(next);
+
+        // Replay the stash edits onto the now-final live tree. Runs after
+        // State assignment so the cascade has already rebuilt RootMembers
+        // — otherwise the new PendingValue assignments would land on VMs
+        // the rebuild is about to discard.
+        if (_restoreStashOntoLive != null)
+        {
+            var (restored, dropped) = _restoreStashOntoLive(stash, null);
+            if (restored > 0 || dropped > 0)
+            {
+                _setStatus?.Invoke(dropped == 0
+                    ? Res.Format("Status_DbSwitched_StashRestored", summary.Name, restored)
+                    : Res.Format("Status_DbSwitched_StashPartial",
+                        summary.Name, restored, dropped));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Additive branch of <see cref="ReactivateStashedDb"/>: append the
+    /// stashed DB to the active set without dropping any other active DBs,
+    /// pop its stash entry, replay its edits. One snapshot, one cascade.
+    /// </summary>
+    private void ReactivateStashedDbAdditive(StashedDbState stash)
+    {
+        var summary = stash.Summary;
+        var built = BuildActiveDbFromSummary(summary);
+        if (built == null) return;
+
+        var stashesNew = _state.Stashes.ToDictionary(kv => kv.Key, kv => kv.Value);
+        stashesNew.Remove(StashKey(summary));
+        SetState(_state.With(
+            dbs: _state.Dbs.Concat(new[] { built }).ToList(),
+            stashes: stashesNew));
+
+        // Multi-DB shape after additive add — scope the path lookup to the
+        // just-added DB's subtree so peer DBs with colliding member paths
+        // don't accidentally absorb the stashed edits (#82 path-identity).
+        if (_restoreStashOntoLive != null)
+        {
+            var (restored, dropped) = _restoreStashOntoLive(stash, built);
+            if (restored > 0 || dropped > 0)
+            {
+                _setStatus?.Invoke(dropped == 0
+                    ? Res.Format("Status_DbSwitched_StashRestored", summary.Name, restored)
+                    : Res.Format("Status_DbSwitched_StashPartial",
+                        summary.Name, restored, dropped));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Pure builder (#78): produces a fully-wired <see cref="ActiveDb"/>
+    /// for a dropdown-picked DB without touching <see cref="State"/>.
+    /// Compound mutations (Solo, Reactivate) call this directly and
+    /// fold the result into their composed snapshot; the simple
+    /// "checkbox checked" path goes through
+    /// <see cref="AddActiveDbFromSummary"/>, which builds + assigns.
+    /// </summary>
+    private ActiveDb? BuildActiveDbFromSummary(DataBlockSummary summary)
+    {
+        try
+        {
+            if (_buildActiveDbForSummary == null)
+            {
+                Log.Information(
+                    "DB enable ignored: buildActiveDbForSummary callback not wired");
+                return null;
+            }
+            var built = _buildActiveDbForSummary(summary);
+            if (built == null)
+                Log.Information("ActiveDb build returned null for {Name}", summary.Name);
+            return built;
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to build ActiveDb {Name}", summary.Name);
+            _setStatus?.Invoke(Res.Format("Status_DbSwitchFailed", summary.Name, ex.Message));
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Single-step add (dropdown checkbox-on). Builds the ActiveDb and
+    /// commits to <see cref="State"/> in one shot — the cascade fires
+    /// once on the resulting snapshot. Compound paths build directly via
+    /// <see cref="BuildActiveDbFromSummary"/> and skip this wrapper.
+    /// </summary>
+    public void AddActiveDbFromSummary(DataBlockSummary summary)
+    {
+        var built = BuildActiveDbFromSummary(summary);
+        if (built == null) return;
+        SetState(_state.With(dbs: _state.Dbs.Concat(new[] { built }).ToList()));
+        Log.Information("DB enabled via dropdown: {Name}", built.Info.Name);
+    }
+
+    /// <summary>
+    /// Looks up an active DB by (Name, PlcName) so dropdown rows resolve to
+    /// the right ActiveDb instance even in multi-PLC projects where two
+    /// PLCs share a DB name (#58 review must-fix #4).
+    /// </summary>
+    private ActiveDb? FindActiveDb(DataBlockSummary summary)
+    {
+        for (int i = 0; i < _state.Dbs.Count; i++)
+        {
+            var db = _state.Dbs[i];
+            // Index 0 reads its display PLC from State.AnchorPlcName; the
+            // rest read it from each ActiveDb directly.
+            var plc = i == 0 ? _state.AnchorPlcName : db.PlcName;
+            if (string.Equals(db.Info.Name, summary.Name, StringComparison.Ordinal)
+                && string.Equals(plc, summary.PlcName, StringComparison.Ordinal))
+                return db;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// User's choice in response to the "this DB has pending edits" prompt
+    /// raised when removing a DB from the active set (#78). Centralised so
+    /// every remove path maps the <see cref="ApplyStashCancelResult"/>
+    /// the same way: ApplyAndSwitch→Apply, StashAndSwitch→Stash, Cancel→Cancel.
+    /// <c>NoEdits</c> is the no-prompt fast path.
+    /// </summary>
+    private enum PendingDecision { NoEdits, Apply, Stash, Cancel }
+
+    /// <summary>
+    /// Single source of truth for the 3-way prompt that fires whenever a
+    /// DB with pending inline edits is about to be dropped from the active
+    /// set (#78). Returns <see cref="PendingDecision.NoEdits"/> immediately
+    /// if there's nothing pending — caller proceeds with the removal
+    /// without showing a dialog.
+    /// </summary>
+    private PendingDecision PromptForPendingEditsOnRemove(ActiveDb db)
+    {
+        var pendingCount = CountPendingEditsForDb(db);
+        if (pendingCount == 0)
+        {
+            Log.Information(
+                "[prompt] no-prompt fast path on {Name} (CountPendingEditsForDb=0) | {State}",
+                db.Info.Name, SnapshotState());
+            return PendingDecision.NoEdits;
+        }
+        if (_messageBox == null)
+        {
+            // Without a wired message-box service we can't ask the user —
+            // treat it as a Cancel so the remove aborts cleanly rather than
+            // dropping pending edits silently.
+            Log.Information(
+                "[prompt] no message-box wired; treating remove of {Name} as Cancel",
+                db.Info.Name);
+            return PendingDecision.Cancel;
+        }
+        Log.Information(
+            "[prompt] Showing 3-way for {Name} (pending={Pending}) | {State}",
+            db.Info.Name, pendingCount, SnapshotState());
+        var result = _messageBox.AskApplyStashCancel(
+            Res.Format("Dialog_SwitchDb_KeepConfirm_Text",
+                pendingCount, db.Info.Name),
+            Res.Get("Dialog_SwitchDb_KeepConfirm_Title"));
+        Log.Information(
+            "[prompt] User picked {Result} for {Name}", result, db.Info.Name);
+        return result switch
+        {
+            ApplyStashCancelResult.ApplyAndSwitch => PendingDecision.Apply,
+            ApplyStashCancelResult.StashAndSwitch => PendingDecision.Stash,
+            _ => PendingDecision.Cancel,
+        };
+    }
+
+    /// <summary>
+    /// Snapshots pending inline edits for <paramref name="db"/> into an
+    /// inert <see cref="StashedDbState"/> ready to be added to a new
+    /// <see cref="ActiveSetState"/>. Returns null when the DB has no
+    /// pending edits to capture. Reads from the store — unambiguous in
+    /// multi-DB sessions where the same Path can exist in multiple DBs,
+    /// and correct even if the tree hasn't rebuilt yet. Pure read —
+    /// does NOT mutate <c>State.Stashes</c> (the snapshot setter does).
+    /// </summary>
+    private StashedDbState? CaptureStashForDb(ActiveDb db)
+    {
+        if (_pendingEditStore == null || _getModelToDb == null) return null;
+        var modelToDb = _getModelToDb();
+        var entries = new List<StashedEditEntry>();
+        foreach (var (node, pendingValue) in _pendingEditStore.GetForDb(db, modelToDb))
+        {
+            // Resolve to the live tree to read StartValue (which is model-
+            // derived and stable). If the lookup can't find it, fall back to
+            // the model's stored StartValue.
+            var startValue = _getStartValueForNode?.Invoke(node) ?? node.StartValue ?? "";
+            entries.Add(new StashedEditEntry(node.Path, startValue, pendingValue));
+        }
+        if (entries.Count == 0) return null;
+        var summary = new DataBlockSummary(
+            db.Info.Name,
+            "",
+            blockType: db.Info.BlockType,
+            isInstanceDb: string.Equals(db.Info.BlockType, "InstanceDB", StringComparison.Ordinal),
+            plcName: _state.AnchorPlcName);
+        return new StashedDbState(summary, entries);
+    }
+
+    /// <summary>
+    /// Computes the next snapshot after removing <paramref name="db"/>
+    /// from <paramref name="current"/>. Side-effects (the user-visible
+    /// prompt + Apply branch's per-DB OnApply + usage-counter charge)
+    /// run here because they MUST occur against the live (pre-cascade)
+    /// tree. Returns null if the user cancelled or the Apply branch
+    /// failed (cap hit / read-only OnApply); caller treats null as
+    /// "abort this remove."
+    /// </summary>
+    private ActiveSetState? TryComputeRemove(ActiveSetState current, ActiveDb db)
+    {
+        var decision = PromptForPendingEditsOnRemove(db);
+        if (decision == PendingDecision.Cancel)
+        {
+            Log.Information("DB remove cancelled by user: {Name}", db.Info.Name);
+            return null;
+        }
+        if (decision == PendingDecision.Apply)
+        {
+            if (_tryApplyActiveDbInPlace == null || !_tryApplyActiveDbInPlace(db))
+            {
+                Log.Information(
+                    "DB remove aborted: pending Apply did not succeed for {Name}",
+                    db.Info.Name);
+                return null;
+            }
+        }
+
+        IReadOnlyDictionary<string, StashedDbState> nextStashes = current.Stashes;
+        if (decision == PendingDecision.Stash)
+        {
+            var captured = CaptureStashForDb(db);
+            if (captured != null)
+            {
+                var dict = current.Stashes.ToDictionary(kv => kv.Key, kv => kv.Value);
+                dict[StashKey(captured.Summary)] = captured;
+                nextStashes = dict;
+                // The DB's edits are now snapshotted into the inert stash —
+                // evict the store entries so the live tree doesn't keep
+                // showing them as pending on whatever DB inherits the path.
+                if (_pendingEditStore != null && _getModelToDb != null)
+                    _pendingEditStore.ClearForDb(db, _getModelToDb());
+            }
+        }
+
+        var nextDbs = current.Dbs.Where(d => !ReferenceEquals(d, db)).ToList();
+        // Anchor handoff: only when the removed DB was the anchor; the
+        // new anchor is whatever moved into nextDbs[0]. Same rule as the
+        // legacy RemoveActiveDb.
+        var nextAnchor = current.AnchorPlcName;
+        if (current.Dbs.Count > 0 && ReferenceEquals(db, current.Dbs[0]))
+        {
+            nextAnchor = nextDbs.Count > 0 ? (nextDbs[0].PlcName ?? "") : "";
+        }
+
+        Log.Information(
+            ReferenceEquals(db, current.Dbs[0])
+                ? "Anchor removed: now {NewName} (was: {OldName})"
+                : "DB disabled: {OldName}",
+            nextDbs.Count > 0 ? nextDbs[0].Info.Name : "<empty>",
+            db.Info.Name);
+
+        return new ActiveSetState(nextDbs, nextStashes, nextAnchor);
+    }
+
+    /// <summary>
+    /// Single-step remove (chip × / dropdown uncheck). Compound paths
+    /// (solo, reactivate) call <see cref="TryComputeRemove"/> directly
+    /// to compose multiple removes into one snapshot before assigning.
+    /// </summary>
+    /// <returns>true if removed; false if the user cancelled.</returns>
+    private bool RemoveActiveDb(ActiveDb db)
+    {
+        var next = TryComputeRemove(_state, db);
+        if (next == null) return false;
+        SetState(next);
+        return true;
+    }
+
+    /// <summary>
+    /// Counts pending inline edits inside a DB's subtree. Used by the
+    /// remove-with-stash-prompt flow (#58, #78). Reads from the store
+    /// rather than walking the VM tree — O(store.Count) instead of
+    /// O(subtree size), and correct even when the tree hasn't rebuilt yet.
+    /// </summary>
+    private int CountPendingEditsForDb(ActiveDb db)
+    {
+        if (_pendingEditStore == null || _getModelToDb == null) return 0;
+        return _pendingEditStore.CountForDb(db, _getModelToDb());
+    }
+
+    private static string StashKey(DataBlockSummary summary) =>
+        $"{summary.PlcName}{summary.FolderPath}{summary.Name}";
 }

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -194,9 +194,9 @@
                      picking a DB from a PLC that isn't in the active set yet.
                      Visible on the same condition as the legacy chip row. -->
                 <DockPanel DockPanel.Dock="Top" Margin="0,0,0,6"
-                           Visibility="{Binding HasDataBlockSwitcher, Converter={StaticResource BoolToVis}}">
+                           Visibility="{Binding ActiveSet.HasDataBlockSwitcher, Converter={StaticResource BoolToVis}}">
                     <StackPanel Orientation="Horizontal">
-                        <ItemsControl ItemsSource="{Binding PlcPills}">
+                        <ItemsControl ItemsSource="{Binding ActiveSet.PlcPills}">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
                                     <WrapPanel Orientation="Horizontal"/>
@@ -224,10 +224,10 @@
                         <Button x:Name="AddDbButton"
                                 Content="{loc:Loc PillRow_AddDb}"
                                 Click="OnAddDbButtonClick"
-                                Visibility="{Binding CanAddPlc, Converter={StaticResource BoolToVis}}"
+                                Visibility="{Binding ActiveSet.CanAddPlc, Converter={StaticResource BoolToVis}}"
                                 Background="White" BorderBrush="#CCC" BorderThickness="1"
                                 Padding="6,2" VerticalAlignment="Center" Cursor="Hand"/>
-                        <Popup IsOpen="{Binding IsAddDbPopupOpen, Mode=TwoWay}"
+                        <Popup IsOpen="{Binding ActiveSet.IsAddDbPopupOpen, Mode=TwoWay}"
                                PlacementTarget="{Binding ElementName=AddDbButton}"
                                Placement="Bottom"
                                StaysOpen="False"
@@ -243,7 +243,7 @@
                                                       BlurRadius="12" ShadowDepth="2"/>
                                 </Border.Effect>
                                 <ListBox x:Name="AddPlcListBox"
-                                         ItemsSource="{Binding InactiveProjectPlcs}"
+                                         ItemsSource="{Binding ActiveSet.InactiveProjectPlcs}"
                                          SelectionChanged="OnAddPlcListSelectionChanged"
                                          BorderThickness="0"
                                          Background="Transparent"

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -90,21 +90,13 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     // name display).
     private ActiveDb _active => State.Dbs[0];
     private string _title = "";
-    // DB-switcher state (#59). Lazy-loaded on first dropdown open and cached
-    // for the dialog session; the ↻ button re-enumerates on demand.
-    private readonly Func<IReadOnlyList<DataBlockSummary>>? _enumerateDataBlocks;
+    // DB-switcher dropdown state (#59), pill row, and the mutators that
+    // touch them moved to ActiveSetViewModel in #80 slice 8b. The host
+    // keeps two callback refs only because BuildActiveDbFromSummaryWithFallback
+    // (DevLauncher / tests with no host factory) needs to synthesize an
+    // ActiveDb from xml via switchToDataBlock + the parser.
     private readonly Func<DataBlockSummary, string>? _switchToDataBlock;
-    // Multi-DB add (#58): host-supplied factory that builds a fully-wired
-    // ActiveDb for an arbitrary DB picked in the dropdown — including a
-    // per-DB OnApply that re-imports the modified xml back into TIA. Null
-    // when the host couldn't supply it (DevLauncher, tests); the VM falls
-    // back to a read-only ActiveDb in that case (see AddActiveDbFromSummary).
     private readonly Func<DataBlockSummary, ActiveDb?>? _buildActiveDbForSummary;
-    private IReadOnlyList<DataBlockSummary>? _availableDataBlocks;
-    private IReadOnlyList<DataBlockSummary> _filteredDataBlocks = Array.Empty<DataBlockSummary>();
-    private string _dataBlockSearchText = "";
-    private bool _isDataBlocksDropdownOpen;
-    private bool _isLoadingDataBlocks;
     // Active-DB set, per-DB pending-edit stashes, and anchor PLC name all
     // live on the State snapshot (#78). Legacy backing fields
     // (_activeDbs / _stashedDbs / _currentPlcName) were deleted in slice 8
@@ -188,28 +180,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         _projectLanguages = projectLanguages is { Count: > 0 } ? projectLanguages : new[] { "en-GB" };
         _commentLanguagePolicy = new CommentLanguagePolicy(editingLanguage, referenceLanguage, _projectLanguages);
 
-        // Seed the active-set slice first so everything below can read
-        // through State.X / ActiveSet.X (slice 8a). Subscribe to
-        // StateChanged in the same step so any mutation that fires before
-        // the constructor's explicit BuildRootMembersFromActiveDbs /
-        // RebuildPlcPills calls below would still cascade correctly.
-        var initialDbs = new List<ActiveDb> { new ActiveDb(dataBlockInfo, currentXml, onApply) };
-        if (additionalActiveDbs != null)
-            initialDbs.AddRange(additionalActiveDbs);
-        ActiveSet = new ActiveSetViewModel(new ActiveSetState(
-            initialDbs,
-            new Dictionary<string, StashedDbState>(),
-            currentPlcName ?? ""));
-        ActiveSet.StateChanged += HandleActiveSetStateChanged;
-        ActiveSet.PropertyChanged += (_, e) =>
-        {
-            // Forward the slice's derived-property notifications to the
-            // host's delegating wrappers so XAML still bound to
-            // `{Binding HasStashedDbs}` repaints. Rebind in slice 9.
-            if (e.PropertyName == nameof(ActiveSetViewModel.HasStashedDbs))
-                OnPropertyChanged(nameof(HasStashedDbs));
-        };
-
         _analyzer = analyzer;
         _bulkChangeService = bulkChangeService;
         _configLoader = configLoader;
@@ -229,9 +199,80 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // ApplyTooltip composes license + remaining-quota state, so re-raise
         // it whenever Subscription publishes a tier / quota change.
         Subscription.StateChanged += () => OnPropertyChanged(nameof(ApplyTooltip));
-        _enumerateDataBlocks = enumerateDataBlocks;
         _switchToDataBlock = switchToDataBlock;
         _buildActiveDbForSummary = buildActiveDbForSummary;
+
+        // Seed the active-set slice (#80 slice 8a + 8b). The slice owns the
+        // ActiveSetState snapshot, the StashedDbs mirror, the DB-switcher
+        // dropdown state, the PLC-pill row, and every mutator that swaps
+        // the snapshot (Add / Solo / Remove / Reactivate). Operations with
+        // host-side side effects (TryApplyActiveDbInPlace, RestoreStashOntoLive)
+        // are wired through callbacks so the slice never reaches into
+        // _writer / Tree / Subscription. The host subscribes to
+        // StateChanged to drive the cross-slice cascade.
+        var initialDbs = new List<ActiveDb> { new ActiveDb(dataBlockInfo, currentXml, onApply) };
+        if (additionalActiveDbs != null)
+            initialDbs.AddRange(additionalActiveDbs);
+        ActiveSet = new ActiveSetViewModel(
+            new ActiveSetState(
+                initialDbs,
+                new Dictionary<string, StashedDbState>(),
+                currentPlcName ?? ""),
+            messageBox: _messageBox,
+            pendingEditStore: _pendingEditStore,
+            getModelToDb: () => Tree.ModelToDb,
+            getStartValueForNode: node => Tree.FindVmByModel(node)?.StartValue,
+            buildActiveDbForSummary: BuildActiveDbFromSummaryWithFallback,
+            enumerateDataBlocks: enumerateDataBlocks,
+            switchToDataBlock: switchToDataBlock,
+            tryApplyActiveDbInPlace: TryApplyActiveDbInPlace,
+            restoreStashOntoLive: RestoreStashOntoLive,
+            setStatus: value => StatusText = value,
+            getPendingCount: () => Pending?.PendingEdits.Count ?? 0,
+            dispatcher: _dispatcher);
+        ActiveSet.StateChanged += HandleActiveSetStateChanged;
+        ActiveSet.PropertyChanged += (_, e) =>
+        {
+            // Forward the slice's derived-property notifications to the
+            // host's delegating wrappers so XAML still bound through the
+            // host repaints. Rebind to {Binding ActiveSet.X} in slice 9.
+            switch (e.PropertyName)
+            {
+                case nameof(ActiveSetViewModel.HasStashedDbs):
+                    OnPropertyChanged(nameof(HasStashedDbs));
+                    break;
+                case nameof(ActiveSetViewModel.HasMultipleActiveDbs):
+                    OnPropertyChanged(nameof(HasMultipleActiveDbs));
+                    break;
+                case nameof(ActiveSetViewModel.IsDataBlocksDropdownOpen):
+                    OnPropertyChanged(nameof(IsDataBlocksDropdownOpen));
+                    break;
+                case nameof(ActiveSetViewModel.IsLoadingDataBlocks):
+                    OnPropertyChanged(nameof(IsLoadingDataBlocks));
+                    break;
+                case nameof(ActiveSetViewModel.FilteredDataBlocks):
+                    OnPropertyChanged(nameof(FilteredDataBlocks));
+                    break;
+                case nameof(ActiveSetViewModel.FilteredDataBlockItems):
+                    OnPropertyChanged(nameof(FilteredDataBlockItems));
+                    break;
+                case nameof(ActiveSetViewModel.DataBlockSearchText):
+                    OnPropertyChanged(nameof(DataBlockSearchText));
+                    break;
+                case nameof(ActiveSetViewModel.ShowEmptyDataBlocksMessage):
+                    OnPropertyChanged(nameof(ShowEmptyDataBlocksMessage));
+                    break;
+                case nameof(ActiveSetViewModel.IsAddDbPopupOpen):
+                    OnPropertyChanged(nameof(IsAddDbPopupOpen));
+                    break;
+                case nameof(ActiveSetViewModel.InactiveProjectPlcs):
+                    OnPropertyChanged(nameof(InactiveProjectPlcs));
+                    break;
+                case nameof(ActiveSetViewModel.CanAddPlc):
+                    OnPropertyChanged(nameof(CanAddPlc));
+                    break;
+            }
+        };
         _autocompleteProvider = tagTableCache != null
             ? new AutocompleteProvider(configLoader, tagTableCache)
             : null;
@@ -305,7 +346,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         Tree.BuildRootMembersFromActiveDbs();
         RefreshRuleHints();
-        RebuildPlcPills();
+        ActiveSet.RebuildPlcPills();
 
         SetPendingCommand = new RelayCommand(ExecuteSetPending, CanExecuteSetPending);
         ApplyCommand = new RelayCommand(ExecuteApply, CanExecuteApply);
@@ -323,24 +364,10 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         ClearManualSelectionCommand = new RelayCommand(ExecuteClearManualSelection,
             () => Selection.ManualSelectionCount > 0);
 
-        OpenDataBlocksDropdownCommand = new RelayCommand(ExecuteOpenDataBlocksDropdown,
-            () => _enumerateDataBlocks != null && _switchToDataBlock != null);
-        CloseDataBlocksDropdownCommand = new RelayCommand(() =>
-        {
-            IsDataBlocksDropdownOpen = false;
-        });
-        RefreshDataBlocksCommand = new RelayCommand(ExecuteRefreshDataBlocks,
-            () => _enumerateDataBlocks != null && !_isLoadingDataBlocks);
-        SwitchToStashedDbCommand = new RelayCommand(parameter =>
-        {
-            // Peer model: clicking a stashed-DB header re-activates that DB
-            // by adding it back to the active set, then restoring its stash
-            // edits. The previous anchor stays — the user can remove it
-            // themselves if desired. Overwriting the anchor in place would
-            // destroy the user's other active DBs, which the legacy
-            // SwitchToDataBlock path did under the old single-DB model.
-            if (parameter is StashedDbState stash) ReactivateStashedDb(stash);
-        });
+        // OpenDataBlocksDropdownCommand / CloseDataBlocksDropdownCommand /
+        // RefreshDataBlocksCommand / SwitchToStashedDbCommand moved to
+        // ActiveSetViewModel (#80 slice 8b). Host delegators expose them
+        // for the existing XAML / test surface — see the property block.
 
         // Apply initial filter and build flat list
         ApplyAllFilters();
@@ -665,20 +692,19 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     public ICommand EditConfigCommand { get; }
     public ICommand ClearManualSelectionCommand { get; }
 
-    // --- DB-switcher dropdown (#59) ---
+    // --- DB-switcher dropdown (#59) — delegators to ActiveSet (#80 slice 8b) ---
 
-    public ICommand OpenDataBlocksDropdownCommand { get; }
-    public ICommand CloseDataBlocksDropdownCommand { get; }
-    public ICommand RefreshDataBlocksCommand { get; }
-    public ICommand SwitchToStashedDbCommand { get; }
+    public ICommand OpenDataBlocksDropdownCommand => ActiveSet.OpenDataBlocksDropdownCommand;
+    public ICommand CloseDataBlocksDropdownCommand => ActiveSet.CloseDataBlocksDropdownCommand;
+    public ICommand RefreshDataBlocksCommand => ActiveSet.RefreshDataBlocksCommand;
+    public ICommand SwitchToStashedDbCommand => ActiveSet.SwitchToStashedDbCommand;
 
     /// <summary>
     /// True when the host wired up DB enumeration + switching callbacks.
     /// The dropdown chevron / popup are hidden in tests + DevLauncher runs
     /// where no project is available.
     /// </summary>
-    public bool HasDataBlockSwitcher =>
-        _enumerateDataBlocks != null && _switchToDataBlock != null;
+    public bool HasDataBlockSwitcher => ActiveSet.HasDataBlockSwitcher;
 
     /// <summary>Header label — the DB name part of the title combo.</summary>
     public string CurrentDataBlockName => _active.Info.Name;
@@ -739,252 +765,50 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     public IReadOnlyList<ActiveDb> AllActiveDbs => State.Dbs;
 
     /// <summary>True when more than one DB is active in this session (#58).</summary>
-    public bool HasMultipleActiveDbs => State.Dbs.Count > 1;
+    public bool HasMultipleActiveDbs => ActiveSet.HasMultipleActiveDbs;
 
-    // ── Pill-row (#pill-refactor) ─────────────────────────────────────────────
-
-    /// <summary>
-    /// One pill per PLC that has at least one active DB. Replaces the old
-    /// chip row + DbSwitcherButton / DbSwitcherPopup in the dialog toolbar.
-    /// Rebuilt by <see cref="RebuildPlcPills"/> whenever the active set changes.
-    /// </summary>
-    public ObservableCollection<PlcPillViewModel> PlcPills { get; }
-        = new ObservableCollection<PlcPillViewModel>();
+    // ── Pill-row (#pill-refactor) — delegators to ActiveSet (#80 slice 8b) ───
 
     /// <summary>
-    /// PLCs the user added via "+ PLC" before they had any active DB.
-    /// These produce empty pills until the user opens them and toggles a
-    /// DB. Once a DB is active for a PLC the entry is redundant (the
-    /// active-DB path also makes the PLC appear), but we keep it so the
-    /// pill survives the user removing all DBs again.
+    /// One pill per PLC that has at least one active DB. Slice owns the
+    /// collection + the rebuild logic; the host forwards the reference so
+    /// XAML bindings (`{Binding PlcPills}`) keep working until slice 9
+    /// rebinds them to <c>ActiveSet.PlcPills</c>.
     /// </summary>
-    private readonly HashSet<string> _extraPillPlcs = new(StringComparer.Ordinal);
+    public ObservableCollection<PlcPillViewModel> PlcPills => ActiveSet.PlcPills;
 
     /// <summary>
-    /// Adds <paramref name="plcName"/> to the row as an empty pill. The
-    /// new pill loads its DB list lazily on first popup open, same as the
-    /// active-set-derived pills. No-op if the PLC isn't a current candidate
-    /// (already in row, or not present in the project's DB list at all) —
-    /// this keeps <see cref="_extraPillPlcs"/> from accumulating stale
-    /// names if the click stream races a project mutation.
+    /// Adds <paramref name="plcName"/> to the row as an empty pill (#pill-refactor).
+    /// Delegator for <see cref="ActiveSetViewModel.AddPlcToRow"/>.
     /// </summary>
-    public void AddPlcToRow(string plcName)
-    {
-        if (string.IsNullOrEmpty(plcName)) return;
-        if (!InactiveProjectPlcs.Contains(plcName, StringComparer.Ordinal)) return;
-        _extraPillPlcs.Add(plcName);
-        RebuildPlcPills();
-        OnPropertyChanged(nameof(InactiveProjectPlcs));
-    }
+    public void AddPlcToRow(string plcName) => ActiveSet.AddPlcToRow(plcName);
 
     /// <summary>
     /// PLC names present in the project but not yet represented in the
     /// pill row. Drives the "+ PLC" popup's item list and the
     /// <see cref="CanAddPlc"/> visibility gate.
     /// </summary>
-    public IReadOnlyList<string> InactiveProjectPlcs
-    {
-        get
-        {
-            if (!HasDataBlockSwitcher) return Array.Empty<string>();
-            LoadAvailableDataBlocks(force: false);
-            var projectDbs = _availableDataBlocks;
-            if (projectDbs == null || projectDbs.Count == 0)
-                return Array.Empty<string>();
-
-            var rowPlcs = new HashSet<string>(
-                PlcPills.Select(p => p.PlcName ?? ""), StringComparer.Ordinal);
-            var seen = new HashSet<string>(StringComparer.Ordinal);
-            var result = new List<string>();
-            foreach (var db in projectDbs)
-            {
-                var plc = db.PlcName ?? "";
-                if (rowPlcs.Contains(plc)) continue;
-                if (!seen.Add(plc)) continue;
-                result.Add(plc);
-            }
-            return result;
-        }
-    }
+    public IReadOnlyList<string> InactiveProjectPlcs => ActiveSet.InactiveProjectPlcs;
 
     /// <summary>
     /// True when at least one project PLC is not yet in the row. Bound
     /// to the "+ PLC" button's Visibility.
     /// </summary>
-    public bool CanAddPlc => InactiveProjectPlcs.Count > 0;
-
-    // Re-entrancy guard: when the cascade rewrites SelectedDbs on each pill,
-    // the pill fires SelectionChanged → OnPillSelectionChanged. Without the
-    // guard we'd enter AddActiveDbToSet / RemoveActiveDb for every item in
-    // the selection sync, spiraling into multiple cascades.
-    private bool _syncingPillSelection;
-
-    // "Add DB" trailing affordance: project-wide pill to pick a DB from a PLC
-    // that has no active DB yet.
-    private bool _isAddDbPopupOpen;
+    public bool CanAddPlc => ActiveSet.CanAddPlc;
 
     public bool IsAddDbPopupOpen
     {
-        get => _isAddDbPopupOpen;
-        set => SetProperty(ref _isAddDbPopupOpen, value);
+        get => ActiveSet.IsAddDbPopupOpen;
+        set => ActiveSet.IsAddDbPopupOpen = value;
     }
-
-    private void RebuildPlcPills()
-    {
-        // Unsubscribe old pills before clearing.
-        foreach (var pill in PlcPills)
-            pill.SelectionChanged -= OnPillSelectionChanged;
-        PlcPills.Clear();
-
-        // Prune _extraPillPlcs of names that no longer correspond to any
-        // project PLC. Without this, a manually-added pill survives even
-        // after its PLC disappears from the project (e.g., after a
-        // refresh), and the orphan stays in the row indefinitely.
-        if (_extraPillPlcs.Count > 0 && _availableDataBlocks != null)
-        {
-            var projectPlcs = new HashSet<string>(
-                _availableDataBlocks.Select(d => d.PlcName ?? ""),
-                StringComparer.Ordinal);
-            _extraPillPlcs.RemoveWhere(p => !projectPlcs.Contains(p));
-        }
-
-        var newPills = PlcPillGroupsService.Build(
-            State.Dbs,
-            State.AnchorPlcName,
-            loadDbsForPlc: LoadDbsForPlcAsync,
-            extraPlcs: _extraPillPlcs);
-
-        foreach (var pill in newPills)
-        {
-            pill.SelectionChanged += OnPillSelectionChanged;
-            PlcPills.Add(pill);
-        }
-
-        // Pill row just changed — re-evaluate the inactive-PLCs list so
-        // the "+ PLC" popup and its button visibility stay in sync.
-        OnPropertyChanged(nameof(InactiveProjectPlcs));
-        OnPropertyChanged(nameof(CanAddPlc));
-    }
-
-    private void OnPillSelectionChanged(object? sender, PillSelectionChangedEventArgs e)
-    {
-        if (_syncingPillSelection) return;
-        _syncingPillSelection = true;
-        try
-        {
-            foreach (var summary in e.Added)
-            {
-                if (!GetActiveStatusFor(summary).isActive)
-                    AddActiveDbFromSummary(summary);
-            }
-            foreach (var summary in e.Removed)
-            {
-                if (State.Dbs.Count <= 1)
-                {
-                    Log.Information(
-                        "Refusing pill remove on {Name} — at least one DB must stay active",
-                        summary.Name);
-                    // Snap pill selection back so the UI doesn't show a deselected last DB.
-                    if (sender is PlcPillViewModel pill)
-                    {
-                        var activeItems = GetActiveItemsForPlc(pill);
-                        pill.SyncSelectedDbs(activeItems);
-                    }
-                    return;
-                }
-                var match = FindActiveDb(summary);
-                if (match != null) RemoveActiveDb(match);
-            }
-        }
-        finally
-        {
-            _syncingPillSelection = false;
-        }
-    }
-
-    private IReadOnlyList<DataBlockListItem> GetActiveItemsForPlc(PlcPillViewModel pill)
-    {
-        var result = new List<DataBlockListItem>();
-        for (int i = 0; i < State.Dbs.Count; i++)
-        {
-            var db = State.Dbs[i];
-            var plc = (i == 0 ? State.AnchorPlcName : db.PlcName) ?? "";
-            if (!string.Equals(plc, pill.PlcName, StringComparison.Ordinal)) continue;
-            result.Add(new DataBlockListItem(
-                new DataBlockSummary(db.Info.Name, "", plcName: plc, number: db.Info.Number),
-                isActive: true,
-                isAnchor: i == 0));
-        }
-        return result;
-    }
-
-    /// <summary>
-    /// Lazy-loads the available DB list for a specific PLC. Called by each
-    /// <see cref="PlcPillViewModel"/> on first popup open.
-    ///
-    /// Reuses the same <see cref="_availableDataBlocks"/> cache that
-    /// <see cref="RefreshDataBlocksCommand"/> populates, then filters to the
-    /// requested PLC so each pill only shows its own DBs.
-    ///
-    /// Returns on the calling (UI) thread since <see cref="LoadAvailableDataBlocks"/>
-    /// already runs synchronously on the UI thread.
-    /// </summary>
-    internal Task<IReadOnlyList<DataBlockListItem>> LoadDbsForPlcAsync(string plcName)
-    {
-        if (_enumerateDataBlocks == null)
-            return Task.FromResult<IReadOnlyList<DataBlockListItem>>(Array.Empty<DataBlockListItem>());
-
-        LoadAvailableDataBlocks(force: false);
-
-        var source = _availableDataBlocks ?? Array.Empty<DataBlockSummary>();
-        var filtered = string.IsNullOrEmpty(plcName)
-            ? source
-            : source.Where(s => string.Equals(s.PlcName, plcName, StringComparison.Ordinal)).ToList();
-
-        var items = filtered
-            .Select(s =>
-            {
-                var (isActive, isAnchor) = GetActiveStatusFor(s);
-                var item = new DataBlockListItem(s, isActive, isAnchor);
-                item.ToggleRequested += OnDataBlockListItemToggled;
-                return item;
-            })
-            .ToList();
-
-        return Task.FromResult<IReadOnlyList<DataBlockListItem>>(items);
-    }
-
-    // ── End pill-row ──────────────────────────────────────────────────────────
 
     /// <summary>
     /// Refuses the last-DB removal (matches the pill last-uncheck rule)
-    /// and routes everything else through the existing
-    /// <see cref="RemoveActiveDb"/> path so the stash / Apply prompt fires
-    /// for DBs with pending edits. Internal so tests can drive gestures
-    /// without going through chip / pill UI objects.
+    /// and routes everything else through the existing remove path so the
+    /// stash / Apply prompt fires for DBs with pending edits. Internal so
+    /// tests can drive gestures without going through chip / pill UI objects.
     /// </summary>
-    internal void RequestRemoveActiveDb(ActiveDb db)
-    {
-        Log.Information(
-            "[gesture] PillRemove on {Name} | {State}", db.Info.Name, SnapshotState());
-        if (State.Dbs.Count <= 1)
-        {
-            Log.Information(
-                "Refusing pill removal on {Name} — at least one DB must stay active",
-                db.Info.Name);
-            return;
-        }
-        RemoveActiveDb(db);
-    }
-
-    /// <summary>
-    /// One-line dump of the gesture-relevant VM state for log breadcrumbs.
-    /// Reads the bound collections so the log matches what the user sees.
-    /// </summary>
-    private string SnapshotState() =>
-        $"active=[{string.Join(",", State.Dbs.Select(d => d.Info.Name))}] " +
-        $"pending={Pending.PendingEdits.Count} stashed={StashedDbs.Count} " +
-        $"treeShape={(State.Dbs.Count == 1 ? "single" : "multi")}";
+    internal void RequestRemoveActiveDb(ActiveDb db) => ActiveSet.RequestRemoveActiveDb(db);
 
     /// <summary>
     /// Owning PLC name for the active DB, surfaced as a dim prefix in the
@@ -1004,158 +828,25 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// <summary>True when <see cref="CurrentPlcName"/> is non-empty.</summary>
     public bool HasCurrentPlcName => !string.IsNullOrEmpty(State.AnchorPlcName);
 
+    // DB-switcher dropdown state delegators (#80 slice 8b). XAML bindings
+    // keep going through the host until slice 9 rebinds to ActiveSet.X.
     public bool IsDataBlocksDropdownOpen
     {
-        get => _isDataBlocksDropdownOpen;
-        set => SetProperty(ref _isDataBlocksDropdownOpen, value);
+        get => ActiveSet.IsDataBlocksDropdownOpen;
+        set => ActiveSet.IsDataBlocksDropdownOpen = value;
     }
 
-    public bool IsLoadingDataBlocks
-    {
-        get => _isLoadingDataBlocks;
-        private set
-        {
-            if (SetProperty(ref _isLoadingDataBlocks, value))
-                OnPropertyChanged(nameof(ShowEmptyDataBlocksMessage));
-        }
-    }
+    public bool IsLoadingDataBlocks => ActiveSet.IsLoadingDataBlocks;
 
     /// <summary>Filtered, alphabetised list shown inside the dropdown.</summary>
-    public IReadOnlyList<DataBlockSummary> FilteredDataBlocks
-    {
-        get => _filteredDataBlocks;
-        private set
-        {
-            if (SetProperty(ref _filteredDataBlocks, value))
-            {
-                OnPropertyChanged(nameof(ShowEmptyDataBlocksMessage));
-                RebuildFilteredDataBlockItems();
-            }
-        }
-    }
-
-    private IReadOnlyList<DataBlockListItem> _filteredDataBlockItems = Array.Empty<DataBlockListItem>();
+    public IReadOnlyList<DataBlockSummary> FilteredDataBlocks => ActiveSet.FilteredDataBlocks;
 
     /// <summary>
     /// Multi-select dropdown rows (#58). Same membership and order as
     /// <see cref="FilteredDataBlocks"/>; each row wraps the summary with a
     /// transient IsActive flag that two-way binds to its checkbox.
     /// </summary>
-    public IReadOnlyList<DataBlockListItem> FilteredDataBlockItems
-    {
-        get => _filteredDataBlockItems;
-        private set => SetProperty(ref _filteredDataBlockItems, value);
-    }
-
-    private void RebuildFilteredDataBlockItems()
-    {
-        var items = new List<DataBlockListItem>(_filteredDataBlocks.Count);
-        foreach (var summary in _filteredDataBlocks)
-        {
-            var (isActive, isAnchor) = GetActiveStatusFor(summary);
-            var item = new DataBlockListItem(summary, isActive, isAnchor);
-            item.ToggleRequested += OnDataBlockListItemToggled;
-            items.Add(item);
-        }
-        FilteredDataBlockItems = items;
-    }
-
-    /// <summary>
-    /// True/false pair for a row: (isActive: in the dialog's active set,
-    /// isAnchor: index 0 of the active set, used as the UI's display
-    /// anchor). isAnchor carries no privilege over removability — it just
-    /// tells the row template whether to render the anchor decoration.
-    /// </summary>
-    private (bool isActive, bool isAnchor) GetActiveStatusFor(DataBlockSummary summary)
-    {
-        // Match on (Name, PlcName) — multi-PLC projects can host two DBs
-        // with the same name on different PLCs (#58 review must-fix #4).
-        // For index 0 the PLC name comes from State.AnchorPlcName (display
-        // state); for the rest we read each ActiveDb.PlcName directly.
-        for (int i = 0; i < State.Dbs.Count; i++)
-        {
-            var db = State.Dbs[i];
-            var plc = i == 0 ? State.AnchorPlcName : db.PlcName;
-            if (string.Equals(db.Info.Name, summary.Name, StringComparison.Ordinal)
-                && string.Equals(plc, summary.PlcName, StringComparison.Ordinal))
-                return (true, i == 0);
-        }
-        return (false, false);
-    }
-
-    /// <summary>
-    /// Pushes the current active-set state back into every existing row so
-    /// checkboxes stay accurate after the user toggles one (which mutates
-    /// the active set but doesn't rebuild the list).
-    /// </summary>
-    private void RefreshFilteredDataBlockItemsActiveState()
-    {
-        foreach (var item in _filteredDataBlockItems)
-        {
-            var (isActive, isAnchor) = GetActiveStatusFor(item.Summary);
-            item.SyncFrom(isActive, isAnchor);
-        }
-    }
-
-    private void OnDataBlockListItemToggled(DataBlockListItem item)
-    {
-        // The IsActive setter has already flipped to the new value. Peer
-        // model: checked → add to active set; unchecked → remove from active
-        // set, with the same Apply / Stash / Cancel prompt regardless of
-        // whether the row is the current anchor. The active set must keep
-        // at least one DB — refuse the last uncheck. Both branches funnel
-        // through State, so the cascade fires exactly once per toggle (#78).
-        var (wasActive, _) = GetActiveStatusFor(item.Summary);
-        bool wantActive = item.IsActive;
-        Log.Information(
-            "[gesture] Dropdown row {Name} {Direction} (was={WasActive} now={WantActive}) | {State}",
-            item.Name,
-            wantActive ? "CHECKED" : "UNCHECKED",
-            wasActive, wantActive, SnapshotState());
-
-        if (wantActive && !wasActive)
-        {
-            AddActiveDbToSet(item);
-        }
-        else if (!wantActive && wasActive)
-        {
-            if (State.Dbs.Count <= 1)
-            {
-                Log.Information(
-                    "Refusing to remove {Name} — at least one DB must stay active",
-                    item.Name);
-                // Snap the row checkbox back into sync with the unchanged
-                // active set — the cascade only fires when State actually
-                // changes, so we have to nudge the dropdown rows here.
-                RefreshFilteredDataBlockItemsActiveState();
-            }
-            else
-            {
-                var match = FindActiveDb(item.Summary);
-                if (match != null) RemoveActiveDb(match);
-                else RefreshFilteredDataBlockItemsActiveState();
-            }
-        }
-    }
-
-    /// <summary>
-    /// Pure-add path: append the dropdown-checked DB to the active set.
-    /// PendingEditStore (9814a6e) seeds pending values onto fresh VMs
-    /// after the rebuild, so the previously-required Apply/Stash/Cancel
-    /// rescue prompt on every other active DB is unnecessary — adding
-    /// a peer never destroys an in-progress edit (#93).
-    /// </summary>
-    private void AddActiveDbToSet(DataBlockListItem item)
-    {
-        var built = BuildActiveDbFromSummary(item.Summary);
-        if (built == null)
-        {
-            RefreshFilteredDataBlockItemsActiveState();
-            return;
-        }
-        ActiveSet.SetState(State.With(dbs: State.Dbs.Concat(new[] { built }).ToList()));
-        Log.Information("DB enabled via dropdown: {Name}", built.Info.Name);
-    }
+    public IReadOnlyList<DataBlockListItem> FilteredDataBlockItems => ActiveSet.FilteredDataBlockItems;
 
     /// <summary>
     /// Solo gesture (#58 peer-mode): replace the active set with just the
@@ -1177,216 +868,22 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// Compound op (#78): builds the next snapshot in a local and commits
     /// once at the end → exactly one cascade per gesture.
     /// </summary>
-    public void SoloActiveDb(DataBlockSummary target)
-    {
-        var original = State;
-        var current = original;
-        var targetDb = FindActiveDb(target);
-        bool targetWasNewlyBuilt = false;
-        if (targetDb == null)
-        {
-            // The user soloed a row that wasn't already checked — append it
-            // to the snapshot before pruning so the "leave only this one"
-            // invariant always holds.
-            var built = BuildActiveDbFromSummary(target);
-            if (built == null)
-            {
-                IsDataBlocksDropdownOpen = false;
-                return;
-            }
-            current = current.With(dbs: current.Dbs.Concat(new[] { built }).ToList());
-            targetDb = built;
-            targetWasNewlyBuilt = true;
-        }
-
-        var next = ComposeRemoveOthers(current, targetDb);
-
-        // If we just appended a fresh target and the prune loop bailed
-        // (next still carries DBs other than target), drop the whole
-        // composition: the user's Cancel applies to the entire gesture.
-        if (targetWasNewlyBuilt && next.Dbs.Count > 1)
-        {
-            Log.Information(
-                "Solo+Cancel reverted: target {Name} was newly built and a " +
-                "prune cancelled — restoring original active set",
-                target.Name);
-            IsDataBlocksDropdownOpen = false;
-            return;
-        }
-
-        ActiveSet.SetState(next);
-        IsDataBlocksDropdownOpen = false;
-    }
+    public void SoloActiveDb(DataBlockSummary target) => ActiveSet.SoloActiveDb(target);
 
     /// <summary>
-    /// Reference-based variant of <see cref="SoloActiveDb"/>. Originally
-    /// called from the chip body click; surviving as a public seam used by
-    /// tests and (in future) any "solo this DB" pill affordance. Same
-    /// prompts on every dropped DB with pending edits; if the user cancels
-    /// mid-solo, the remaining drops are skipped and the active set is
-    /// whatever survived.
+    /// Reference-based variant of <see cref="SoloActiveDb"/>. Delegator
+    /// for <see cref="ActiveSetViewModel.SoloActiveDbByReference"/>.
     /// </summary>
-    public void SoloActiveDbByReference(ActiveDb target)
-    {
-        Log.Information(
-            "[gesture] SoloByReference → {Name} | {State}",
-            target.Info.Name, SnapshotState());
-        if (State.Dbs.Count <= 1)
-        {
-            // Already the only active DB — there's nothing to solo away.
-            return;
-        }
-
-        ActiveSet.SetState(ComposeRemoveOthers(State, target));
-    }
+    public void SoloActiveDbByReference(ActiveDb target) => ActiveSet.SoloActiveDbByReference(target);
 
     /// <summary>
-    /// Composes the snapshot that results from removing every DB in
-    /// <paramref name="current"/> except <paramref name="target"/>. Walks
-    /// the others in storage order, calling <see cref="TryComputeRemove"/>
-    /// for each (which prompts on pending edits). If the user cancels mid-
-    /// loop, returns the partial composition so the active set ends up as
-    /// whatever survived. Caller assigns the result to <see cref="State"/>.
+    /// Inspector path delegator (#80 slice 8b). The slice owns the full
+    /// Reactivate flow (additive/replace prompt, snapshot composition,
+    /// stash-replay via the restoreStashOntoLive callback). The host
+    /// keeps this as a public-ish seam for tests that drove the legacy
+    /// internal call site directly.
     /// </summary>
-    private ActiveSetState ComposeRemoveOthers(ActiveSetState current, ActiveDb target)
-    {
-        var next = current;
-        foreach (var db in current.Dbs.Where(d => !ReferenceEquals(d, target)).ToList())
-        {
-            var step = TryComputeRemove(next, db);
-            if (step == null)
-            {
-                Log.Information(
-                    "Solo cancelled at {Name} — leaving partial set", db.Info.Name);
-                break;
-            }
-            next = step;
-        }
-        return next;
-    }
-
-    private bool IsSameSummary(ActiveDb db, DataBlockSummary summary)
-    {
-        // Mirror FindActiveDb's anchor PLC handling: the anchor reads its
-        // display PLC from State.AnchorPlcName; the rest carry their own
-        // PlcName on ActiveDb.
-        var isAnchor = State.Dbs.Count > 0 && ReferenceEquals(State.Dbs[0], db);
-        var plc = isAnchor ? State.AnchorPlcName : db.PlcName;
-        return string.Equals(db.Info.Name, summary.Name, StringComparison.Ordinal)
-            && string.Equals(plc, summary.PlcName, StringComparison.Ordinal);
-    }
-
-    /// <summary>
-    /// Inspector path: re-add a previously-stashed DB back into the active
-    /// set, drop the others (with the same Apply / Stash / Cancel prompt
-    /// every remove uses), pop the stash entry, and replay its edits onto
-    /// the live tree. One snapshot is composed across all of these and
-    /// committed once → exactly one cascade. The pending-value replay
-    /// runs after the State assignment so it lands on the freshly-built
-    /// tree, not on VMs the cascade is about to discard.
-    /// </summary>
-    private void ReactivateStashedDb(StashedDbState stash)
-    {
-        Log.Information(
-            "[gesture] Stash header click → reactivate {Name} | {State}",
-            stash.DbName, SnapshotState());
-        var summary = stash.Summary;
-        var current = State;
-        var target = FindActiveDb(summary);
-
-        // #92 — When the user has ≥2 active DBs and clicks a stash header,
-        // ask whether they want to *add* the stashed DB to the current
-        // session (additive) or *replace* the active set with it (the
-        // legacy single-DB behaviour). Single-DB sessions skip the prompt:
-        // there's nothing to "replace away" so the gesture is unambiguous
-        // and goes through the additive branch implicitly via the existing
-        // append-then-prune flow below (which becomes a no-op prune when
-        // current has only one DB == target).
-        if (current.Dbs.Count >= 2)
-        {
-            var decision = _messageBox.AskAddOrReplace(
-                Res.Format("Reactivate_AdditiveOrReplace_Text", summary.Name),
-                Res.Get("Reactivate_AdditiveOrReplace_Title"));
-            if (decision == AddOrReplaceResult.Cancel)
-            {
-                Log.Information("Reactivate cancelled by user for {Name}", summary.Name);
-                return;
-            }
-            if (decision == AddOrReplaceResult.Add)
-            {
-                ReactivateStashedDbAdditive(stash);
-                return;
-            }
-            // Replace falls through to the Replace path below.
-        }
-
-        if (target == null)
-        {
-            var built = BuildActiveDbFromSummary(summary);
-            if (built == null) return;
-            current = current.With(dbs: current.Dbs.Concat(new[] { built }).ToList());
-            target = built;
-        }
-
-        var next = ComposeRemoveOthers(current, target);
-
-        // Pop the stash entry inside the same snapshot so the cascade
-        // sees stashes-changed once. Other DBs that got stashed during
-        // ComposeRemoveOthers (peer with pending edits, user picked Stash)
-        // stay in next.Stashes — only the reactivated DB's entry is popped.
-        var stashKey = StashKey(summary);
-        if (next.Stashes.ContainsKey(stashKey))
-        {
-            var stashesNew = next.Stashes.ToDictionary(kv => kv.Key, kv => kv.Value);
-            stashesNew.Remove(stashKey);
-            next = next.With(stashes: stashesNew);
-        }
-
-        ActiveSet.SetState(next);
-
-        // Replay the stash edits onto the now-final live tree. Runs after
-        // State assignment so the cascade has already rebuilt RootMembers
-        // — otherwise the new PendingValue assignments would land on VMs
-        // the rebuild is about to discard.
-        var (restored, dropped) = RestoreStashOntoLive(stash);
-        if (restored > 0 || dropped > 0)
-        {
-            StatusText = dropped == 0
-                ? Res.Format("Status_DbSwitched_StashRestored", summary.Name, restored)
-                : Res.Format("Status_DbSwitched_StashPartial",
-                    summary.Name, restored, dropped);
-        }
-    }
-
-    /// <summary>
-    /// Additive branch of <see cref="ReactivateStashedDb"/>: append the
-    /// stashed DB to the active set without dropping any other active DBs,
-    /// pop its stash entry, replay its edits. One snapshot, one cascade.
-    /// </summary>
-    private void ReactivateStashedDbAdditive(StashedDbState stash)
-    {
-        var summary = stash.Summary;
-        var built = BuildActiveDbFromSummary(summary);
-        if (built == null) return;
-
-        var stashesNew = State.Stashes.ToDictionary(kv => kv.Key, kv => kv.Value);
-        stashesNew.Remove(StashKey(summary));
-        ActiveSet.SetState(State.With(
-            dbs: State.Dbs.Concat(new[] { built }).ToList(),
-            stashes: stashesNew));
-
-        // Multi-DB shape after additive add — scope the path lookup to the
-        // just-added DB's subtree so peer DBs with colliding member paths
-        // don't accidentally absorb the stashed edits (#82 path-identity).
-        var (restored, dropped) = RestoreStashOntoLive(stash, scopedTo: built);
-        if (restored > 0 || dropped > 0)
-        {
-            StatusText = dropped == 0
-                ? Res.Format("Status_DbSwitched_StashRestored", summary.Name, restored)
-                : Res.Format("Status_DbSwitched_StashPartial",
-                    summary.Name, restored, dropped);
-        }
-    }
+    internal void ReactivateStashedDb(StashedDbState stash) => ActiveSet.ReactivateStashedDb(stash);
 
     /// <summary>
     /// Re-runs the full UI rebuild after State.Dbs changes (add / remove /
@@ -1396,11 +893,22 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// filters + the flat list so the visible ListView (bound to FlatMembers,
     /// not RootMembers) doesn't need a stray click to refresh.
     /// </summary>
+    /// <summary>
+    /// Host-side log breadcrumb. The slice has its own equivalent
+    /// <c>SnapshotState</c>, but a couple of pure-host call sites
+    /// (RebuildAfterActiveSetChanged, OnSingleValueEdited) still need
+    /// to log gesture state without reaching across the slice boundary.
+    /// </summary>
+    private string BuildSnapshotForLog() =>
+        $"active=[{string.Join(",", State.Dbs.Select(d => d.Info.Name))}] " +
+        $"pending={Pending.PendingEdits.Count} stashed={StashedDbs.Count} " +
+        $"treeShape={(State.Dbs.Count == 1 ? "single" : "multi")}";
+
     private void RebuildAfterActiveSetChanged()
     {
         Log.Information(
             "[cascade] RebuildAfterActiveSetChanged → rebuilding tree | {State}",
-            SnapshotState());
+            BuildSnapshotForLog());
         // BuildRootMembersFromActiveDbs creates fresh MemberNodeViewModel
         // instances on every rebuild, so any selection / scope / manual-
         // selection state held by reference points at orphaned VMs from
@@ -1415,7 +923,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         Tree.BuildRootMembersFromActiveDbs();
         ApplyAllFilters();
         RefreshFlatList();
-        RebuildPlcPills();
+        ActiveSet.RebuildPlcPills();
         // PendingEdits / BulkPreview hold MemberNodeViewModel references —
         // BuildRootMembersFromActiveDbs just minted fresh ones, so any
         // surviving entries point at orphans from the prior tree. Without
@@ -1454,139 +962,62 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     }
 
     /// <summary>
-    /// Pure builder (#78): produces a fully-wired <see cref="ActiveDb"/>
-    /// for a dropdown-picked DB without touching <see cref="State"/>.
-    /// Compound mutations (Solo, Reactivate) call this directly and
-    /// fold the result into their composed snapshot; the simple
-    /// "checkbox checked" path goes through
-    /// <see cref="AddActiveDbFromSummary"/>, which builds + assigns.
+    /// Slice 8b wiring: passed to <see cref="ActiveSetViewModel"/> as the
+    /// <c>buildActiveDbForSummary</c> callback. Preferred path delegates
+    /// to the host-supplied factory (which wires per-DB OnApply); the
+    /// fallback (DevLauncher / tests with no factory) reuses the older
+    /// <c>switchToDataBlock(summary) → xml</c> + parser path to mint a
+    /// read-only <see cref="ActiveDb"/>. Read-only DBs explicitly route
+    /// Apply as a no-op on the multi-DB Apply pipeline.
     /// </summary>
-    private ActiveDb? BuildActiveDbFromSummary(DataBlockSummary summary)
+    private ActiveDb? BuildActiveDbFromSummaryWithFallback(DataBlockSummary summary)
     {
-        try
+        // Preferred path (#58): host supplies a fully-wired ActiveDb,
+        // including a per-DB OnApply that re-imports the modified xml
+        // back into TIA. Symmetric with the context-menu's ActiveDbFactory.
+        if (_buildActiveDbForSummary != null)
         {
-            // Preferred path (#58): host supplies a fully-wired ActiveDb,
-            // including a per-DB OnApply that re-imports the modified xml
-            // back into TIA. This is symmetric with the context-menu's
-            // ActiveDbFactory so dropdown-added DBs are first-class for
-            // Apply, not read-only.
-            if (_buildActiveDbForSummary != null)
-            {
-                var built = _buildActiveDbForSummary(summary);
-                if (built == null)
-                    Log.Information("ActiveDb build returned null for {Name}", summary.Name);
-                return built;
-            }
-
-            // Fallback (DevLauncher / tests): no host factory wired. Use
-            // the older _switchToDataBlock(summary) → xml callback to
-            // build a READ-ONLY ActiveDb. Apply on this DB will be a
-            // no-op (OnApply is null); the multi-DB Apply path skips
-            // null callbacks rather than throwing, and the
-            // remove-with-stash-prompt's 'Apply, then remove' branch
-            // refuses to charge a quota unit for a write that never
-            // reaches TIA.
-            if (_switchToDataBlock == null)
-            {
-                Log.Information(
-                    "DB enable ignored: neither buildActiveDbForSummary nor switchToDataBlock wired");
-                return null;
-            }
-            var xml = _switchToDataBlock(summary);
-            var constantResolver = _tagTableCache != null
-                ? new TagTableConstantResolver(_tagTableCache)
-                : (IConstantResolver?)null;
-            var parser = new SimaticMLParser(constantResolver, _udtResolver, _commentResolver);
-            var info = parser.Parse(xml);
-            // PlcName from State.AnchorPlcName: the dropdown only enumerates DBs
-            // from the anchor's PLC, so any read-only-fallback addition is
-            // implicitly on the same PLC as the anchor.
-            return new ActiveDb(info, xml, onApply: null, plcName: State.AnchorPlcName);
+            var built = _buildActiveDbForSummary(summary);
+            if (built == null)
+                Log.Information("ActiveDb build returned null for {Name}", summary.Name);
+            return built;
         }
-        catch (Exception ex)
-        {
-            Log.Warning(ex, "Failed to build ActiveDb {Name}", summary.Name);
-            StatusText = Res.Format("Status_DbSwitchFailed", summary.Name, ex.Message);
-            return null;
-        }
-    }
 
-    /// <summary>
-    /// Single-step add (dropdown checkbox-on). Builds the ActiveDb and
-    /// commits to <see cref="State"/> in one shot — the cascade fires
-    /// once on the resulting snapshot. Compound paths build directly via
-    /// <see cref="BuildActiveDbFromSummary"/> and skip this wrapper.
-    /// </summary>
-    private void AddActiveDbFromSummary(DataBlockSummary summary)
-    {
-        var built = BuildActiveDbFromSummary(summary);
-        if (built == null) return;
-        ActiveSet.SetState(State.With(dbs: State.Dbs.Concat(new[] { built }).ToList()));
-        Log.Information("DB enabled via dropdown: {Name}", built.Info.Name);
-    }
-
-    /// <summary>
-    /// Looks up an active DB by (Name, PlcName) so dropdown rows resolve to
-    /// the right ActiveDb instance even in multi-PLC projects where two
-    /// PLCs share a DB name (#58 review must-fix #4).
-    /// </summary>
-    private ActiveDb? FindActiveDb(DataBlockSummary summary)
-    {
-        for (int i = 0; i < State.Dbs.Count; i++)
-        {
-            var db = State.Dbs[i];
-            // Index 0 reads its display PLC from State.AnchorPlcName; the
-            // rest read it from each ActiveDb directly.
-            var plc = i == 0 ? State.AnchorPlcName : db.PlcName;
-            if (string.Equals(db.Info.Name, summary.Name, StringComparison.Ordinal)
-                && string.Equals(plc, summary.PlcName, StringComparison.Ordinal))
-                return db;
-        }
-        return null;
-    }
-
-    /// <summary>
-    /// User's choice in response to the "this DB has pending edits" prompt
-    /// raised when removing a DB from the active set (#78). Centralised so
-    /// every remove path maps the <see cref="ApplyStashCancelResult"/>
-    /// the same way: ApplyAndSwitch→Apply, StashAndSwitch→Stash, Cancel→Cancel.
-    /// <c>NoEdits</c> is the no-prompt fast path.
-    /// </summary>
-    private enum PendingDecision { NoEdits, Apply, Stash, Cancel }
-
-    /// <summary>
-    /// Single source of truth for the 3-way prompt that fires whenever a
-    /// DB with pending inline edits is about to be dropped from the active
-    /// set (#78). Returns <see cref="PendingDecision.NoEdits"/> immediately
-    /// if there's nothing pending — caller proceeds with the removal
-    /// without showing a dialog.
-    /// </summary>
-    private PendingDecision PromptForPendingEditsOnRemove(ActiveDb db)
-    {
-        var pendingCount = CountPendingEditsForDb(db);
-        if (pendingCount == 0)
+        // Fallback (DevLauncher / tests): no host factory wired. The
+        // older switchToDataBlock(summary) → xml callback feeds the
+        // parser, then we mint a READ-ONLY ActiveDb (OnApply == null).
+        if (_switchToDataBlock == null)
         {
             Log.Information(
-                "[prompt] no-prompt fast path on {Name} (CountPendingEditsForDb=0) | {State}",
-                db.Info.Name, SnapshotState());
-            return PendingDecision.NoEdits;
+                "DB enable ignored: neither buildActiveDbForSummary nor switchToDataBlock wired");
+            return null;
         }
-        Log.Information(
-            "[prompt] Showing 3-way for {Name} (pending={Pending}) | {State}",
-            db.Info.Name, pendingCount, SnapshotState());
-        var result = _messageBox.AskApplyStashCancel(
-            Res.Format("Dialog_SwitchDb_KeepConfirm_Text",
-                pendingCount, db.Info.Name),
-            Res.Get("Dialog_SwitchDb_KeepConfirm_Title"));
-        Log.Information(
-            "[prompt] User picked {Result} for {Name}", result, db.Info.Name);
-        return result switch
-        {
-            ApplyStashCancelResult.ApplyAndSwitch => PendingDecision.Apply,
-            ApplyStashCancelResult.StashAndSwitch => PendingDecision.Stash,
-            _ => PendingDecision.Cancel,
-        };
+        var xml = _switchToDataBlock(summary);
+        var constantResolver = _tagTableCache != null
+            ? new TagTableConstantResolver(_tagTableCache)
+            : (IConstantResolver?)null;
+        var parser = new SimaticMLParser(constantResolver, _udtResolver, _commentResolver);
+        var info = parser.Parse(xml);
+        // PlcName from State.AnchorPlcName: the dropdown only enumerates DBs
+        // from the anchor's PLC, so any read-only-fallback addition is
+        // implicitly on the same PLC as the anchor.
+        return new ActiveDb(info, xml, onApply: null, plcName: State.AnchorPlcName);
     }
+
+    // AddActiveDbFromSummary, FindActiveDb, PendingDecision,
+    // PromptForPendingEditsOnRemove, CaptureStashForDb, TryComputeRemove,
+    // RemoveActiveDb, CountPendingEditsForDb moved to ActiveSetViewModel
+    // (#80 slice 8b). The dead-code IsSameSummary helper was dropped per
+    // PR #110 review (zero callers in src/). Slice exposes
+    // AddActiveDbFromSummary as a public delegator surface for tests; the
+    // others are slice-private.
+
+    /// <summary>
+    /// Delegator surface for tests that drive the dropdown checkbox-on path
+    /// directly. The slice owns the implementation.
+    /// </summary>
+    internal void AddActiveDbFromSummary(DataBlockSummary summary)
+        => ActiveSet.AddActiveDbFromSummary(summary);
 
     /// <summary>
     /// Close-confirm prompt fired when both the active DB and stashed DBs
@@ -1602,112 +1033,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             Res.Format("Dialog_UnsavedChanges_Prompt_WithStash",
                 active, stashedCount, stashedDbList),
             Res.Get("Dialog_UnsavedChanges_Title"));
-    }
-
-    /// <summary>
-    /// Snapshots pending inline edits for <paramref name="db"/> into an
-    /// inert <see cref="StashedDbState"/> ready to be added to a new
-    /// <see cref="ActiveSetState"/>. Returns null when the DB has no
-    /// pending edits to capture. Reads from the store — unambiguous in
-    /// multi-DB sessions where the same Path can exist in multiple DBs,
-    /// and correct even if the tree hasn't rebuilt yet. Pure read —
-    /// does NOT mutate <c>State.Stashes</c> (the snapshot setter does).
-    /// </summary>
-    private StashedDbState? CaptureStashForDb(ActiveDb db)
-    {
-        var entries = new List<StashedEditEntry>();
-        foreach (var (node, pendingValue) in _pendingEditStore.GetForDb(db, Tree.ModelToDb))
-        {
-            // Resolve to the VM to read StartValue (which is model-derived
-            // and stable). If the VM can't be found the model is still valid.
-            var vm = Tree.FindVmByModel(node);
-            entries.Add(new StashedEditEntry(
-                node.Path,
-                vm?.StartValue ?? node.StartValue ?? "",
-                pendingValue));
-        }
-        if (entries.Count == 0) return null;
-        var summary = new DataBlockSummary(
-            db.Info.Name,
-            "",
-            blockType: db.Info.BlockType,
-            isInstanceDb: string.Equals(db.Info.BlockType, "InstanceDB", StringComparison.Ordinal),
-            plcName: State.AnchorPlcName);
-        return new StashedDbState(summary, entries);
-    }
-
-    /// <summary>
-    /// Computes the next snapshot after removing <paramref name="db"/>
-    /// from <paramref name="current"/>. Side-effects (the user-visible
-    /// prompt + Apply branch's per-DB OnApply + usage-counter charge)
-    /// run here because they MUST occur against the live (pre-cascade)
-    /// tree. Returns null if the user cancelled or the Apply branch
-    /// failed (cap hit / read-only OnApply); caller treats null as
-    /// "abort this remove."
-    /// </summary>
-    private ActiveSetState? TryComputeRemove(ActiveSetState current, ActiveDb db)
-    {
-        var decision = PromptForPendingEditsOnRemove(db);
-        if (decision == PendingDecision.Cancel)
-        {
-            Log.Information("DB remove cancelled by user: {Name}", db.Info.Name);
-            return null;
-        }
-        if (decision == PendingDecision.Apply)
-        {
-            if (!TryApplyActiveDbInPlace(db))
-            {
-                Log.Information(
-                    "DB remove aborted: pending Apply did not succeed for {Name}",
-                    db.Info.Name);
-                return null;
-            }
-        }
-
-        IReadOnlyDictionary<string, StashedDbState> nextStashes = current.Stashes;
-        if (decision == PendingDecision.Stash)
-        {
-            var captured = CaptureStashForDb(db);
-            if (captured != null)
-            {
-                var dict = current.Stashes.ToDictionary(kv => kv.Key, kv => kv.Value);
-                dict[StashKey(captured.Summary)] = captured;
-                nextStashes = dict;
-            }
-        }
-
-        var nextDbs = current.Dbs.Where(d => !ReferenceEquals(d, db)).ToList();
-        // Anchor handoff: only when the removed DB was the anchor; the
-        // new anchor is whatever moved into nextDbs[0]. Same rule as the
-        // legacy RemoveActiveDb.
-        var nextAnchor = current.AnchorPlcName;
-        if (current.Dbs.Count > 0 && ReferenceEquals(db, current.Dbs[0]))
-        {
-            nextAnchor = nextDbs.Count > 0 ? (nextDbs[0].PlcName ?? "") : "";
-        }
-
-        Log.Information(
-            ReferenceEquals(db, current.Dbs[0])
-                ? "Anchor removed: now {NewName} (was: {OldName})"
-                : "DB disabled: {OldName}",
-            nextDbs.Count > 0 ? nextDbs[0].Info.Name : "<empty>",
-            db.Info.Name);
-
-        return new ActiveSetState(nextDbs, nextStashes, nextAnchor);
-    }
-
-    /// <summary>
-    /// Single-step remove (chip × / dropdown uncheck). Compound paths
-    /// (solo, reactivate) call <see cref="TryComputeRemove"/> directly
-    /// to compose multiple removes into one snapshot before assigning.
-    /// </summary>
-    /// <returns>true if removed; false if the user cancelled.</returns>
-    private bool RemoveActiveDb(ActiveDb db)
-    {
-        var next = TryComputeRemove(State, db);
-        if (next == null) return false;
-        ActiveSet.SetState(next);
-        return true;
     }
 
     /// <summary>
@@ -1731,15 +1056,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // values that were just committed.
         _pendingEditStore.ClearForDb(db, Tree.ModelToDb);
     }
-
-    /// <summary>
-    /// Counts pending inline edits inside a DB's subtree. Used by the
-    /// remove-with-stash-prompt flow (#58, #78). Reads from the store
-    /// rather than walking the VM tree — O(store.Count) instead of
-    /// O(subtree size), and correct even when the tree hasn't rebuilt yet.
-    /// </summary>
-    private int CountPendingEditsForDb(ActiveDb db)
-        => _pendingEditStore.CountForDb(db, Tree.ModelToDb);
 
     /// <summary>
     /// Best-effort "apply this DB's edits before we remove it" (#58
@@ -1803,77 +1119,19 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     }
 
     /// <summary>True when enumeration is settled but the filter matches nothing.</summary>
-    public bool ShowEmptyDataBlocksMessage =>
-        !_isLoadingDataBlocks
-        && _availableDataBlocks != null
-        && _filteredDataBlocks.Count == 0;
+    public bool ShowEmptyDataBlocksMessage => ActiveSet.ShowEmptyDataBlocksMessage;
 
     /// <summary>Type-to-filter text for the dropdown's search box.</summary>
     public string DataBlockSearchText
     {
-        get => _dataBlockSearchText;
-        set
-        {
-            if (SetProperty(ref _dataBlockSearchText, value))
-                ApplyDataBlockFilter();
-        }
+        get => ActiveSet.DataBlockSearchText;
+        set => ActiveSet.DataBlockSearchText = value;
     }
 
-    /// <summary>
-    /// Lazy-load + cache enumeration result. Subsequent opens are O(filter)
-    /// — no re-enumeration unless the user clicks ↻ (#59).
-    /// </summary>
-    private void ExecuteOpenDataBlocksDropdown()
-    {
-        if (_availableDataBlocks == null)
-            LoadAvailableDataBlocks(force: false);
-
-        ApplyDataBlockFilter();
-        IsDataBlocksDropdownOpen = true;
-    }
-
-    private void ExecuteRefreshDataBlocks()
-    {
-        LoadAvailableDataBlocks(force: true);
-        ApplyDataBlockFilter();
-    }
-
-    private void LoadAvailableDataBlocks(bool force)
-    {
-        if (_enumerateDataBlocks == null) return;
-        if (!force && _availableDataBlocks != null) return;
-
-        IsLoadingDataBlocks = true;
-        try
-        {
-            // Enumeration runs on the UI thread today: TIA Openness calls
-            // must originate from the same thread that owns the project.
-            // The visible spinner + the dialog's scoped scope keep this OK
-            // for typical project sizes; if it ever bites we'd move the
-            // enumeration onto a background task with a marshalled call.
-            _availableDataBlocks = DataBlockListFilter.Sort(_enumerateDataBlocks());
-        }
-        catch (Exception ex)
-        {
-            Log.Error(ex, "DB enumeration failed");
-            _availableDataBlocks = Array.Empty<DataBlockSummary>();
-            StatusText = Res.Format("Status_DbEnumFailed", ex.Message);
-        }
-        finally
-        {
-            IsLoadingDataBlocks = false;
-        }
-    }
-
-    private void ApplyDataBlockFilter()
-    {
-        var source = _availableDataBlocks ?? (IReadOnlyList<DataBlockSummary>)Array.Empty<DataBlockSummary>();
-        FilteredDataBlocks = DataBlockListFilter.Filter(source, _dataBlockSearchText);
-    }
-
-    private static string StashKey(DataBlockSummary summary) =>
-        $"{summary.PlcName}\u0001{summary.FolderPath}\u0001{summary.Name}";
-
+    // ExecuteOpenDataBlocksDropdown / ExecuteRefreshDataBlocks /
+    // LoadAvailableDataBlocks / ApplyDataBlockFilter / StashKey all moved
+    // to ActiveSetViewModel (#80 slice 8b). Commands wired through
+    // ActiveSet.{Open,Close,Refresh}DataBlocksDropdownCommand.
 
     /// <summary>
     /// Builds the dialog window title. Single-DB sessions render
@@ -3741,7 +2999,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     {
         Log.Information(
             "[gesture] Inline edit on {Path}: '{Old}' → '{New}' | {State}",
-            memberVm.Path, memberVm.StartValue ?? "", newValue, SnapshotState());
+            memberVm.Path, memberVm.StartValue ?? "", newValue, BuildSnapshotForLog());
         if (string.IsNullOrEmpty(newValue))
         {
             // Inline revert / cleared field: drop any stale validation error


### PR DESCRIPTION
## Summary

Second half of slice 8 from #80 — the user picked the 8a + 8b split,
and 8a (state container) landed in #111. Slice 8b moves the
**mutators**, **DB-switcher**, and **PlcPills** into the same
`ActiveSetViewModel` class. After this lands, only host cleanup
(slice 9) and `IsSameSummary`-style dead-code is left from the
original #80 plan.

### Intentional behavior change

**`TryComputeRemove` Stash branch now also evicts `_pendingEditStore`
entries for the removed DB** (`ActiveSetViewModel.cs:1097-1098`).
Pre-PR, only the Apply branch (`TryApplyActiveDbInPlace`) and
`ClearPendingValuesForDb` evicted; the Stash branch left store
entries pointing at MemberNode references from the now-removed DB
that nothing cleaned up after the tree rebuild. Strictly an
improvement (the orphaned references were dead-key memory weight,
not active bugs — lookups are by node reference, so no live DB
"inherited" them), and it matches Apply's behavior for symmetry.
Flagged here so future bisecters don't have to rediscover it.
Test `RequestRemoveActiveDb_PendingEditsPrompt_Stash_ClearsStore`
locks in the new contract.

### What moved (~1,045 LOC, into `src/BlockParam/UI/ActiveSetViewModel.cs`)

| Cluster | LOC | Includes |
|---|---:|---|
| Mutators | ~583 | `AddActiveDbFromSummary` / `AddActiveDbToSet` / `SoloActiveDb` (+ `SoloActiveDbByReference` + `ComposeRemoveOthers`) / `RequestRemoveActiveDb` / `TryComputeRemove` (3-branch Apply/Stash/Cancel) / `ReactivateStashedDb` (+ `ReactivateStashedDbAdditive`) / `BuildActiveDbFromSummary` / `FindActiveDb` / `PendingDecision` / `PromptForPendingEditsOnRemove` / `CaptureStashForDb` / `CountPendingEditsForDb` / `StashKey` / `SnapshotState` |
| DB-switcher | ~251 | dropdown state fields, 4 commands (`OpenDataBlocksDropdownCommand` / `CloseDataBlocksDropdownCommand` / `RefreshDataBlocksCommand` / `SwitchToStashedDbCommand`), `FilteredDataBlocks` + `FilteredDataBlockItems`, `DataBlockSearchText`, filter / refresh / item-toggle handlers |
| PlcPills | ~211 | `PlcPills` ObservableCollection, `_extraPillPlcs` + `_syncingPillSelection` re-entrancy guard, `InactiveProjectPlcs` + `CanAddPlc` + `IsAddDbPopupOpen`, `RebuildPlcPills` + `OnPillSelectionChanged` + `GetActiveItemsForPlc` + `LoadDbsForPlcAsync` + `AddPlcToRow` |

### What stayed on host (with callbacks into slice)

Per the agent's surface map — these touch too many host slices to
justify moving:

- **`TryApplyActiveDbInPlace`** (the Apply branch of `TryComputeRemove`)
  — touches `_writer`, `Subscription.GetUsageStatus/RecordUsage`,
  `_pendingEditStore`, `Tree.ModelToDb`, `StatusText`, `db.OnApply`.
  Slice receives `Func<ActiveDb, bool> tryApplyActiveDbInPlace`.
- **`RestoreStashOntoLive`** — touches Tree, `_configLoader`,
  `_analyzer`, `_tagTableCache`, `_udtResolver`, `_pendingEditStore`,
  `Pending`. Slice receives
  `Func<StashedDbState, ActiveDb?, (int restored, int dropped)> restoreStashOntoLive`.
- **`RebuildAfterActiveSetChanged`** — host's `StateChanged`
  subscriber; runs the cross-slice cascade (Tree / Selection /
  Pending / Filter / ApplyAllFilters / RefreshFlatList).
- **`BuildTitle` / `RefreshAnchorDisplay` / `_active` alias** —
  host UI state.

### Slice constructor

The 8a `ActiveSetViewModel(ActiveSetState initial)` constructor
stays — all 8b deps are optional with safe defaults so the 12
slice-8a tests keep passing unchanged. Mutators that need a
missing dep throw a clear `InvalidOperationException` rather than
NREing silently.

Full ctor shape:

```csharp
public ActiveSetViewModel(
    ActiveSetState initial,
    IMessageBoxService? messageBox = null,
    PendingEditStore? pendingEditStore = null,
    Func<IReadOnlyDictionary<MemberNode, ActiveDb>>? getModelToDb = null,
    Func<MemberNode, string?>? getStartValueForNode = null,
    Func<DataBlockSummary, ActiveDb?>? buildActiveDbForSummary = null,
    Func<IReadOnlyList<DataBlockSummary>>? enumerateDataBlocks = null,
    Func<DataBlockSummary, string>? switchToDataBlock = null,
    Func<ActiveDb, bool>? tryApplyActiveDbInPlace = null,
    Func<StashedDbState, ActiveDb?, (int restored, int dropped)>? restoreStashOntoLive = null,
    Action<string>? setStatus = null,
    Func<int>? getPendingCount = null,
    Dispatcher? dispatcher = null)
```

Two deviations from the original spec (both reasonable):

1. **`getModelToDb`** returns the live dictionary rather than a
   single-node lookup, because `PendingEditStore.GetForDb` consumes
   the full dict. Cheap reference pass.
2. **`getStartValueForNode`** is a separate accessor used by the
   stash-capture path so the slice doesn't need a `Tree.X` reference.

### Host delegators kept

For each of the ~73 test sites referencing the moved surface, the
host keeps a one-line delegator (`=> ActiveSet.X(...)`). Same
pattern slices 1–8a followed; slice 9 drops the delegators in one
sweep. Delegators: methods (`RequestRemoveActiveDb`, `SoloActiveDb`,
`SoloActiveDbByReference`, `AddPlcToRow`, `AddActiveDbFromSummary`,
`ReactivateStashedDb`), properties (`PlcPills`, `FilteredDataBlocks`,
`FilteredDataBlockItems`, `DataBlockSearchText`,
`IsDataBlocksDropdownOpen`, `IsLoadingDataBlocks`,
`HasMultipleActiveDbs`, `InactiveProjectPlcs`, `CanAddPlc`,
`HasDataBlockSwitcher`, `ShowEmptyDataBlocksMessage`,
`IsAddDbPopupOpen`), and the 4 DB-switcher commands.

### XAML

`HasDataBlockSwitcher`, `PlcPills`, `CanAddPlc`, `IsAddDbPopupOpen`,
`InactiveProjectPlcs` rebound to `{Binding ActiveSet.X}`. Per-PR-#111
established pattern.

### Dropped

- **`IsSameSummary` removed** (the dead helper flagged by the
  PR #110 review — zero callers in `src/`). New test
  `NoIsSameSummaryReferenceInSlice` reads the slice source and
  asserts the symbol stays gone, so a future regression that
  reintroduces dead code is caught.
- **Host's `_enumerateDataBlocks` field** removed — only the slice
  keeps it; the host's `BuildActiveDbFromSummaryWithFallback` only
  needed `_switchToDataBlock`.

### Tests

New `src/BlockParam.Tests/ActiveSetViewModelMutatorTests.cs` (18 facts):

- `AddActiveDbFromSummary` happy path + StateChanged payload.
- `SoloActiveDb` target found / not found / already-only no-op.
- `RequestRemoveActiveDb` last-DB refused.
- `TryComputeRemove` clean (no prompt) vs Apply / Stash / Cancel
  branches — each verifying the right callback fires and the
  pendingEditStore touched / not touched.
- `ReactivateStashedDb` — stash removed from key set, callback
  invoked.
- DB-switcher open / filter / refresh.
- PlcPills rebuild after Dbs change.
- Dead-code regression test for `IsSameSummary`.

NSubstitute mocks the message-box service and the two host
callbacks.

### Numbers

- **Slice file**: 87 → **1,150 LOC** (+1,063).
- **Host VM**: 4,135 → **3,393 LOC** (−742). Net 18% reduction
  vs main; cumulative 31% reduction from the pre-slice 4,931 LOC
  baseline.
- **New tests**: 509 LOC.
- **XAML**: 5 binding rebinds.

### Next

Slice 9 (host cleanup) drops the ~25 host delegators added in
slices 1–8b, folds `RefreshAnchorDisplay` / `BuildTitle` into the
slice (or wherever they end up best), and does a lint pass for
remaining `// removed` style comments. The #80 issue closes
after that.

## Test plan

- [ ] CI `Build & Test (V20, net48)` green — includes 18 new
      mutator-test facts + the 12 8a facts + all existing host /
      invariant / multi-DB / DB-switcher tests
- [ ] CI `Build (V21, net48)` green
- [ ] No host-VM tests touched in this PR

Refs #80.

https://claude.ai/code/session_0168J7dK7tApviBaDquX6gUd