### PR TITLE
refactor(#80): drop host delegators + PropertyChanged forwarder (slice 9a)

### DIFF
--- a/src/BlockParam.Tests/BulkChangeViewModelDbSwitcherTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelDbSwitcherTests.cs
@@ -205,10 +205,10 @@ public class BulkChangeViewModelDbSwitcherTests
 
         // Remove anchor → Keep (stash).
         var anchorDbA1 = vm.AllActiveDbs.First(d => d.Info.Name == aInfo.Name);
-        vm.RequestRemoveActiveDb(anchorDbA1);
+        vm.ActiveSet.RequestRemoveActiveDb(anchorDbA1);
 
-        vm.StashedDbs.Should().HaveCount(1);
-        vm.StashedDbs[0].Summary.PlcName.Should().Be("PLC_Line1",
+        vm.ActiveSet.StashedDbs.Should().HaveCount(1);
+        vm.ActiveSet.StashedDbs[0].Summary.PlcName.Should().Be("PLC_Line1",
             "stash must record which PLC the edits came from — without the PlcName " +
             "in the StashKey, two DBs with identical (name, folder) on different PLCs " +
             "would collide.");
@@ -250,11 +250,11 @@ public class BulkChangeViewModelDbSwitcherTests
 
         // Remove anchor → Keep (stash).
         var anchorDbA2 = vm.AllActiveDbs.First(d => d.Info.Name == aInfo.Name);
-        vm.RequestRemoveActiveDb(anchorDbA2);
+        vm.ActiveSet.RequestRemoveActiveDb(anchorDbA2);
 
-        vm.StashedDbs.Should().HaveCount(1);
-        vm.StashedDbs[0].DbName.Should().Be(aInfo.Name);
-        vm.StashedDbs[0].FolderPath.Should().Be("",
+        vm.ActiveSet.StashedDbs.Should().HaveCount(1);
+        vm.ActiveSet.StashedDbs[0].DbName.Should().Be(aInfo.Name);
+        vm.ActiveSet.StashedDbs[0].FolderPath.Should().Be("",
             "FolderPath is part of the stash key — without it, same-named DBs in " +
             "different folders would collide.");
     }
@@ -300,11 +300,11 @@ public class BulkChangeViewModelDbSwitcherTests
 
         // 2. Remove A with Keep → A stashed, B becomes sole active anchor.
         var anchorDbA3 = vm.AllActiveDbs.First(d => d.Info.Name == aInfo.Name);
-        vm.RequestRemoveActiveDb(anchorDbA3);
+        vm.ActiveSet.RequestRemoveActiveDb(anchorDbA3);
         vm.AllActiveDbs.Should().ContainSingle()
             .Which.Info.Name.Should().Be(bInfo.Name);
-        vm.StashedDbs.Should().HaveCount(1);
-        vm.StashedDbs[0].DbName.Should().Be(aInfo.Name);
+        vm.ActiveSet.StashedDbs.Should().HaveCount(1);
+        vm.ActiveSet.StashedDbs[0].DbName.Should().Be(aInfo.Name);
 
         // 3. Stage on B (now anchor) and Apply.
         vm.Tree.RootMembers.First(m => m.IsLeaf).EditableStartValue = "222";
@@ -314,10 +314,10 @@ public class BulkChangeViewModelDbSwitcherTests
         applyCount.Should().Be(1, "only B is active — exactly one OnApply fires");
 
         // 4. A's stash must still be there.
-        vm.StashedDbs.Should().HaveCount(1);
-        vm.StashedDbs[0].DbName.Should().Be(aInfo.Name);
-        vm.StashedDbs[0].Edits.Should().HaveCount(1);
-        vm.StashedDbs[0].Edits[0].PendingValue.Should().Be("111",
+        vm.ActiveSet.StashedDbs.Should().HaveCount(1);
+        vm.ActiveSet.StashedDbs[0].DbName.Should().Be(aInfo.Name);
+        vm.ActiveSet.StashedDbs[0].Edits.Should().HaveCount(1);
+        vm.ActiveSet.StashedDbs[0].Edits[0].PendingValue.Should().Be("111",
             "Apply on B doesn't touch the stash dictionary");
     }
 

--- a/src/BlockParam.Tests/BulkChangeViewModelDbSwitcherTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelDbSwitcherTests.cs
@@ -83,7 +83,7 @@ public class BulkChangeViewModelDbSwitcherTests
     public void HasDataBlockSwitcher_TrueWhenCallbacksWired()
     {
         var h = CreateVm();
-        h.Vm.HasDataBlockSwitcher.Should().BeTrue();
+        h.Vm.ActiveSet.HasDataBlockSwitcher.Should().BeTrue();
     }
 
     [Fact]
@@ -125,16 +125,16 @@ public class BulkChangeViewModelDbSwitcherTests
     {
         var h = CreateVm();
 
-        h.Vm.OpenDataBlocksDropdownCommand.Execute(null);
+        h.Vm.ActiveSet.OpenDataBlocksDropdownCommand.Execute(null);
         h.EnumerateCallCount().Should().Be(1);
-        h.Vm.IsDataBlocksDropdownOpen.Should().BeTrue();
-        h.Vm.FilteredDataBlocks.Should().HaveCount(2);
+        h.Vm.ActiveSet.IsDataBlocksDropdownOpen.Should().BeTrue();
+        h.Vm.ActiveSet.FilteredDataBlocks.Should().HaveCount(2);
 
         // Close and reopen: enumeration MUST NOT run again — cache hit.
-        h.Vm.IsDataBlocksDropdownOpen = false;
-        h.Vm.OpenDataBlocksDropdownCommand.Execute(null);
+        h.Vm.ActiveSet.IsDataBlocksDropdownOpen = false;
+        h.Vm.ActiveSet.OpenDataBlocksDropdownCommand.Execute(null);
         h.EnumerateCallCount().Should().Be(1);
-        h.Vm.IsDataBlocksDropdownOpen.Should().BeTrue();
+        h.Vm.ActiveSet.IsDataBlocksDropdownOpen.Should().BeTrue();
     }
 
     [Fact]
@@ -142,10 +142,10 @@ public class BulkChangeViewModelDbSwitcherTests
     {
         var h = CreateVm();
 
-        h.Vm.OpenDataBlocksDropdownCommand.Execute(null);
+        h.Vm.ActiveSet.OpenDataBlocksDropdownCommand.Execute(null);
         h.EnumerateCallCount().Should().Be(1);
 
-        h.Vm.RefreshDataBlocksCommand.Execute(null);
+        h.Vm.ActiveSet.RefreshDataBlocksCommand.Execute(null);
         h.EnumerateCallCount().Should().Be(2);
     }
 
@@ -159,11 +159,11 @@ public class BulkChangeViewModelDbSwitcherTests
             new DataBlockSummary("DB_Sensors", ""),
         });
 
-        h.Vm.OpenDataBlocksDropdownCommand.Execute(null);
-        h.Vm.DataBlockSearchText = "Sensors";
+        h.Vm.ActiveSet.OpenDataBlocksDropdownCommand.Execute(null);
+        h.Vm.ActiveSet.DataBlockSearchText = "Sensors";
 
-        h.Vm.FilteredDataBlocks.Should().HaveCount(1);
-        h.Vm.FilteredDataBlocks[0].Name.Should().Be("DB_Sensors");
+        h.Vm.ActiveSet.FilteredDataBlocks.Should().HaveCount(1);
+        h.Vm.ActiveSet.FilteredDataBlocks[0].Name.Should().Be("DB_Sensors");
     }
 
     [Fact]

--- a/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
@@ -61,12 +61,12 @@ public class BulkChangeViewModelInvariantTests
             .WithDropdownPeer("nested-struct-db.xml", plc: "PLC_B")
             .Build();
 
-        env.Vm.OpenDataBlocksDropdownCommand.Execute(null);
-        var peerRow = env.Vm.FilteredDataBlockItems.First(i => i.Name == "NestedStructDB");
+        env.Vm.ActiveSet.OpenDataBlocksDropdownCommand.Execute(null);
+        var peerRow = env.Vm.ActiveSet.FilteredDataBlockItems.First(i => i.Name == "NestedStructDB");
         peerRow.IsActive = true;
 
         env.Vm.AllActiveDbs.Should().HaveCount(2);
-        env.Vm.PlcPills.Select(p => p.PlcName).Should().BeEquivalentTo(
+        env.Vm.ActiveSet.PlcPills.Select(p => p.PlcName).Should().BeEquivalentTo(
             new[] { "PLC_A", "PLC_B" });
         env.Vm.Tree.RootMembers.Should().HaveCount(2);
         env.Vm.Tree.RootMembers.Should().AllSatisfy(r => r.Datatype.Should().Be("DB"));
@@ -88,29 +88,29 @@ public class BulkChangeViewModelInvariantTests
             .WithPromptResults(YesNoCancelResult.No)
             .Build();
 
-        env.Vm.OpenDataBlocksDropdownCommand.Execute(null);
-        var peerRow = env.Vm.FilteredDataBlockItems.First(i => i.Name == "NestedStructDB");
+        env.Vm.ActiveSet.OpenDataBlocksDropdownCommand.Execute(null);
+        var peerRow = env.Vm.ActiveSet.FilteredDataBlockItems.First(i => i.Name == "NestedStructDB");
         peerRow.IsActive = false;
 
         env.Vm.AllActiveDbs.Should().HaveCount(1);
         env.Vm.AllActiveDbs[0].Info.Name.Should().Be("FlatDB");
-        env.Vm.HasStashedDbs.Should().BeTrue();
-        env.Vm.StashedDbs.Should().ContainSingle(s => s.DbName == "NestedStructDB");
+        env.Vm.ActiveSet.HasStashedDbs.Should().BeTrue();
+        env.Vm.ActiveSet.StashedDbs.Should().ContainSingle(s => s.DbName == "NestedStructDB");
         env.Mbx.AskYesNoCancelCallCount.Should().Be(1);
         AssertInvariants(env.Vm);
     }
 
     [Fact]
-    public void HasStashedDbs_PropertyChanged_FiresOnHostWhenStashFlipsFromEmpty()
+    public void HasStashedDbs_PropertyChanged_FiresOnSliceWhenStashFlipsFromEmpty()
     {
-        // Slice 8a regression guard. The host's HasStashedDbs is a
-        // delegator over ActiveSet.HasStashedDbs; the slice raises its
-        // own PropertyChanged, and the host's constructor wires a
-        // forwarder lambda so external `vm.PropertyChanged` subscribers
-        // filtering on HasStashedDbs still see the notification. If a
-        // future slice-9 cleanup deletes the forwarder, vm.HasStashedDbs
-        // will still read correctly but bindings observing the host
-        // VM's PropertyChanged will silently stop repainting.
+        // Slice 8a regression guard, migrated in slice 9a. The host's
+        // HasStashedDbs delegator and the constructor's PropertyChanged
+        // forwarder were dropped in 9a; XAML now binds through
+        // {Binding ActiveSet.HasStashedDbs} directly, so the slice's own
+        // PropertyChanged is the single source of truth for repaints. The
+        // intent — "stash-from-empty must publish a HasStashedDbs notification
+        // that bindings can observe" — is preserved by listening on the
+        // slice's PropertyChanged channel instead of the host's.
         var env = new ActiveSetTestBuilder()
             .WithAnchor("flat-db.xml")
             .WithPeer("nested-struct-db.xml")
@@ -118,15 +118,16 @@ public class BulkChangeViewModelInvariantTests
             .WithPromptResults(YesNoCancelResult.No)
             .Build();
         var changedProps = new List<string?>();
-        ((INotifyPropertyChanged)env.Vm).PropertyChanged += (_, e) => changedProps.Add(e.PropertyName);
+        ((INotifyPropertyChanged)env.Vm.ActiveSet).PropertyChanged
+            += (_, e) => changedProps.Add(e.PropertyName);
 
-        env.Vm.OpenDataBlocksDropdownCommand.Execute(null);
-        var peerRow = env.Vm.FilteredDataBlockItems.First(i => i.Name == "NestedStructDB");
+        env.Vm.ActiveSet.OpenDataBlocksDropdownCommand.Execute(null);
+        var peerRow = env.Vm.ActiveSet.FilteredDataBlockItems.First(i => i.Name == "NestedStructDB");
         peerRow.IsActive = false;
 
-        env.Vm.HasStashedDbs.Should().BeTrue("setup: stash created");
-        changedProps.Should().Contain(nameof(BulkChangeViewModel.HasStashedDbs),
-            "the binding cannot repaint without this notification on the host VM");
+        env.Vm.ActiveSet.HasStashedDbs.Should().BeTrue("setup: stash created");
+        changedProps.Should().Contain(nameof(ActiveSetViewModel.HasStashedDbs),
+            "the binding cannot repaint without this notification on the slice VM");
     }
 
     [Fact]
@@ -142,7 +143,7 @@ public class BulkChangeViewModelInvariantTests
         // Verify the last-DB removal is refused at the VM level.
         var anchorDb = env.Vm.AllActiveDbs[0];
         var countBefore = env.Vm.AllActiveDbs.Count;
-        env.Vm.RequestRemoveActiveDb(anchorDb); // should be a no-op
+        env.Vm.ActiveSet.RequestRemoveActiveDb(anchorDb); // should be a no-op
         env.Vm.AllActiveDbs.Should().HaveCount(countBefore,
             "the dialog must always have at least one DB");
         env.Mbx.AskYesNoCancelCallCount.Should().Be(0);
@@ -166,10 +167,10 @@ public class BulkChangeViewModelInvariantTests
         var pendingValue = peerLeaf.PendingValue;
 
         var peerDb = env.Vm.AllActiveDbs.First(d => d.Info.Name == "NestedStructDB");
-        env.Vm.RequestRemoveActiveDb(peerDb);
+        env.Vm.ActiveSet.RequestRemoveActiveDb(peerDb);
 
         env.Vm.AllActiveDbs.Should().HaveCount(2, "Cancel keeps the peer in place");
-        env.Vm.HasStashedDbs.Should().BeFalse("Cancel does not stash");
+        env.Vm.ActiveSet.HasStashedDbs.Should().BeFalse("Cancel does not stash");
         peerLeaf.PendingValue.Should().Be(pendingValue, "edit was not lost");
         peerLeaf.IsPendingInlineEdit.Should().BeTrue();
         env.Mbx.AskYesNoCancelCallCount.Should().Be(1);
@@ -193,7 +194,7 @@ public class BulkChangeViewModelInvariantTests
             .Build();
 
         var targetDb = env.Vm.AllActiveDbs.First(d => d.Info.Name == "ArrayDB");
-        env.Vm.SoloActiveDbByReference(targetDb);
+        env.Vm.ActiveSet.SoloActiveDbByReference(targetDb);
 
         env.Vm.AllActiveDbs.Should().HaveCount(1);
         env.Vm.AllActiveDbs[0].Info.Name.Should().Be("ArrayDB");
@@ -202,7 +203,7 @@ public class BulkChangeViewModelInvariantTests
             o => o.WithoutStrictOrdering(),
             "every non-target DB with pending edits committed exactly once");
         env.Mbx.AskYesNoCancelCallCount.Should().Be(2);
-        env.Vm.HasStashedDbs.Should().BeFalse("Apply branch does not stash");
+        env.Vm.ActiveSet.HasStashedDbs.Should().BeFalse("Apply branch does not stash");
         AssertInvariants(env.Vm);
     }
 
@@ -222,12 +223,12 @@ public class BulkChangeViewModelInvariantTests
             .Build();
 
         var targetDb = env.Vm.AllActiveDbs.First(d => d.Info.Name == "ArrayDB");
-        env.Vm.SoloActiveDbByReference(targetDb);
+        env.Vm.ActiveSet.SoloActiveDbByReference(targetDb);
 
         env.Vm.AllActiveDbs.Select(d => d.Info.Name).Should().BeEquivalentTo(
             new[] { "NestedStructDB", "ArrayDB" },
             "Cancel on the middle DB aborts the rest of the solo loop");
-        env.Vm.HasStashedDbs.Should().BeFalse();
+        env.Vm.ActiveSet.HasStashedDbs.Should().BeFalse();
         env.Mbx.AskYesNoCancelCallCount.Should().Be(1);
         AssertInvariants(env.Vm);
     }
@@ -266,16 +267,16 @@ public class BulkChangeViewModelInvariantTests
 
         // Bootstrap: close NestedStructDB to create the stash entry.
         var nestedDb = env.Vm.AllActiveDbs.First(d => d.Info.Name == "NestedStructDB");
-        env.Vm.RequestRemoveActiveDb(nestedDb);
-        env.Vm.HasStashedDbs.Should().BeTrue("setup: stash created via chip-close");
+        env.Vm.ActiveSet.RequestRemoveActiveDb(nestedDb);
+        env.Vm.ActiveSet.HasStashedDbs.Should().BeTrue("setup: stash created via chip-close");
         env.Vm.AllActiveDbs.Should().HaveCount(2,
             "setup: FlatDB + ArrayDB active before reactivate, ≥2 → prompt fires");
 
         // Click the stash header. The new additive/replace prompt must fire
         // (count >= 2). User picks Yes = additive.
         var promptsBefore = env.Mbx.AskYesNoCancelCallCount;
-        var stash = env.Vm.StashedDbs.Single();
-        env.Vm.SwitchToStashedDbCommand.Execute(stash);
+        var stash = env.Vm.ActiveSet.StashedDbs.Single();
+        env.Vm.ActiveSet.SwitchToStashedDbCommand.Execute(stash);
 
         (env.Mbx.AskYesNoCancelCallCount - promptsBefore).Should().Be(1,
             "reactivate with ≥2 active DBs must fire the additive/replace prompt");
@@ -283,7 +284,7 @@ public class BulkChangeViewModelInvariantTests
             "Yes = Additive: the previously-active DBs stay, stashed DB added back");
         env.Vm.AllActiveDbs.Select(d => d.Info.Name)
             .Should().BeEquivalentTo(new[] { "FlatDB", "ArrayDB", "NestedStructDB" });
-        env.Vm.HasStashedDbs.Should().BeFalse(
+        env.Vm.ActiveSet.HasStashedDbs.Should().BeFalse(
             "NestedStructDB's stash entry pops on restore");
 
         // Stash edits replay onto the live tree.
@@ -322,12 +323,12 @@ public class BulkChangeViewModelInvariantTests
         var pendingValue = pendingLeaf.PendingValue!;
 
         var nestedDb2 = env.Vm.AllActiveDbs.First(d => d.Info.Name == "NestedStructDB");
-        env.Vm.RequestRemoveActiveDb(nestedDb2);
-        env.Vm.HasStashedDbs.Should().BeTrue("setup: stash created");
+        env.Vm.ActiveSet.RequestRemoveActiveDb(nestedDb2);
+        env.Vm.ActiveSet.HasStashedDbs.Should().BeTrue("setup: stash created");
 
         var promptsBefore = env.Mbx.AskYesNoCancelCallCount;
-        var stash = env.Vm.StashedDbs.Single();
-        env.Vm.SwitchToStashedDbCommand.Execute(stash);
+        var stash = env.Vm.ActiveSet.StashedDbs.Single();
+        env.Vm.ActiveSet.SwitchToStashedDbCommand.Execute(stash);
 
         (env.Mbx.AskYesNoCancelCallCount - promptsBefore).Should().Be(1,
             "reactivate with ≥2 active DBs must fire the additive/replace prompt " +
@@ -335,7 +336,7 @@ public class BulkChangeViewModelInvariantTests
         env.Vm.AllActiveDbs.Should().HaveCount(1,
             "No = Replace: others dropped (silently here, no edits)");
         env.Vm.AllActiveDbs[0].Info.Name.Should().Be("NestedStructDB");
-        env.Vm.HasStashedDbs.Should().BeFalse();
+        env.Vm.ActiveSet.HasStashedDbs.Should().BeFalse();
 
         var restored = env.Vm.Tree.RootMembers
             .SelectMany(r => new[] { r }.Concat(r.AllDescendants()))
@@ -370,9 +371,9 @@ public class BulkChangeViewModelInvariantTests
 
         // Setup: stash NestedStructDB.
         var nestedDb3 = env.Vm.AllActiveDbs.First(d => d.Info.Name == "NestedStructDB");
-        env.Vm.RequestRemoveActiveDb(nestedDb3);
-        env.Vm.HasStashedDbs.Should().BeTrue();
-        env.Vm.StashedDbs.Should().ContainSingle(s => s.DbName == "NestedStructDB");
+        env.Vm.ActiveSet.RequestRemoveActiveDb(nestedDb3);
+        env.Vm.ActiveSet.HasStashedDbs.Should().BeTrue();
+        env.Vm.ActiveSet.StashedDbs.Should().ContainSingle(s => s.DbName == "NestedStructDB");
 
         // Stage a pending edit on FlatDB (the still-active anchor) after the
         // peer drop, i.e. while we're in single-DB shape. Use EditableStartValue
@@ -384,13 +385,13 @@ public class BulkChangeViewModelInvariantTests
 
         // Reactivate the stashed peer via header click.
         var promptsBefore = env.Mbx.AskYesNoCancelCallCount;
-        var stash = env.Vm.StashedDbs.Single();
-        env.Vm.SwitchToStashedDbCommand.Execute(stash);
+        var stash = env.Vm.ActiveSet.StashedDbs.Single();
+        env.Vm.ActiveSet.SwitchToStashedDbCommand.Execute(stash);
 
         env.Vm.AllActiveDbs.Should().HaveCount(1);
         env.Vm.AllActiveDbs[0].Info.Name.Should().Be("NestedStructDB");
-        env.Vm.HasStashedDbs.Should().BeTrue("anchor's edits stashed during reactivate");
-        env.Vm.StashedDbs.Should().ContainSingle(s => s.DbName == "FlatDB",
+        env.Vm.ActiveSet.HasStashedDbs.Should().BeTrue("anchor's edits stashed during reactivate");
+        env.Vm.ActiveSet.StashedDbs.Should().ContainSingle(s => s.DbName == "FlatDB",
             "exactly one stash remains — NestedStructDB's popped on restore, FlatDB's was just created");
         (env.Mbx.AskYesNoCancelCallCount - promptsBefore).Should().Be(1,
             "reactivate's solo step must prompt for the anchor's pending edits");
@@ -424,8 +425,8 @@ public class BulkChangeViewModelInvariantTests
         var anchorLeafBefore = FindFirstPendingLeaf(env.Vm, "FlatDB");
         var pendingValue = anchorLeafBefore.PendingValue;
 
-        env.Vm.OpenDataBlocksDropdownCommand.Execute(null);
-        var peerRow = env.Vm.FilteredDataBlockItems.First(i => i.Name == "NestedStructDB");
+        env.Vm.ActiveSet.OpenDataBlocksDropdownCommand.Execute(null);
+        var peerRow = env.Vm.ActiveSet.FilteredDataBlockItems.First(i => i.Name == "NestedStructDB");
         peerRow.IsActive = true;
 
         env.Mbx.AskYesNoCancelCallCount.Should().Be(0,
@@ -481,12 +482,12 @@ public class BulkChangeViewModelInvariantTests
         var anchorLeaf = FindFirstPendingLeaf(env.Vm, "FlatDB");
         var pendingValue = anchorLeaf.PendingValue;
 
-        env.Vm.SoloActiveDb(new DataBlockSummary("NestedStructDB", ""));
+        env.Vm.ActiveSet.SoloActiveDb(new DataBlockSummary("NestedStructDB", ""));
 
         env.Vm.AllActiveDbs.Should().HaveCount(1,
             "Solo+Cancel on a newly-built target must revert — no peer added");
         env.Vm.AllActiveDbs[0].Info.Name.Should().Be("FlatDB");
-        env.Vm.HasStashedDbs.Should().BeFalse("Cancel does not stash");
+        env.Vm.ActiveSet.HasStashedDbs.Should().BeFalse("Cancel does not stash");
         anchorLeaf.PendingValue.Should().Be(pendingValue,
             "tree never rebuilt → anchor's pending VM is still the same instance");
         anchorLeaf.IsPendingInlineEdit.Should().BeTrue();
@@ -522,13 +523,13 @@ public class BulkChangeViewModelInvariantTests
         var pendingValue = anchorLeaf.PendingValue;
 
         var anchorDbToRemove = env.Vm.AllActiveDbs.First(d => d.Info.Name == "FlatDB");
-        env.Vm.RequestRemoveActiveDb(anchorDbToRemove);
+        env.Vm.ActiveSet.RequestRemoveActiveDb(anchorDbToRemove);
 
         env.Vm.AllActiveDbs.Should().ContainSingle()
             .Which.Info.Name.Should().Be("NestedStructDB",
                 "Keep on chip-close removes the anchor from the active set");
-        env.Vm.HasStashedDbs.Should().BeTrue("Keep moves pending edits into the stash");
-        env.Vm.StashedDbs.Should().ContainSingle(s => s.DbName == "FlatDB",
+        env.Vm.ActiveSet.HasStashedDbs.Should().BeTrue("Keep moves pending edits into the stash");
+        env.Vm.ActiveSet.StashedDbs.Should().ContainSingle(s => s.DbName == "FlatDB",
             "anchor's pending edit must land in the stash dictionary, not be silently dropped");
         env.Vm.Pending.PendingEdits.Should().BeEmpty(
             "removed DB's pending leaves must vacate the bound PendingEdits list");
@@ -557,7 +558,7 @@ public class BulkChangeViewModelInvariantTests
         env.Vm.CurrentPlcName.Should().Be("PLC_A", "setup: anchor PLC display is PLC_A");
 
         var anchorDb2 = env.Vm.AllActiveDbs.First(d => d.Info.Name == "FlatDB");
-        env.Vm.RequestRemoveActiveDb(anchorDb2); // 2-DB session — anchor is removable
+        env.Vm.ActiveSet.RequestRemoveActiveDb(anchorDb2); // 2-DB session — anchor is removable
 
         env.Vm.AllActiveDbs.Should().HaveCount(1);
         env.Vm.AllActiveDbs[0].Info.Name.Should().Be("NestedStructDB",
@@ -606,7 +607,7 @@ public class BulkChangeViewModelInvariantTests
         env.Vm.Selection.ManualSelectionCount.Should().Be(2);
 
         var anchorDbManual = env.Vm.AllActiveDbs.First(d => d.Info.Name == "FlatDB");
-        env.Vm.RequestRemoveActiveDb(anchorDbManual);
+        env.Vm.ActiveSet.RequestRemoveActiveDb(anchorDbManual);
 
         env.Vm.AllActiveDbs.Should().HaveCount(1);
         env.Vm.AllActiveDbs[0].Info.Name.Should().Be("NestedStructDB");
@@ -660,7 +661,7 @@ public class BulkChangeViewModelInvariantTests
 
         // Remove the peer (no pending edits on peer → no prompt).
         var peerDb4 = env.Vm.AllActiveDbs.First(d => d.Info.Name == "NestedStructDB");
-        env.Vm.RequestRemoveActiveDb(peerDb4);
+        env.Vm.ActiveSet.RequestRemoveActiveDb(peerDb4);
 
         // Tree rebuilt: multi-DB → single-DB (flat) shape, all VMs replaced.
         env.Vm.AllActiveDbs.Should().HaveCount(1, "peer was silently removed");
@@ -696,7 +697,7 @@ public class BulkChangeViewModelInvariantTests
 
         // Attempt to remove the peer — prompt fires, user cancels.
         var peerDb5 = env.Vm.AllActiveDbs.First(d => d.Info.Name == "NestedStructDB");
-        env.Vm.RequestRemoveActiveDb(peerDb5);
+        env.Vm.ActiveSet.RequestRemoveActiveDb(peerDb5);
 
         // After cancel: same VMs, same tree shape, store still has the edit.
         env.Vm.AllActiveDbs.Should().HaveCount(2, "Cancel leaves the peer active");
@@ -810,7 +811,7 @@ public class BulkChangeViewModelInvariantTests
 
         // Solo to NestedStructDB via SoloActiveDbByReference.
         var targetDbSolo = env.Vm.AllActiveDbs.First(d => d.Info.Name == "NestedStructDB");
-        env.Vm.SoloActiveDbByReference(targetDbSolo);
+        env.Vm.ActiveSet.SoloActiveDbByReference(targetDbSolo);
 
         env.Vm.AllActiveDbs.Should().HaveCount(1, "solo collapses to one DB");
         env.Vm.AllActiveDbs[0].Info.Name.Should().Be("NestedStructDB");
@@ -836,7 +837,7 @@ public class BulkChangeViewModelInvariantTests
         vm.AllActiveDbs.Should().NotBeEmpty("invariant 1: AllActiveDbs.Count >= 1");
 
         // (2) pill-row covers the same DB names as the active set
-        var pillDbNames = vm.PlcPills
+        var pillDbNames = vm.ActiveSet.PlcPills
             .SelectMany(p => p.SelectedDbs.OfType<DataBlockListItem>())
             .Select(i => i.Name)
             .ToList();
@@ -859,14 +860,14 @@ public class BulkChangeViewModelInvariantTests
         }
 
         // (4) stash-flag matches stash list
-        vm.HasStashedDbs.Should().Be(vm.StashedDbs.Count > 0,
+        vm.ActiveSet.HasStashedDbs.Should().Be(vm.ActiveSet.StashedDbs.Count > 0,
             "invariant 4: HasStashedDbs == (StashedDbs.Count > 0)");
 
         // (5) anchor PLC display matches the anchor pill's PlcName
-        if (vm.PlcPills.Count > 0)
+        if (vm.ActiveSet.PlcPills.Count > 0)
         {
             var anchorName = vm.AllActiveDbs[0].Info.Name;
-            var anchorPill = vm.PlcPills
+            var anchorPill = vm.ActiveSet.PlcPills
                 .FirstOrDefault(p => p.SelectedDbs.OfType<DataBlockListItem>()
                     .Any(i => i.Name == anchorName));
             anchorPill?.PlcName.Should().Be(vm.CurrentPlcName,

--- a/src/BlockParam.Tests/BulkChangeViewModelMultiDbTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelMultiDbTests.cs
@@ -64,7 +64,7 @@ public class BulkChangeViewModelMultiDbTests
     public void HasMultipleActiveDbs_TrueWhenPeerPresent()
     {
         var (vm, _, _, _, _) = CreateMultiDbVm();
-        vm.HasMultipleActiveDbs.Should().BeTrue();
+        vm.ActiveSet.HasMultipleActiveDbs.Should().BeTrue();
         vm.AllActiveDbs.Should().HaveCount(2);
     }
 
@@ -83,7 +83,7 @@ public class BulkChangeViewModelMultiDbTests
             info, xml,
             new HierarchyAnalyzer(), bulkService, tracker, configLoader);
 
-        vm.HasMultipleActiveDbs.Should().BeFalse();
+        vm.ActiveSet.HasMultipleActiveDbs.Should().BeFalse();
         vm.AllActiveDbs.Should().HaveCount(1);
     }
 
@@ -243,9 +243,9 @@ public class BulkChangeViewModelMultiDbTests
             additionalActiveDbs: new[] { peerDb });
 
         // Open the dropdown to populate the wrapper list.
-        vm.OpenDataBlocksDropdownCommand.Execute(null);
+        vm.ActiveSet.OpenDataBlocksDropdownCommand.Execute(null);
 
-        var items = vm.FilteredDataBlockItems;
+        var items = vm.ActiveSet.FilteredDataBlockItems;
         items.Should().HaveCount(3);
 
         var focusedRow = items.First(i => i.Name == focused.Name);
@@ -380,8 +380,8 @@ public class BulkChangeViewModelMultiDbTests
 
         // Open the popup so FilteredDataBlockItems is populated, then toggle
         // off the peer row.
-        vm.OpenDataBlocksDropdownCommand.Execute(null);
-        var peerRow = vm.FilteredDataBlockItems
+        vm.ActiveSet.OpenDataBlocksDropdownCommand.Execute(null);
+        var peerRow = vm.ActiveSet.FilteredDataBlockItems
             .FirstOrDefault(i => i.Name == peer.Name);
         if (peerRow == null) return; // dropdown didn't have the row — environment-dependent
 
@@ -389,7 +389,7 @@ public class BulkChangeViewModelMultiDbTests
 
         // Cancel branch: peer is still present, OnApply not called,
         // user's pending edit not silently lost.
-        vm.HasMultipleActiveDbs.Should().BeTrue(
+        vm.ActiveSet.HasMultipleActiveDbs.Should().BeTrue(
             "Cancel must keep the peer in the active set");
         peerApplied.Should().BeFalse();
         mbx.AskYesNoCancelCallCount.Should().BeGreaterOrEqualTo(1,
@@ -425,7 +425,7 @@ public class BulkChangeViewModelMultiDbTests
         // by MemberNodeViewModel reference, not path string. Two leaves in
         // different DBs that happen to share a path are distinct entries.
         var (vm, _, _, _, _) = CreateMultiDbVm();
-        vm.HasMultipleActiveDbs.Should().BeTrue();
+        vm.ActiveSet.HasMultipleActiveDbs.Should().BeTrue();
 
         // Find a leaf in each DB.
         var focusedRoot = vm.Tree.RootMembers.First();
@@ -478,7 +478,7 @@ public class BulkChangeViewModelMultiDbTests
 
         // Single-DB shape pre-toggle: top-level members are flat, no synthetic
         // group node.
-        vm.HasMultipleActiveDbs.Should().BeFalse();
+        vm.ActiveSet.HasMultipleActiveDbs.Should().BeFalse();
         vm.Tree.RootMembers.Should().AllSatisfy(r =>
             r.Datatype.Should().NotBe("DB",
                 "single-DB shape exposes leaves directly, not under a synthetic group"));
@@ -486,14 +486,14 @@ public class BulkChangeViewModelMultiDbTests
 
         // Open dropdown so FilteredDataBlockItems gets populated, then toggle
         // the peer row on.
-        vm.OpenDataBlocksDropdownCommand.Execute(null);
-        var peerRow = vm.FilteredDataBlockItems
+        vm.ActiveSet.OpenDataBlocksDropdownCommand.Execute(null);
+        var peerRow = vm.ActiveSet.FilteredDataBlockItems
             .First(i => i.Name == peer.Name);
         peerRow.IsActive = true;
 
         vm.AllActiveDbs.Should().HaveCount(2,
             "the dropdown toggle should add the peer DB to the active set");
-        vm.HasMultipleActiveDbs.Should().BeTrue();
+        vm.ActiveSet.HasMultipleActiveDbs.Should().BeTrue();
         vm.Tree.RootMembers.Should().HaveCount(2,
             "tree must rebuild as two synthetic per-DB group nodes");
         vm.Tree.RootMembers.Should().AllSatisfy(r =>
@@ -532,26 +532,26 @@ public class BulkChangeViewModelMultiDbTests
                 : null);
 
         // Single-DB: one pill with one selected entry; last DB cannot be removed.
-        vm.PlcPills.Should().HaveCount(1,
+        vm.ActiveSet.PlcPills.Should().HaveCount(1,
             "one pill for the single active PLC");
         vm.AllActiveDbs.Should().HaveCount(1);
         var anchorDb = vm.AllActiveDbs[0];
-        vm.RequestRemoveActiveDb(anchorDb); // should be refused
+        vm.ActiveSet.RequestRemoveActiveDb(anchorDb); // should be refused
         vm.AllActiveDbs.Should().HaveCount(1,
             "the last remaining DB cannot be removed");
 
         // Add the peer via the dropdown checkbox path.
-        vm.OpenDataBlocksDropdownCommand.Execute(null);
-        vm.FilteredDataBlockItems.First(i => i.Name == peer.Name).IsActive = true;
+        vm.ActiveSet.OpenDataBlocksDropdownCommand.Execute(null);
+        vm.ActiveSet.FilteredDataBlockItems.First(i => i.Name == peer.Name).IsActive = true;
 
         // Two DBs active → still one pill (both on same PLC).
         vm.AllActiveDbs.Should().HaveCount(2);
-        vm.PlcPills.Should().HaveCount(1,
+        vm.ActiveSet.PlcPills.Should().HaveCount(1,
             "both DBs are on the same PLC → one pill");
 
         // Remove the peer → back to one DB.
         var peerDbRef = vm.AllActiveDbs.First(d => d.Info.Name == peer.Name);
-        vm.RequestRemoveActiveDb(peerDbRef);
+        vm.ActiveSet.RequestRemoveActiveDb(peerDbRef);
         vm.AllActiveDbs.Should().HaveCount(1);
         vm.AllActiveDbs[0].Info.Name.Should().Be(focused.Name);
     }
@@ -569,7 +569,7 @@ public class BulkChangeViewModelMultiDbTests
         var peerName = vm.AllActiveDbs[1].Info.Name;
         var peerDb = vm.AllActiveDbs.First(d => d.Info.Name == peerName);
 
-        vm.SoloActiveDbByReference(peerDb);
+        vm.ActiveSet.SoloActiveDbByReference(peerDb);
 
         vm.AllActiveDbs.Should().HaveCount(1,
             "solo collapses the active set to a single DB");
@@ -600,11 +600,11 @@ public class BulkChangeViewModelMultiDbTests
             additionalActiveDbs: new[] { peerDb });
 
         // Two distinct PLCs → two pills, one per PLC.
-        vm.PlcPills.Should().HaveCount(2);
-        vm.PlcPills.Select(p => p.PlcName).Should().BeEquivalentTo(
+        vm.ActiveSet.PlcPills.Should().HaveCount(2);
+        vm.ActiveSet.PlcPills.Select(p => p.PlcName).Should().BeEquivalentTo(
             new[] { "PLC_Anchor", "PLC_Other" });
-        vm.PlcPills[0].SelectedDbs.Should().HaveCount(1);
-        vm.PlcPills[1].SelectedDbs.Should().HaveCount(1);
+        vm.ActiveSet.PlcPills[0].SelectedDbs.Should().HaveCount(1);
+        vm.ActiveSet.PlcPills[1].SelectedDbs.Should().HaveCount(1);
     }
 
     [Fact]
@@ -614,9 +614,9 @@ public class BulkChangeViewModelMultiDbTests
         // when there's only one PLC).
         var (vm, _, _, _, _) = CreateMultiDbVm();
 
-        vm.PlcPills.Should().HaveCount(1,
+        vm.ActiveSet.PlcPills.Should().HaveCount(1,
             "both DBs are on the same PLC — only one pill");
-        vm.PlcPills[0].Label.Should().BeEmpty(
+        vm.ActiveSet.PlcPills[0].Label.Should().BeEmpty(
             "single-PLC sessions omit the PLC label on the pill");
     }
 
@@ -638,9 +638,9 @@ public class BulkChangeViewModelMultiDbTests
             new HierarchyAnalyzer(), bulkService, tracker, configLoader,
             currentPlcName: "PLC_Anchor");
 
-        vm.PlcPills.Should().HaveCount(1);
-        vm.PlcPills[0].PlcName.Should().Be("PLC_Anchor");
-        vm.PlcPills[0].Label.Should().Be("PLC_Anchor",
+        vm.ActiveSet.PlcPills.Should().HaveCount(1);
+        vm.ActiveSet.PlcPills[0].PlcName.Should().Be("PLC_Anchor");
+        vm.ActiveSet.PlcPills[0].Label.Should().Be("PLC_Anchor",
             "multi-PLC context: pill label shows the PLC name");
     }
 
@@ -703,20 +703,20 @@ public class BulkChangeViewModelMultiDbTests
         // Remove the peer — pending edit triggers the 3-way prompt;
         // FakeMessageBox returns "No" so the edits get stashed.
         var peerDbRef = vm.AllActiveDbs.First(d => d.Info.Name == peer.Name);
-        vm.RequestRemoveActiveDb(peerDbRef);
+        vm.ActiveSet.RequestRemoveActiveDb(peerDbRef);
 
         vm.AllActiveDbs.Should().HaveCount(1, "peer was removed from active set");
-        vm.HasStashedDbs.Should().BeTrue("Keep branch must stash edits for restore");
-        vm.StashedDbs.Should().ContainSingle(s => s.DbName == peer.Name);
+        vm.ActiveSet.HasStashedDbs.Should().BeTrue("Keep branch must stash edits for restore");
+        vm.ActiveSet.StashedDbs.Should().ContainSingle(s => s.DbName == peer.Name);
 
         // Reactivate via the stash header click.
-        var stash = vm.StashedDbs[0];
-        vm.SwitchToStashedDbCommand.Execute(stash);
+        var stash = vm.ActiveSet.StashedDbs[0];
+        vm.ActiveSet.SwitchToStashedDbCommand.Execute(stash);
 
         // Stash entry was popped — header gone.
-        vm.HasStashedDbs.Should().BeFalse(
+        vm.ActiveSet.HasStashedDbs.Should().BeFalse(
             "RestoreStashFor must remove the entry on successful restore");
-        vm.StashedDbs.Should().BeEmpty();
+        vm.ActiveSet.StashedDbs.Should().BeEmpty();
 
         // Switch-back gesture soloed: anchor DB dropped, only the
         // reactivated DB remains active.
@@ -765,13 +765,13 @@ public class BulkChangeViewModelMultiDbTests
                 : null);
 
         vm.AllActiveDbs.Should().HaveCount(1, "single-DB session to start");
-        vm.PlcPills.Should().HaveCount(1);
+        vm.ActiveSet.PlcPills.Should().HaveCount(1);
 
         // Simulate pill selection gaining the peer (as if the user opened
         // the pill popup and checked the peer row).
         var peerSummary = new DataBlockSummary(peer.Name, "");
         var peerItem = new DataBlockListItem(peerSummary, isActive: false, isAnchor: false);
-        var pill = vm.PlcPills[0];
+        var pill = vm.ActiveSet.PlcPills[0];
         pill.AvailableDbs.Add(peerItem);   // mimic lazy-loaded list
         pill.SelectedDbs.Add(peerItem);    // mimic user checking the row
 
@@ -796,8 +796,8 @@ public class BulkChangeViewModelMultiDbTests
             new HierarchyAnalyzer(), bulkService, tracker, configLoader);
 
         vm.AllActiveDbs.Should().HaveCount(1);
-        vm.PlcPills.Should().HaveCount(1);
-        var pill = vm.PlcPills[0];
+        vm.ActiveSet.PlcPills.Should().HaveCount(1);
+        var pill = vm.ActiveSet.PlcPills[0];
         var initial = pill.SelectedDbs.Count;
 
         // Attempt to deselect the only item.
@@ -833,12 +833,12 @@ public class BulkChangeViewModelMultiDbTests
             additionalActiveDbs: new[] { peerDb });
 
         vm.AllActiveDbs.Should().HaveCount(2);
-        vm.PlcPills.Should().HaveCount(1, "both DBs on same PLC → one pill");
+        vm.ActiveSet.PlcPills.Should().HaveCount(1, "both DBs on same PLC → one pill");
 
         // Remove one DB — this triggers RebuildPlcPills which calls
         // SyncSelectedDbs on the pill. The guard must prevent a second cascade.
         var peerDbRef = vm.AllActiveDbs.First(d => d.Info.Name == peer.Name);
-        var act = () => vm.RequestRemoveActiveDb(peerDbRef);
+        var act = () => vm.ActiveSet.RequestRemoveActiveDb(peerDbRef);
         act.Should().NotThrow("cascade re-entrancy guard must prevent infinite recursion");
         vm.AllActiveDbs.Should().HaveCount(1);
     }
@@ -934,16 +934,16 @@ public class BulkChangeViewModelMultiDbTests
             currentPlcName: "PLC_A",
             additionalActiveDbs: new[] { peerDb });
 
-        vm.PlcPills.Should().HaveCount(2, "two PLCs → two pills");
+        vm.ActiveSet.PlcPills.Should().HaveCount(2, "two PLCs → two pills");
 
         // Remove the peer (PLC_B's only DB).
         var peerDbRef = vm.AllActiveDbs.First(d => d.Info.Name == peer.Name);
-        vm.RequestRemoveActiveDb(peerDbRef);
+        vm.ActiveSet.RequestRemoveActiveDb(peerDbRef);
 
         vm.AllActiveDbs.Should().HaveCount(1);
-        vm.PlcPills.Should().HaveCount(1,
+        vm.ActiveSet.PlcPills.Should().HaveCount(1,
             "PLC_B's pill must vanish when its last DB is removed");
-        vm.PlcPills[0].PlcName.Should().Be("PLC_A");
+        vm.ActiveSet.PlcPills[0].PlcName.Should().Be("PLC_A");
     }
 
     // ── "+ PLC" workflow tests (#pill-refactor empty-pill path) ──────────────
@@ -951,7 +951,7 @@ public class BulkChangeViewModelMultiDbTests
     /// <summary>
     /// Shared fixture for the "+ PLC"-flow tests: one active DB on PLC_A,
     /// plus two project-only PLCs (PLC_B with a DB, PLC_C with a DB) that
-    /// have no active DB so they show up in <see cref="BulkChangeViewModel.InactiveProjectPlcs"/>.
+    /// have no active DB so they show up in <see cref="ActiveSetViewModel.InactiveProjectPlcs"/>.
     /// </summary>
     private static BulkChangeViewModel BuildVmForAddPlcTests()
     {
@@ -986,16 +986,16 @@ public class BulkChangeViewModelMultiDbTests
     public void AddPlcToRow_AddsEmptyPillForCandidate()
     {
         var vm = BuildVmForAddPlcTests();
-        vm.PlcPills.Should().HaveCount(1, "one PLC active to start");
-        vm.InactiveProjectPlcs.Should().BeEquivalentTo(new[] { "PLC_B", "PLC_C" });
+        vm.ActiveSet.PlcPills.Should().HaveCount(1, "one PLC active to start");
+        vm.ActiveSet.InactiveProjectPlcs.Should().BeEquivalentTo(new[] { "PLC_B", "PLC_C" });
 
-        vm.AddPlcToRow("PLC_B");
+        vm.ActiveSet.AddPlcToRow("PLC_B");
 
-        vm.PlcPills.Should().HaveCount(2, "PLC_B's empty pill joins the row");
-        vm.PlcPills.Select(p => p.PlcName).Should().Contain("PLC_B");
-        var newPill = vm.PlcPills.First(p => p.PlcName == "PLC_B");
+        vm.ActiveSet.PlcPills.Should().HaveCount(2, "PLC_B's empty pill joins the row");
+        vm.ActiveSet.PlcPills.Select(p => p.PlcName).Should().Contain("PLC_B");
+        var newPill = vm.ActiveSet.PlcPills.First(p => p.PlcName == "PLC_B");
         newPill.SelectedDbs.Should().BeEmpty("the pill is added with no DB active yet");
-        vm.InactiveProjectPlcs.Should().BeEquivalentTo(new[] { "PLC_C" },
+        vm.ActiveSet.InactiveProjectPlcs.Should().BeEquivalentTo(new[] { "PLC_C" },
             "PLC_B is now in the row, so it drops off the candidate list");
     }
 
@@ -1003,31 +1003,31 @@ public class BulkChangeViewModelMultiDbTests
     public void AddPlcToRow_RejectsUnknownPlcName()
     {
         var vm = BuildVmForAddPlcTests();
-        var pillsBefore = vm.PlcPills.Count;
+        var pillsBefore = vm.ActiveSet.PlcPills.Count;
 
         // Garbage input the click stream could produce after a project refresh
         // dropped that PLC, or via a hostile caller.
-        vm.AddPlcToRow("DoesNotExist");
+        vm.ActiveSet.AddPlcToRow("DoesNotExist");
 
-        vm.PlcPills.Count.Should().Be(pillsBefore,
+        vm.ActiveSet.PlcPills.Count.Should().Be(pillsBefore,
             "unknown PLC must be silently rejected, no pill added");
         // Critically: the bad name must NOT have landed in _extraPillPlcs (we
         // verify this indirectly: a subsequent valid add stays clean).
-        vm.AddPlcToRow("PLC_B");
-        vm.PlcPills.Should().HaveCount(pillsBefore + 1);
-        vm.PlcPills.Select(p => p.PlcName).Should().NotContain("DoesNotExist");
+        vm.ActiveSet.AddPlcToRow("PLC_B");
+        vm.ActiveSet.PlcPills.Should().HaveCount(pillsBefore + 1);
+        vm.ActiveSet.PlcPills.Select(p => p.PlcName).Should().NotContain("DoesNotExist");
     }
 
     [Fact]
     public void AddPlcToRow_RejectsAlreadyActivePlc()
     {
         var vm = BuildVmForAddPlcTests();
-        var pillsBefore = vm.PlcPills.Count;
+        var pillsBefore = vm.ActiveSet.PlcPills.Count;
 
         // PLC_A is the anchor — already in the row.
-        vm.AddPlcToRow("PLC_A");
+        vm.ActiveSet.AddPlcToRow("PLC_A");
 
-        vm.PlcPills.Count.Should().Be(pillsBefore,
+        vm.ActiveSet.PlcPills.Count.Should().Be(pillsBefore,
             "PLC already in row → no-op, no duplicate pill");
     }
 
@@ -1035,26 +1035,26 @@ public class BulkChangeViewModelMultiDbTests
     public void InactiveProjectPlcs_ReflectsCurrentRow()
     {
         var vm = BuildVmForAddPlcTests();
-        vm.InactiveProjectPlcs.Should().BeEquivalentTo(new[] { "PLC_B", "PLC_C" });
+        vm.ActiveSet.InactiveProjectPlcs.Should().BeEquivalentTo(new[] { "PLC_B", "PLC_C" });
 
-        vm.AddPlcToRow("PLC_B");
-        vm.InactiveProjectPlcs.Should().BeEquivalentTo(new[] { "PLC_C" });
+        vm.ActiveSet.AddPlcToRow("PLC_B");
+        vm.ActiveSet.InactiveProjectPlcs.Should().BeEquivalentTo(new[] { "PLC_C" });
 
-        vm.AddPlcToRow("PLC_C");
-        vm.InactiveProjectPlcs.Should().BeEmpty("every PLC is in the row now");
+        vm.ActiveSet.AddPlcToRow("PLC_C");
+        vm.ActiveSet.InactiveProjectPlcs.Should().BeEmpty("every PLC is in the row now");
     }
 
     [Fact]
     public void CanAddPlc_FlipsAsRowFills()
     {
         var vm = BuildVmForAddPlcTests();
-        vm.CanAddPlc.Should().BeTrue("two PLCs still inactive");
+        vm.ActiveSet.CanAddPlc.Should().BeTrue("two PLCs still inactive");
 
-        vm.AddPlcToRow("PLC_B");
-        vm.CanAddPlc.Should().BeTrue("PLC_C still available");
+        vm.ActiveSet.AddPlcToRow("PLC_B");
+        vm.ActiveSet.CanAddPlc.Should().BeTrue("PLC_C still available");
 
-        vm.AddPlcToRow("PLC_C");
-        vm.CanAddPlc.Should().BeFalse("every project PLC is now in the row");
+        vm.ActiveSet.AddPlcToRow("PLC_C");
+        vm.ActiveSet.CanAddPlc.Should().BeFalse("every project PLC is now in the row");
     }
 
     /// <summary>

--- a/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
@@ -282,7 +282,7 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         // RequestRemoveActiveDb runs the State setter, which fires
         // RebuildAfterActiveSetChanged → Filter.RaiseSetpointsCapabilityChanged().
         var anchorDb = vm.AllActiveDbs.First(d => d.Info.Name == "DB_Anchor");
-        vm.RequestRemoveActiveDb(anchorDb);
+        vm.ActiveSet.RequestRemoveActiveDb(anchorDb);
 
         vm.AllActiveDbs.Should().HaveCount(1);
         vm.AllActiveDbs[0].Info.Name.Should().Be("DB_Peer",

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -1333,7 +1333,7 @@
                                                     <Button Background="Transparent" BorderThickness="0"
                                                             Cursor="Hand" Padding="0"
                                                             HorizontalContentAlignment="Stretch"
-                                                            Command="{Binding DataContext.SwitchToStashedDbCommand,
+                                                            Command="{Binding DataContext.ActiveSet.SwitchToStashedDbCommand,
                                                                       RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                                             CommandParameter="{Binding}">
                                                         <DockPanel>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml.cs
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml.cs
@@ -894,14 +894,14 @@ public partial class BulkChangeDialog : Window
     // ---- "+ Add DB" trailing button (#pill-refactor) -----------------------
 
     /// <summary>
-    /// Toggles the "+ PLC" popup. The VM's <see cref="BulkChangeViewModel.InactiveProjectPlcs"/>
+    /// Toggles the "+ PLC" popup. The VM's <see cref="ActiveSetViewModel.InactiveProjectPlcs"/>
     /// reads the cached project DB list lazily; no separate eager load
     /// is needed for the flat-list popup.
     /// </summary>
     private void OnAddDbButtonClick(object sender, RoutedEventArgs e)
     {
         if (DataContext is not BulkChangeViewModel vm) return;
-        vm.IsAddDbPopupOpen = !vm.IsAddDbPopupOpen;
+        vm.ActiveSet.IsAddDbPopupOpen = !vm.ActiveSet.IsAddDbPopupOpen;
     }
 
     /// <summary>
@@ -917,8 +917,8 @@ public partial class BulkChangeDialog : Window
         if (sender is not System.Windows.Controls.ListBox lb) return;
         if (lb.SelectedItem is not string plc || string.IsNullOrEmpty(plc)) return;
 
-        vm.AddPlcToRow(plc);
-        vm.IsAddDbPopupOpen = false;
+        vm.ActiveSet.AddPlcToRow(plc);
+        vm.ActiveSet.IsAddDbPopupOpen = false;
         lb.SelectedItem = null;
     }
 
@@ -951,10 +951,10 @@ public partial class BulkChangeDialog : Window
         var active = vm.PendingInlineEditCount;
         var stashedCount = 0;
         string stashedDbList = "";
-        if (vm.StashedDbs.Count > 0)
+        if (vm.ActiveSet.StashedDbs.Count > 0)
         {
-            stashedCount = vm.StashedDbs.Sum(s => s.Count);
-            stashedDbList = string.Join(", ", vm.StashedDbs.Select(s => s.DbName));
+            stashedCount = vm.ActiveSet.StashedDbs.Sum(s => s.Count);
+            stashedDbList = string.Join(", ", vm.ActiveSet.StashedDbs.Select(s => s.DbName));
         }
 
         if (active > 0 && stashedCount > 0)

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -220,8 +220,12 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                 currentPlcName ?? ""),
             messageBox: _messageBox,
             pendingEditStore: _pendingEditStore,
-            getModelToDb: () => Tree.ModelToDb,
-            getStartValueForNode: node => Tree.FindVmByModel(node)?.StartValue,
+            // Tree is assigned later in this constructor (~line 291); the
+            // closures are only invoked at user-gesture time, well after
+            // construction completes. Null-forgiving silences the build
+            // warning without changing runtime behaviour.
+            getModelToDb: () => Tree!.ModelToDb,
+            getStartValueForNode: node => Tree!.FindVmByModel(node)?.StartValue,
             buildActiveDbForSummary: BuildActiveDbFromSummaryWithFallback,
             enumerateDataBlocks: enumerateDataBlocks,
             switchToDataBlock: switchToDataBlock,

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -88,7 +88,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     // just the first one in storage order, used as the anchor when the
     // UI needs a single representative (title, default scope, "current"
     // name display).
-    private ActiveDb _active => State.Dbs[0];
+    private ActiveDb _active => ActiveSet.State.Dbs[0];
     private string _title = "";
     // DB-switcher dropdown state (#59), pill row, and the mutators that
     // touch them moved to ActiveSetViewModel in #80 slice 8b. The host
@@ -231,48 +231,11 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             getPendingCount: () => Pending?.PendingEdits.Count ?? 0,
             dispatcher: _dispatcher);
         ActiveSet.StateChanged += HandleActiveSetStateChanged;
-        ActiveSet.PropertyChanged += (_, e) =>
-        {
-            // Forward the slice's derived-property notifications to the
-            // host's delegating wrappers so XAML still bound through the
-            // host repaints. Rebind to {Binding ActiveSet.X} in slice 9.
-            switch (e.PropertyName)
-            {
-                case nameof(ActiveSetViewModel.HasStashedDbs):
-                    OnPropertyChanged(nameof(HasStashedDbs));
-                    break;
-                case nameof(ActiveSetViewModel.HasMultipleActiveDbs):
-                    OnPropertyChanged(nameof(HasMultipleActiveDbs));
-                    break;
-                case nameof(ActiveSetViewModel.IsDataBlocksDropdownOpen):
-                    OnPropertyChanged(nameof(IsDataBlocksDropdownOpen));
-                    break;
-                case nameof(ActiveSetViewModel.IsLoadingDataBlocks):
-                    OnPropertyChanged(nameof(IsLoadingDataBlocks));
-                    break;
-                case nameof(ActiveSetViewModel.FilteredDataBlocks):
-                    OnPropertyChanged(nameof(FilteredDataBlocks));
-                    break;
-                case nameof(ActiveSetViewModel.FilteredDataBlockItems):
-                    OnPropertyChanged(nameof(FilteredDataBlockItems));
-                    break;
-                case nameof(ActiveSetViewModel.DataBlockSearchText):
-                    OnPropertyChanged(nameof(DataBlockSearchText));
-                    break;
-                case nameof(ActiveSetViewModel.ShowEmptyDataBlocksMessage):
-                    OnPropertyChanged(nameof(ShowEmptyDataBlocksMessage));
-                    break;
-                case nameof(ActiveSetViewModel.IsAddDbPopupOpen):
-                    OnPropertyChanged(nameof(IsAddDbPopupOpen));
-                    break;
-                case nameof(ActiveSetViewModel.InactiveProjectPlcs):
-                    OnPropertyChanged(nameof(InactiveProjectPlcs));
-                    break;
-                case nameof(ActiveSetViewModel.CanAddPlc):
-                    OnPropertyChanged(nameof(CanAddPlc));
-                    break;
-            }
-        };
+        // Slice 9a: the PropertyChanged forwarder that re-raised 11 derived
+        // notifications on the host VM was deleted. XAML, code-behind,
+        // DevLauncher and tests now bind / read through {Binding ActiveSet.X}
+        // directly, so the slice's own PropertyChanged is the single source
+        // of truth for repaints.
         _autocompleteProvider = tagTableCache != null
             ? new AutocompleteProvider(configLoader, tagTableCache)
             : null;
@@ -305,7 +268,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         }
 
         var version = typeof(BulkChangeViewModel).Assembly.GetName().Version;
-        _title = BuildTitle(version, State.AnchorPlcName, dataBlockInfo.Name, State.Dbs.Count);
+        _title = BuildTitle(version, ActiveSet.State.AnchorPlcName, dataBlockInfo.Name, ActiveSet.State.Dbs.Count);
 
         InlineRuleExtractor.ApplyTo(configLoader.GetConfig(), dataBlockInfo);
 
@@ -326,8 +289,8 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // flat union so each match carries a visible DB-of-origin label,
         // and scope walks naturally extend one level deeper.
         Tree = new MemberTreeViewModel(
-            getActiveDbs: () => State.Dbs,
-            getCurrentPlcName: () => State.AnchorPlcName,
+            getActiveDbs: () => ActiveSet.State.Dbs,
+            getCurrentPlcName: () => ActiveSet.State.AnchorPlcName,
             commentLanguagePolicy: _commentLanguagePolicy,
             subscribeToVm: SubscribeStartValueEdited);
         Tree.RootsRebuilt += OnTreeRootsRebuilt;
@@ -382,17 +345,10 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
     // --- Properties ---
 
-    /// <summary>
-    /// Current snapshot of the active-DB set + interlocked state (#78).
-    /// Delegator for <see cref="ActiveSet"/>.<see cref="ActiveSetViewModel.State"/>;
-    /// mutators call <see cref="ActiveSetViewModel.SetState"/> directly.
-    /// The host runs the cross-slice cascade
-    /// (<see cref="RebuildAfterActiveSetChanged"/> + anchor-display
-    /// refresh) via <see cref="HandleActiveSetStateChanged"/>, which is
-    /// subscribed to <see cref="ActiveSetViewModel.StateChanged"/> in
-    /// the constructor.
-    /// </summary>
-    public ActiveSetState State => ActiveSet.State;
+    // Slice 9a: the `State` delegator and the explicit
+    // OnPropertyChanged(nameof(HasMultipleActiveDbs)) re-raise were dropped.
+    // Internal host code reads ActiveSet.State directly; HasMultipleActiveDbs
+    // is owned by the slice, which raises its own PropertyChanged.
 
     /// <summary>
     /// Handler for <see cref="ActiveSetViewModel.StateChanged"/>. Diffs old
@@ -414,7 +370,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         bool dbsChanged = !ReferenceEquals(old.Dbs, now.Dbs);
 
         if (dbsChanged) RebuildAfterActiveSetChanged();
-        OnPropertyChanged(nameof(HasMultipleActiveDbs));
 
         // #91 — every cascade that changes the active set must refresh the
         // title and CurrentDataBlockName, not just the anchor-remove path.
@@ -427,8 +382,8 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private void RefreshAnchorDisplay()
     {
         var version = typeof(BulkChangeViewModel).Assembly.GetName().Version;
-        var anchorName = State.Dbs.Count > 0 ? State.Dbs[0].Info.Name : "";
-        Title = BuildTitle(version, State.AnchorPlcName, anchorName, State.Dbs.Count);
+        var anchorName = ActiveSet.State.Dbs.Count > 0 ? ActiveSet.State.Dbs[0].Info.Name : "";
+        Title = BuildTitle(version, ActiveSet.State.AnchorPlcName, anchorName, ActiveSet.State.Dbs.Count);
         OnPropertyChanged(nameof(CurrentDataBlockName));
     }
 
@@ -483,27 +438,10 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// </summary>
     public SearchFilterViewModel Filter { get; }
 
-    /// <summary>
-    /// One entry per DB the user has switched away from with un-applied
-    /// pending edits (#59). Each entry renders as its own inspector section
-    /// so the staged work stays visible across switches; clicking the section
-    /// header switches back to that DB (running the same prompt again).
-    ///
-    /// <para>
-    /// Delegator for <see cref="ActiveSetViewModel.StashedDbs"/> (slice 8a).
-    /// XAML rebound to <c>{Binding ActiveSet.StashedDbs}</c> in the same
-    /// PR; the host delegator stays for non-XAML readers
-    /// (<see cref="BulkChangeDialog"/> code-behind, tests, DevLauncher)
-    /// and is dropped in slice 9. The underlying collection instance is
-    /// stable — the slice mutates it in place via <c>Clear()</c> +
-    /// <c>Add()</c> — so any subscriber observing
-    /// <c>INotifyCollectionChanged</c> sees the same source across
-    /// snapshots.
-    /// </para>
-    /// </summary>
-    public ObservableCollection<StashedDbState> StashedDbs => ActiveSet.StashedDbs;
-
-    public bool HasStashedDbs => ActiveSet.HasStashedDbs;
+    // Slice 9a: StashedDbs / HasStashedDbs delegators dropped — readers
+    // (XAML, code-behind, DevLauncher, tests) go through ActiveSet.X
+    // directly. The slice raises its own PropertyChanged / collection
+    // changes; binding observers see the slice's signals.
 
     public event Action? RequestClose;
 
@@ -692,19 +630,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     public ICommand EditConfigCommand { get; }
     public ICommand ClearManualSelectionCommand { get; }
 
-    // --- DB-switcher dropdown (#59) — delegators to ActiveSet (#80 slice 8b) ---
-
-    public ICommand OpenDataBlocksDropdownCommand => ActiveSet.OpenDataBlocksDropdownCommand;
-    public ICommand CloseDataBlocksDropdownCommand => ActiveSet.CloseDataBlocksDropdownCommand;
-    public ICommand RefreshDataBlocksCommand => ActiveSet.RefreshDataBlocksCommand;
-    public ICommand SwitchToStashedDbCommand => ActiveSet.SwitchToStashedDbCommand;
-
-    /// <summary>
-    /// True when the host wired up DB enumeration + switching callbacks.
-    /// The dropdown chevron / popup are hidden in tests + DevLauncher runs
-    /// where no project is available.
-    /// </summary>
-    public bool HasDataBlockSwitcher => ActiveSet.HasDataBlockSwitcher;
+    // Slice 9a: DB-switcher command delegators (Open/Close/Refresh/SwitchToStashedDb)
+    // and HasDataBlockSwitcher dropped. XAML, code-behind, DevLauncher and tests
+    // read them through ActiveSet.X directly.
 
     /// <summary>Header label — the DB name part of the title combo.</summary>
     public string CurrentDataBlockName => _active.Info.Name;
@@ -762,128 +690,26 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// (default title / scope label, see <see cref="DataBlockListItem.IsAnchor"/>);
     /// it has no privilege over removability or Apply ordering.
     /// </summary>
-    public IReadOnlyList<ActiveDb> AllActiveDbs => State.Dbs;
+    public IReadOnlyList<ActiveDb> AllActiveDbs => ActiveSet.State.Dbs;
 
-    /// <summary>True when more than one DB is active in this session (#58).</summary>
-    public bool HasMultipleActiveDbs => ActiveSet.HasMultipleActiveDbs;
-
-    // ── Pill-row (#pill-refactor) — delegators to ActiveSet (#80 slice 8b) ───
-
-    /// <summary>
-    /// One pill per PLC that has at least one active DB. Slice owns the
-    /// collection + the rebuild logic; the host forwards the reference so
-    /// XAML bindings (`{Binding PlcPills}`) keep working until slice 9
-    /// rebinds them to <c>ActiveSet.PlcPills</c>.
-    /// </summary>
-    public ObservableCollection<PlcPillViewModel> PlcPills => ActiveSet.PlcPills;
+    // Slice 9a: HasMultipleActiveDbs / PlcPills / AddPlcToRow / InactiveProjectPlcs /
+    // CanAddPlc / IsAddDbPopupOpen / RequestRemoveActiveDb / IsDataBlocksDropdownOpen /
+    // IsLoadingDataBlocks / FilteredDataBlocks / FilteredDataBlockItems / SoloActiveDb /
+    // SoloActiveDbByReference / ReactivateStashedDb delegators dropped.
+    // External readers (XAML, code-behind, DevLauncher, tests) go through
+    // ActiveSet.X directly.
 
     /// <summary>
-    /// Adds <paramref name="plcName"/> to the row as an empty pill (#pill-refactor).
-    /// Delegator for <see cref="ActiveSetViewModel.AddPlcToRow"/>.
+    /// Anchor PLC display, derived from <see cref="ActiveSet"/>'s
+    /// <c>State.AnchorPlcName</c>. Get-only — the slice's SetState is the
+    /// single path that updates the underlying field; the host re-raises
+    /// CurrentPlcName / HasCurrentPlcName from HandleActiveSetStateChanged
+    /// when the anchor changes.
     /// </summary>
-    public void AddPlcToRow(string plcName) => ActiveSet.AddPlcToRow(plcName);
-
-    /// <summary>
-    /// PLC names present in the project but not yet represented in the
-    /// pill row. Drives the "+ PLC" popup's item list and the
-    /// <see cref="CanAddPlc"/> visibility gate.
-    /// </summary>
-    public IReadOnlyList<string> InactiveProjectPlcs => ActiveSet.InactiveProjectPlcs;
-
-    /// <summary>
-    /// True when at least one project PLC is not yet in the row. Bound
-    /// to the "+ PLC" button's Visibility.
-    /// </summary>
-    public bool CanAddPlc => ActiveSet.CanAddPlc;
-
-    public bool IsAddDbPopupOpen
-    {
-        get => ActiveSet.IsAddDbPopupOpen;
-        set => ActiveSet.IsAddDbPopupOpen = value;
-    }
-
-    /// <summary>
-    /// Refuses the last-DB removal (matches the pill last-uncheck rule)
-    /// and routes everything else through the existing remove path so the
-    /// stash / Apply prompt fires for DBs with pending edits. Internal so
-    /// tests can drive gestures without going through chip / pill UI objects.
-    /// </summary>
-    internal void RequestRemoveActiveDb(ActiveDb db) => ActiveSet.RequestRemoveActiveDb(db);
-
-    /// <summary>
-    /// Owning PLC name for the active DB, surfaced as a dim prefix in the
-    /// combo button and the window title so multi-PLC projects don't leave
-    /// the user guessing which PLC the dialog is operating on. Empty when
-    /// the host couldn't supply it (DevLauncher, single-PLC stand-ins).
-    /// </summary>
-    /// <summary>
-    /// Anchor PLC display, derived from <see cref="State"/>'s
-    /// <c>AnchorPlcName</c>. Get-only — the State setter is the single
-    /// path that updates the underlying field and raises the
-    /// <see cref="System.ComponentModel.INotifyPropertyChanged"/> events
-    /// for both this property and <see cref="HasCurrentPlcName"/>.
-    /// </summary>
-    public string CurrentPlcName => State.AnchorPlcName;
+    public string CurrentPlcName => ActiveSet.State.AnchorPlcName;
 
     /// <summary>True when <see cref="CurrentPlcName"/> is non-empty.</summary>
-    public bool HasCurrentPlcName => !string.IsNullOrEmpty(State.AnchorPlcName);
-
-    // DB-switcher dropdown state delegators (#80 slice 8b). XAML bindings
-    // keep going through the host until slice 9 rebinds to ActiveSet.X.
-    public bool IsDataBlocksDropdownOpen
-    {
-        get => ActiveSet.IsDataBlocksDropdownOpen;
-        set => ActiveSet.IsDataBlocksDropdownOpen = value;
-    }
-
-    public bool IsLoadingDataBlocks => ActiveSet.IsLoadingDataBlocks;
-
-    /// <summary>Filtered, alphabetised list shown inside the dropdown.</summary>
-    public IReadOnlyList<DataBlockSummary> FilteredDataBlocks => ActiveSet.FilteredDataBlocks;
-
-    /// <summary>
-    /// Multi-select dropdown rows (#58). Same membership and order as
-    /// <see cref="FilteredDataBlocks"/>; each row wraps the summary with a
-    /// transient IsActive flag that two-way binds to its checkbox.
-    /// </summary>
-    public IReadOnlyList<DataBlockListItem> FilteredDataBlockItems => ActiveSet.FilteredDataBlockItems;
-
-    /// <summary>
-    /// Solo gesture (#58 peer-mode): replace the active set with just the
-    /// target DB. Each dropped DB runs through the same Apply / Stash /
-    /// Cancel prompt RemoveActiveDb uses.
-    ///
-    /// Cancel semantics:
-    ///   • Target was already in the active set → partial-set behaviour
-    ///     (current matches user choices: silently-dropped DBs stay dropped,
-    ///     cancelled-on DBs stay, target stays).
-    ///   • Target was newly built (soloed from the dropdown without first
-    ///     checking it) → any cancel reverts the entire gesture so the
-    ///     freshly-built target is NOT silently added alongside the DB the
-    ///     user explicitly refused to drop. Without this, Solo+Cancel from a
-    ///     single-DB session quietly mutates the active set into multi-DB
-    ///     shape, triggering a tree rebuild that orphans pending edits on
-    ///     the original DB.
-    ///
-    /// Compound op (#78): builds the next snapshot in a local and commits
-    /// once at the end → exactly one cascade per gesture.
-    /// </summary>
-    public void SoloActiveDb(DataBlockSummary target) => ActiveSet.SoloActiveDb(target);
-
-    /// <summary>
-    /// Reference-based variant of <see cref="SoloActiveDb"/>. Delegator
-    /// for <see cref="ActiveSetViewModel.SoloActiveDbByReference"/>.
-    /// </summary>
-    public void SoloActiveDbByReference(ActiveDb target) => ActiveSet.SoloActiveDbByReference(target);
-
-    /// <summary>
-    /// Inspector path delegator (#80 slice 8b). The slice owns the full
-    /// Reactivate flow (additive/replace prompt, snapshot composition,
-    /// stash-replay via the restoreStashOntoLive callback). The host
-    /// keeps this as a public-ish seam for tests that drove the legacy
-    /// internal call site directly.
-    /// </summary>
-    internal void ReactivateStashedDb(StashedDbState stash) => ActiveSet.ReactivateStashedDb(stash);
+    public bool HasCurrentPlcName => !string.IsNullOrEmpty(ActiveSet.State.AnchorPlcName);
 
     /// <summary>
     /// Re-runs the full UI rebuild after State.Dbs changes (add / remove /
@@ -900,9 +726,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// to log gesture state without reaching across the slice boundary.
     /// </summary>
     private string BuildSnapshotForLog() =>
-        $"active=[{string.Join(",", State.Dbs.Select(d => d.Info.Name))}] " +
-        $"pending={Pending.PendingEdits.Count} stashed={StashedDbs.Count} " +
-        $"treeShape={(State.Dbs.Count == 1 ? "single" : "multi")}";
+        $"active=[{string.Join(",", ActiveSet.State.Dbs.Select(d => d.Info.Name))}] " +
+        $"pending={Pending.PendingEdits.Count} stashed={ActiveSet.StashedDbs.Count} " +
+        $"treeShape={(ActiveSet.State.Dbs.Count == 1 ? "single" : "multi")}";
 
     private void RebuildAfterActiveSetChanged()
     {
@@ -958,7 +784,9 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // which re-raises SetButtonText / SetButtonTooltip on the host channel.
         // No need to raise those a second time directly.
         Selection.RaiseManualSelectionChanged();
-        OnPropertyChanged(nameof(HasMultipleActiveDbs));
+        // Slice 9a: HasMultipleActiveDbs moved fully to the slice; the slice
+        // raises its own PropertyChanged when Dbs.Count crosses 1, so the
+        // host no longer needs to re-raise.
     }
 
     /// <summary>
@@ -1001,23 +829,16 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // PlcName from State.AnchorPlcName: the dropdown only enumerates DBs
         // from the anchor's PLC, so any read-only-fallback addition is
         // implicitly on the same PLC as the anchor.
-        return new ActiveDb(info, xml, onApply: null, plcName: State.AnchorPlcName);
+        return new ActiveDb(info, xml, onApply: null, plcName: ActiveSet.State.AnchorPlcName);
     }
 
     // AddActiveDbFromSummary, FindActiveDb, PendingDecision,
     // PromptForPendingEditsOnRemove, CaptureStashForDb, TryComputeRemove,
     // RemoveActiveDb, CountPendingEditsForDb moved to ActiveSetViewModel
     // (#80 slice 8b). The dead-code IsSameSummary helper was dropped per
-    // PR #110 review (zero callers in src/). Slice exposes
-    // AddActiveDbFromSummary as a public delegator surface for tests; the
-    // others are slice-private.
-
-    /// <summary>
-    /// Delegator surface for tests that drive the dropdown checkbox-on path
-    /// directly. The slice owns the implementation.
-    /// </summary>
-    internal void AddActiveDbFromSummary(DataBlockSummary summary)
-        => ActiveSet.AddActiveDbFromSummary(summary);
+    // PR #110 review (zero callers in src/). Slice 9a dropped the
+    // AddActiveDbFromSummary host delegator — tests drive the slice
+    // directly via env.Vm.ActiveSet.AddActiveDbFromSummary(...).
 
     /// <summary>
     /// Close-confirm prompt fired when both the active DB and stashed DBs
@@ -1027,8 +848,8 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     internal CloseWithStashResult PromptForCloseWithStash()
     {
         var active = PendingInlineEditCount;
-        var stashedCount = StashedDbs.Sum(s => s.Count);
-        var stashedDbList = string.Join(", ", StashedDbs.Select(s => s.DbName));
+        var stashedCount = ActiveSet.StashedDbs.Sum(s => s.Count);
+        var stashedDbList = string.Join(", ", ActiveSet.StashedDbs.Select(s => s.DbName));
         return _messageBox.AskCloseWithStash(
             Res.Format("Dialog_UnsavedChanges_Prompt_WithStash",
                 active, stashedCount, stashedDbList),
@@ -1118,15 +939,8 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         }
     }
 
-    /// <summary>True when enumeration is settled but the filter matches nothing.</summary>
-    public bool ShowEmptyDataBlocksMessage => ActiveSet.ShowEmptyDataBlocksMessage;
-
-    /// <summary>Type-to-filter text for the dropdown's search box.</summary>
-    public string DataBlockSearchText
-    {
-        get => ActiveSet.DataBlockSearchText;
-        set => ActiveSet.DataBlockSearchText = value;
-    }
+    // Slice 9a: ShowEmptyDataBlocksMessage / DataBlockSearchText delegators
+    // dropped. XAML / tests read them through ActiveSet.X directly.
 
     // ExecuteOpenDataBlocksDropdown / ExecuteRefreshDataBlocks /
     // LoadAvailableDataBlocks / ApplyDataBlockFilter / StashKey all moved
@@ -1520,7 +1334,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // within-DB analysis; the other active DBs contribute only to
         // the cross-DB lifts.
         AnalysisResult result;
-        if (HasMultipleActiveDbs)
+        if (ActiveSet.HasMultipleActiveDbs)
         {
             var owningDb = Tree.FindActiveDbForModel(memberVm.Model)?.Info ?? _active.Info;
             var allInfos = AllActiveDbs.Select(a => a.Info).ToList();
@@ -1897,7 +1711,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         }
         Filter.HiddenByRuleCount = totalHidden;
 
-        if (HasMultipleActiveDbs)
+        if (ActiveSet.HasMultipleActiveDbs)
         {
             // Route per synthetic root so each DB's filter sets only affect
             // its own subtree.
@@ -1948,7 +1762,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         var searchQuery = Filter.SearchQuery;
         if (string.IsNullOrWhiteSpace(searchQuery)) return;
 
-        if (HasMultipleActiveDbs)
+        if (ActiveSet.HasMultipleActiveDbs)
         {
             // Per-DB search so a path that's a hit in one DB doesn't smart-
             // expand the same path in other active DBs that don't have a hit.
@@ -2490,7 +2304,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // OnApply inside the same dialog tick. Host wires all OnApply
         // invocations into a single ExclusiveAccess block so multi-DB Apply
         // is one TIA undo step (matches issue #58 decision).
-        if (State.Dbs.Count > 1)
+        if (ActiveSet.State.Dbs.Count > 1)
         {
             ExecuteApplyMultiDb();
             return;
@@ -3189,7 +3003,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                 // siblings + mega-scope and forcing the user to re-pick after
                 // every Apply.
                 AnalysisResult result;
-                if (HasMultipleActiveDbs)
+                if (ActiveSet.HasMultipleActiveDbs)
                 {
                     var owningDb = Tree.FindActiveDbForModel(restored.Model)?.Info ?? _active.Info;
                     var allInfos = AllActiveDbs.Select(a => a.Info).ToList();


### PR DESCRIPTION
## Summary

First half of slice 9 from #80 — the closer. Drops the 25 host
delegators carried through slices 1–8b, drops the 11-case
`ActiveSet.PropertyChanged` forwarder block, and rebinds every
external caller (XAML, code-behind, tests) to read through the
slice property directly.

**Doesn't fold** `BuildTitle` / `RefreshAnchorDisplay` / `Title` /
`CurrentDataBlockName` and **doesn't move** `ShowConstants` /
`ConstantsForced` — those are slice 9b (separately reviewable
because they re-introduce code on the slice side, where 9a is
pure-removal).

### What's deleted

**Delegators** (~150 LOC of host getters / commands / methods):

- **Slice 8a originals**: `State`, `StashedDbs`, `HasStashedDbs`.
- **Slice 8b additions**: `RequestRemoveActiveDb`, `SoloActiveDb`,
  `SoloActiveDbByReference`, `AddPlcToRow`, `AddActiveDbFromSummary`,
  `ReactivateStashedDb` (methods); `PlcPills`, `FilteredDataBlocks`,
  `FilteredDataBlockItems`, `DataBlockSearchText`,
  `IsDataBlocksDropdownOpen`, `IsLoadingDataBlocks`,
  `HasMultipleActiveDbs`, `InactiveProjectPlcs`, `CanAddPlc`,
  `HasDataBlockSwitcher`, `ShowEmptyDataBlocksMessage`,
  `IsAddDbPopupOpen` (properties); `OpenDataBlocksDropdownCommand`,
  `CloseDataBlocksDropdownCommand`, `RefreshDataBlocksCommand`,
  `SwitchToStashedDbCommand` (commands).

**PropertyChanged forwarder** (~42 LOC): the `ActiveSet.PropertyChanged += (_, e) => { switch (...) { ... } }` block
forwarding 11 derived-property names. After 9a, XAML / code-behind
/ tests subscribe to the slice's `PropertyChanged` channel directly.

Also dropped: explicit `OnPropertyChanged(nameof(HasMultipleActiveDbs))`
calls at two host sites previously paired with the now-deleted
delegator.

### Kept

- `Subscription.StateChanged += () => OnPropertyChanged(nameof(ApplyTooltip));`
  — unrelated forwarder that composes Apply-pipeline state.
- `PendingInlineEditCount` delegator — 6 internal host uses
  (CanExecute / tooltip composition) still depend on it; out of
  scope for 9a, will revisit when slice 4's `_pendingEditStore`
  cleanup happens.

### Rebinds

| Site | Count |
|---|---:|
| `BulkChangeViewModelDbSwitcherTests.cs` | 27 |
| `BulkChangeViewModelInvariantTests.cs` | 50 |
| `BulkChangeViewModelMultiDbTests.cs` | 71 |
| `BulkChangeViewModelRegressionTests.cs` | 1 |
| `BulkChangeDialog.xaml.cs` (code-behind) | 4 |
| `BulkChangeDialog.xaml` (one `RelativeSource` binding) | 1 |
| **Total** | **154** |

DevLauncher had three mentions in `PillRowCapture.cs` / `Program.cs`
flagged by the surface map but they're documentation comments,
not live property access — verified, no rebind needed.

### Special test migration

`HasStashedDbs_PropertyChanged_FiresOnHostWhenStashFlipsFromEmpty`
was added in slice 8a explicitly as a slice-9 regression guard
(its docstring literally said *"If a future slice-9 cleanup deletes
the forwarder, vm.HasStashedDbs will still read correctly but
bindings observing the host VM's PropertyChanged will silently
stop repainting"*). 9a fulfills the guard's prediction: the
forwarder is gone, the host's `HasStashedDbs` delegator is gone,
XAML now binds through `{Binding ActiveSet.HasStashedDbs}`. The
test migrates to subscribe to
`((INotifyPropertyChanged)env.Vm.ActiveSet).PropertyChanged` and
assert on `nameof(ActiveSetViewModel.HasStashedDbs)`. Same intent
(stash-from-empty must publish a notification a binding can
observe); new subject is the slice. Renamed to
`...FiresOnSliceWhenStashFlipsFromEmpty`.

### Numbers

- **Host VM**: 3,393 → **3,207 LOC** (−186). Cumulative reduction
  from the 4,931-LOC pre-slice baseline is now **−35%**.
- **Tests**: ~213 lines added (mostly the migrated test + rebind
  whitespace), −398 lines removed. Net 4 files smaller.
- **No new tests**; the existing 8a regression-guard test was
  migrated rather than reauthored.

### Verification (from agent's run-time grep)

- 0 delegator declarations remain on the host VM (confirmed via
  property/method/command name regex).
- 0 bare `vm.X` / `env.Vm.X` references to dropped delegators
  remain in tests / DevLauncher / code-behind. All such references
  now go through `vm.ActiveSet.X`.

### Next (slice 9b)

- Fold `BuildTitle` + `RefreshAnchorDisplay` into the slice (Title
  becomes `ActiveSet.Title`, raised from `SetState`). XAML rebind
  for `Title="{Binding Title}"` → `{Binding ActiveSet.Title}`.
- Move `ShowConstants` + `ConstantsForced` to `AutocompleteViewModel`
  with a `ShowConstantsChanged` event the host subscribes to for
  the `ReloadSuggestions` callback.
- Trim ~14 LOC of slice-9a removal-marker comments to hit the
  3,193-LOC target from the surface map.
- Closes #80.

## Test plan

- [ ] CI `Build & Test (V20, net48)` green — every host VM test
      file was touched, so any binding regression surfaces
      immediately
- [ ] CI `Build (V21, net48)` green

Refs #80.

https://claude.ai/code/session_0168J7dK7tApviBaDquX6gUd

---
_Generated by [Claude Code](https://claude.ai/code/session_0168J7dK7tApviBaDquX6gUd)_