### PR TITLE
refactor(#80): fold BuildTitle/RefreshAnchorDisplay + move ShowConstants (slice 9b)

### DIFF
--- a/src/BlockParam.Tests/BulkChangeViewModelDbSwitcherTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelDbSwitcherTests.cs
@@ -105,9 +105,9 @@ public class BulkChangeViewModelDbSwitcherTests
             new HierarchyAnalyzer(), bulkService, usageTracker, configLoader,
             currentPlcName: "PLC_Line1");
 
-        vm.HasCurrentPlcName.Should().BeTrue();
-        vm.CurrentPlcName.Should().Be("PLC_Line1");
-        vm.Title.Should().Contain("PLC_Line1 / " + primaryInfo.Name);
+        vm.ActiveSet.HasCurrentPlcName.Should().BeTrue();
+        vm.ActiveSet.CurrentPlcName.Should().Be("PLC_Line1");
+        vm.ActiveSet.Title.Should().Contain("PLC_Line1 / " + primaryInfo.Name);
     }
 
     [Fact]
@@ -115,9 +115,9 @@ public class BulkChangeViewModelDbSwitcherTests
     {
         // Single-PLC / DevLauncher: no PlcName → no prefix, no badge.
         var h = CreateVm();
-        h.Vm.HasCurrentPlcName.Should().BeFalse();
-        h.Vm.CurrentPlcName.Should().Be("");
-        h.Vm.Title.Should().NotContain(" / ");
+        h.Vm.ActiveSet.HasCurrentPlcName.Should().BeFalse();
+        h.Vm.ActiveSet.CurrentPlcName.Should().Be("");
+        h.Vm.ActiveSet.Title.Should().NotContain(" / ");
     }
 
     [Fact]

--- a/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelInvariantTests.cs
@@ -555,7 +555,7 @@ public class BulkChangeViewModelInvariantTests
             .Build();
 
         env.Vm.AllActiveDbs[0].Info.Name.Should().Be("FlatDB", "setup: anchor is FlatDB");
-        env.Vm.CurrentPlcName.Should().Be("PLC_A", "setup: anchor PLC display is PLC_A");
+        env.Vm.ActiveSet.CurrentPlcName.Should().Be("PLC_A", "setup: anchor PLC display is PLC_A");
 
         var anchorDb2 = env.Vm.AllActiveDbs.First(d => d.Info.Name == "FlatDB");
         env.Vm.ActiveSet.RequestRemoveActiveDb(anchorDb2); // 2-DB session — anchor is removable
@@ -563,9 +563,9 @@ public class BulkChangeViewModelInvariantTests
         env.Vm.AllActiveDbs.Should().HaveCount(1);
         env.Vm.AllActiveDbs[0].Info.Name.Should().Be("NestedStructDB",
             "the surviving peer rotates into the anchor slot");
-        env.Vm.CurrentDataBlockName.Should().Be("NestedStructDB",
+        env.Vm.ActiveSet.CurrentDataBlockName.Should().Be("NestedStructDB",
             "CurrentDataBlockName tracks State.Dbs[0]");
-        env.Vm.CurrentPlcName.Should().Be("PLC_B",
+        env.Vm.ActiveSet.CurrentPlcName.Should().Be("PLC_B",
             "anchor PLC display follows the new anchor (TryComputeRemove " +
             "rewrites AnchorPlcName; CurrentPlcName reads State.AnchorPlcName)");
         env.Mbx.AskYesNoCancelCallCount.Should().Be(0, "no edits → no prompt");
@@ -780,9 +780,9 @@ public class BulkChangeViewModelInvariantTests
             .Build();
 
         env.Vm.AllActiveDbs.Should().HaveCount(2, "setup: multi-DB session");
-        env.Vm.Title.Should().NotContain("FlatDB",
+        env.Vm.ActiveSet.Title.Should().NotContain("FlatDB",
             "multi-DB title must not surface the anchor DB's name");
-        env.Vm.Title.Should().NotContain("NestedStructDB",
+        env.Vm.ActiveSet.Title.Should().NotContain("NestedStructDB",
             "multi-DB title must not surface any single DB's name");
         AssertInvariants(env.Vm);
     }
@@ -805,7 +805,7 @@ public class BulkChangeViewModelInvariantTests
             .WithPeer("array-db.xml")
             .Build();
 
-        var titleBefore = env.Vm.Title;
+        var titleBefore = env.Vm.ActiveSet.Title;
         titleBefore.Should().NotContain("NestedStructDB",
             "setup: 3-DB title doesn't already include the soloed name");
 
@@ -815,10 +815,10 @@ public class BulkChangeViewModelInvariantTests
 
         env.Vm.AllActiveDbs.Should().HaveCount(1, "solo collapses to one DB");
         env.Vm.AllActiveDbs[0].Info.Name.Should().Be("NestedStructDB");
-        env.Vm.Title.Should().Contain("NestedStructDB",
+        env.Vm.ActiveSet.Title.Should().Contain("NestedStructDB",
             "single-DB shape after solo must surface the new lone DB's name " +
             "(or, post-fix, the chip-only header must consistently re-render)");
-        env.Vm.Title.Should().NotContain("FlatDB",
+        env.Vm.ActiveSet.Title.Should().NotContain("FlatDB",
             "previous anchor's name must NOT linger after solo");
         AssertInvariants(env.Vm);
     }
@@ -870,7 +870,7 @@ public class BulkChangeViewModelInvariantTests
             var anchorPill = vm.ActiveSet.PlcPills
                 .FirstOrDefault(p => p.SelectedDbs.OfType<DataBlockListItem>()
                     .Any(i => i.Name == anchorName));
-            anchorPill?.PlcName.Should().Be(vm.CurrentPlcName,
+            anchorPill?.PlcName.Should().Be(vm.ActiveSet.CurrentPlcName,
                 "invariant 5: anchor pill's PlcName == CurrentPlcName");
         }
 

--- a/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelRegressionTests.cs
@@ -723,11 +723,11 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         vm.Selection.SelectedFlatMember = leaf;
 
         // Confirm starting state: ShowConstants=false → Suggestions empty
-        vm.ShowConstants.Should().BeFalse("no rule forces ShowConstants on");
+        vm.Autocomplete.ShowConstants.Should().BeFalse("no rule forces ShowConstants on");
         vm.Autocomplete.Suggestions.Should().BeEmpty("ShowConstants is off — no suggestions loaded yet");
 
         // Toggle on → Suggestions must populate from the tag-table cache
-        vm.ShowConstants = true;
+        vm.Autocomplete.ShowConstants = true;
 
         vm.Autocomplete.Suggestions.Should().NotBeEmpty(
             "ShowConstants=true must load suggestions from the tag-table cache");
@@ -778,7 +778,7 @@ public class BulkChangeViewModelRegressionTests : IDisposable
         vm.Selection.SelectedFlatMember = vm.Tree.FlatMembers.First(m => m.IsLeaf);
 
         // Force ShowConstants on to populate _suggestions
-        vm.ShowConstants = true;
+        vm.Autocomplete.ShowConstants = true;
         vm.Autocomplete.Suggestions.Should().HaveCount(10, "all 10 entries loaded");
         vm.Autocomplete.FilteredSuggestions.Should().BeEmpty("not yet toggled open");
 

--- a/src/BlockParam/UI/ActiveSetViewModel.cs
+++ b/src/BlockParam/UI/ActiveSetViewModel.cs
@@ -41,6 +41,7 @@ namespace BlockParam.UI;
 public sealed class ActiveSetViewModel : ViewModelBase
 {
     private ActiveSetState _state;
+    private string _title = "";
 
     // --- Optional dependencies (8b). All-null defaults keep the legacy
     // ActiveSetViewModel(initial) ctor (used by slice-8a tests) working
@@ -121,6 +122,10 @@ public sealed class ActiveSetViewModel : ViewModelBase
         _state = initial ?? throw new ArgumentNullException(nameof(initial));
         StashedDbs = new ObservableCollection<StashedDbState>();
         SyncStashedDbsCollection();
+        // Seed the dialog window title from the initial snapshot so the
+        // host's XAML binding has a non-empty value before the first
+        // active-set change. SetState recomputes on every snapshot swap.
+        _title = ComputeTitleFromState();
 
         _messageBox = messageBox;
         _pendingEditStore = pendingEditStore;
@@ -197,10 +202,81 @@ public sealed class ActiveSetViewModel : ViewModelBase
         if (!ReferenceEquals(old.Stashes, next.Stashes))
             SyncStashedDbsCollection();
 
-        if (!ReferenceEquals(old.Dbs, next.Dbs))
+        bool dbsChanged = !ReferenceEquals(old.Dbs, next.Dbs);
+        bool anchorPlcChanged = !string.Equals(
+            old.AnchorPlcName, next.AnchorPlcName, StringComparison.Ordinal);
+
+        if (dbsChanged)
             OnPropertyChanged(nameof(HasMultipleActiveDbs));
 
+        // Anchor display: Title + CurrentDataBlockName + CurrentPlcName all
+        // derive from State.Dbs[0] / State.AnchorPlcName. Recompute the
+        // title once per snapshot install (#91) — every gesture that swaps
+        // the active set funnels through SetState, so the chip-only/single-DB
+        // title shape stays in sync without each mutator owning its own
+        // refresh call.
+        if (dbsChanged || anchorPlcChanged)
+        {
+            Title = ComputeTitleFromState();
+            OnPropertyChanged(nameof(CurrentDataBlockName));
+        }
+
+        if (anchorPlcChanged)
+        {
+            OnPropertyChanged(nameof(CurrentPlcName));
+            OnPropertyChanged(nameof(HasCurrentPlcName));
+        }
+
         StateChanged?.Invoke(old, next);
+    }
+
+    /// <summary>
+    /// Dialog window title. Single-DB sessions render
+    /// <c>"BlockParam v{version}: {PLC} / {DB}"</c>; multi-DB sessions
+    /// drop the DB/PLC suffix entirely (#91). XAML binds via
+    /// <c>{Binding ActiveSet.Title}</c>.
+    /// </summary>
+    public string Title
+    {
+        get => _title;
+        private set => SetProperty(ref _title, value);
+    }
+
+    /// <summary>Header label — the DB name part of the title combo.</summary>
+    public string CurrentDataBlockName =>
+        _state.Dbs.Count > 0 ? _state.Dbs[0].Info.Name : "";
+
+    /// <summary>
+    /// Anchor PLC display, derived from <see cref="ActiveSetState.AnchorPlcName"/>.
+    /// Multi-PLC sessions render the chip prefix from this; single-PLC
+    /// hosts (DevLauncher) leave it empty and the prefix is omitted.
+    /// </summary>
+    public string CurrentPlcName => _state.AnchorPlcName;
+
+    /// <summary>True when <see cref="CurrentPlcName"/> is non-empty.</summary>
+    public bool HasCurrentPlcName => !string.IsNullOrEmpty(_state.AnchorPlcName);
+
+    private string ComputeTitleFromState()
+    {
+        var version = typeof(ActiveSetViewModel).Assembly.GetName().Version;
+        var anchorName = _state.Dbs.Count > 0 ? _state.Dbs[0].Info.Name : "";
+        return BuildTitle(version, _state.AnchorPlcName, anchorName, _state.Dbs.Count);
+    }
+
+    /// <summary>
+    /// Builds the dialog window title. Single-DB sessions render
+    /// <c>"BlockParam v{version}: {PLC} / {DB}"</c>. Multi-DB sessions
+    /// drop the DB/PLC suffix entirely (#91): the chip strip is the
+    /// single source of truth for which DBs are in scope, so surfacing
+    /// one specific DB's name in the title contradicts the peer-DB
+    /// model. Single-PLC hosts (DevLauncher) pass an empty PLC name and
+    /// the prefix is dropped.
+    /// </summary>
+    private static string BuildTitle(System.Version? version, string plcName, string dbName, int activeDbCount)
+    {
+        if (activeDbCount > 1) return $"BlockParam v{version}";
+        var location = string.IsNullOrEmpty(plcName) ? dbName : $"{plcName} / {dbName}";
+        return $"BlockParam v{version}: {location}";
     }
 
     private void SyncStashedDbsCollection()

--- a/src/BlockParam/UI/AutocompleteViewModel.cs
+++ b/src/BlockParam/UI/AutocompleteViewModel.cs
@@ -30,6 +30,18 @@ public class AutocompleteViewModel : ViewModelBase
     private IReadOnlyList<AutocompleteSuggestion> _suggestions = Array.Empty<AutocompleteSuggestion>();
     private IReadOnlyList<AutocompleteSuggestion> _filteredSuggestions = Array.Empty<AutocompleteSuggestion>();
     private bool _suppressSuggestions;
+    private bool _showConstants;
+    private bool _constantsForced;
+
+    /// <summary>
+    /// Raised after <see cref="ShowConstants"/> changes via the public
+    /// setter. The host VM subscribes and calls its <c>ReloadSuggestions</c>
+    /// — the slice doesn't own the reload pipeline (it composes
+    /// SelectedFlatMember, config rules, and the tag-table cache, all of
+    /// which live on the host), so a fire-and-forget event is the
+    /// minimal cross-slice coupling.
+    /// </summary>
+    public event Action? ShowConstantsChanged;
 
     /// <summary>Suggestion provider for glob-based per-row matching (null = no suggestions).</summary>
     public GlobSuggestionProvider? SuggestionProvider
@@ -67,6 +79,44 @@ public class AutocompleteViewModel : ViewModelBase
     {
         get => _suppressSuggestions;
         set => _suppressSuggestions = value;
+    }
+
+    /// <summary>
+    /// Whether to show constant suggestions. Forced on when a rule with
+    /// <c>tagTableReference</c> matches the current member; the setter
+    /// no-ops when <see cref="ConstantsForced"/> is true and the caller
+    /// tries to uncheck. Raises <see cref="ShowConstantsChanged"/> on
+    /// actual flip so the host can reload its suggestion pool.
+    /// </summary>
+    public bool ShowConstants
+    {
+        get => _showConstants;
+        set
+        {
+            if (_constantsForced && !value) return; // Can't uncheck when forced
+            if (SetProperty(ref _showConstants, value))
+                ShowConstantsChanged?.Invoke();
+        }
+    }
+
+    /// <summary>True when a config rule forces constants on (checkbox disabled).</summary>
+    public bool ConstantsForced
+    {
+        get => _constantsForced;
+        set => SetProperty(ref _constantsForced, value);
+    }
+
+    /// <summary>
+    /// Update <see cref="ShowConstants"/> without firing
+    /// <see cref="ShowConstantsChanged"/>. Used by the host's
+    /// <c>OnMemberSelected</c> rule-forced visibility path so a single
+    /// member-selection gesture doesn't run <c>ReloadSuggestions</c>
+    /// twice (once for the forced flip, once for the explicit reload
+    /// call that follows). Raises <c>PropertyChanged</c> for XAML.
+    /// </summary>
+    public void SetShowConstantsSilent(bool value)
+    {
+        SetProperty(ref _showConstants, value, nameof(ShowConstants));
     }
 
     /// <summary>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -4,7 +4,7 @@
         xmlns:local="clr-namespace:BlockParam.UI"
         xmlns:loc="clr-namespace:BlockParam.Localization"
         xmlns:controls="clr-namespace:BlockParam.UI.Controls.PillMultiSelect"
-        Title="{Binding Title}"
+        Title="{Binding ActiveSet.Title}"
                 Width="1100" Height="700"
         MinWidth="800" MinHeight="500"
         WindowState="Maximized"
@@ -819,8 +819,8 @@
                                                            FontSize="9.5" FontWeight="Bold" Foreground="#5b6471"/>
                                                 <StackPanel DockPanel.Dock="Right" Orientation="Horizontal"
                                                             HorizontalAlignment="Right">
-                                                    <CheckBox Content="{loc:Loc Dialog_Constants}" IsChecked="{Binding ShowConstants}"
-                                                              IsEnabled="{Binding ConstantsForced, Converter={StaticResource InvertBool}}"
+                                                    <CheckBox Content="{loc:Loc Dialog_Constants}" IsChecked="{Binding Autocomplete.ShowConstants}"
+                                                              IsEnabled="{Binding Autocomplete.ConstantsForced, Converter={StaticResource InvertBool}}"
                                                               VerticalAlignment="Center" FontSize="10" Margin="0,0,4,0"/>
                                                     <TextBlock Text="{Binding TagTableAge}" Foreground="#999" FontSize="9"
                                                                VerticalAlignment="Center" Margin="0,0,3,0"/>
@@ -838,7 +838,7 @@
                                                 <Button HorizontalAlignment="Right" VerticalAlignment="Stretch"
                                                         Width="20" Background="Transparent" BorderThickness="0"
                                                         Click="OnDropdownArrowClick" Cursor="Hand"
-                                                        Visibility="{Binding ShowConstants, Converter={StaticResource BoolToVis}}">
+                                                        Visibility="{Binding Autocomplete.ShowConstants, Converter={StaticResource BoolToVis}}">
                                                     <Path Data="M 0,0 L 6,5 L 12,0 Z" Fill="#888"/>
                                                 </Button>
                                             </Grid>

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -24,17 +24,18 @@ namespace BlockParam.UI;
 /// ListView/GridView.
 ///
 /// <para>
-/// <b>Active-set state model (#78, slice 8a).</b> The dialog's active
-/// DBs + per-DB pending-edit stashes + anchor PLC name are bundled
-/// into a single immutable <see cref="ActiveSetState"/> snapshot
-/// owned by the <see cref="ActiveSetViewModel"/> slice (exposed as
-/// <see cref="ActiveSet"/>). Mutators call
+/// <b>Active-set state model (#78, slice 8a/8b/9).</b> The dialog's
+/// active DBs + per-DB pending-edit stashes + anchor PLC name are
+/// bundled into a single immutable <see cref="ActiveSetState"/>
+/// snapshot owned by the <see cref="ActiveSetViewModel"/> slice
+/// (exposed as <see cref="ActiveSet"/>). Mutators call
 /// <see cref="ActiveSetViewModel.SetState"/>; the slice raises
 /// <see cref="ActiveSetViewModel.StateChanged"/>, and the host's
 /// <see cref="HandleActiveSetStateChanged"/> runs the cross-slice
-/// cascade (<c>RebuildAfterActiveSetChanged</c> + anchor-PLC display
-/// refresh). <c>StashedDbs</c> sync now lives inside the slice, so
-/// every mutation gesture still funnels through a single point and
+/// cascade (<see cref="RebuildAfterActiveSetChanged"/>).
+/// <c>StashedDbs</c> sync and anchor-display refresh (Title +
+/// CurrentDataBlockName + CurrentPlcName) both live inside the slice
+/// — every mutation gesture funnels through a single point and
 /// forgetting to refresh after a change remains structurally
 /// impossible.
 /// </para>
@@ -42,22 +43,21 @@ namespace BlockParam.UI;
 /// <para>
 /// Mutators compute a new snapshot in locals and assign once.
 /// Single-step gestures (chip ×, dropdown toggle) call helpers like
-/// <see cref="TryComputeRemove"/> and assign the returned snapshot;
-/// compound gestures (Solo, Reactivate stash, legacy
-/// <see cref="SwitchToDataBlock"/>) compose the new snapshot across
-/// multiple steps and assign once at the end → exactly one cascade per
-/// user gesture, regardless of how many DBs were swapped in or out.
-/// Cancellation = don't assign; the dialog stays on the previous
-/// snapshot.
+/// <c>TryComputeRemove</c> and assign the returned snapshot; compound
+/// gestures (Solo, Reactivate stash, legacy SwitchToDataBlock) compose
+/// the new snapshot across multiple steps and assign once at the end
+/// → exactly one cascade per user gesture, regardless of how many DBs
+/// were swapped in or out. Cancellation = don't assign; the dialog
+/// stays on the previous snapshot.
 /// </para>
 ///
 /// <para>
 /// <b>Single authoritative storage.</b> Slice 8 PR 0 deleted the
 /// legacy backing fields (<c>_activeDbs</c> / <c>_stashedDbs</c> /
-/// <c>_currentPlcName</c>) — every read now goes through
-/// <c>State.Dbs[i]</c> / <c>State.Stashes[k]</c> / <c>State.AnchorPlcName</c>.
-/// The State setter has no sync-cascade left and the snapshot cannot
-/// drift out of sync with what the cascade can see.
+/// <c>_currentPlcName</c>) — every read goes through
+/// <c>ActiveSet.State.Dbs[i]</c> / <c>ActiveSet.State.Stashes[k]</c> /
+/// <c>ActiveSet.State.AnchorPlcName</c>. The snapshot lives on the
+/// slice; the host only reads through <see cref="ActiveSet"/>.
 /// </para>
 /// </summary>
 public class BulkChangeViewModel : ViewModelBase, IDisposable
@@ -81,32 +81,21 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private AutocompleteProvider? _autocompleteProvider;
     private TagTableCache? _tagTableCache;
 
-    // _active is a derived alias over State.Dbs[0] so the ~50 host call
-    // sites that expected "the anchor DB" don't all need rewriting. It
-    // carries no privilege — removing State.Dbs[0] just shifts the next
-    // one into position. Active DBs in State.Dbs are peers; index 0 is
-    // just the first one in storage order, used as the anchor when the
-    // UI needs a single representative (title, default scope, "current"
+    // _active is a derived alias over ActiveSet.State.Dbs[0] so the ~50
+    // host call sites that expected "the anchor DB" don't all need
+    // rewriting. It carries no privilege — removing the first DB just
+    // shifts the next one into position. Active DBs are peers; index 0
+    // is the first one in storage order, used as the anchor when the
+    // UI needs a single representative (default scope label, "current"
     // name display).
     private ActiveDb _active => ActiveSet.State.Dbs[0];
-    private string _title = "";
     // DB-switcher dropdown state (#59), pill row, and the mutators that
-    // touch them moved to ActiveSetViewModel in #80 slice 8b. The host
+    // touch them live on ActiveSetViewModel (#80 slice 8b). The host
     // keeps two callback refs only because BuildActiveDbFromSummaryWithFallback
     // (DevLauncher / tests with no host factory) needs to synthesize an
     // ActiveDb from xml via switchToDataBlock + the parser.
     private readonly Func<DataBlockSummary, string>? _switchToDataBlock;
     private readonly Func<DataBlockSummary, ActiveDb?>? _buildActiveDbForSummary;
-    // Active-DB set, per-DB pending-edit stashes, and anchor PLC name all
-    // live on the State snapshot (#78). Legacy backing fields
-    // (_activeDbs / _stashedDbs / _currentPlcName) were deleted in slice 8
-    // PR 0 once every read site was migrated to State.X — the State
-    // setter no longer needs its sync-cascade and there is one
-    // authoritative storage for each.
-
-    // Tree-shape state (RootMembers, flat list, model lookups, synthetic-
-    // group routing) lives on the MemberTreeViewModel slice (#80 slice 7a).
-    // The host accesses it via the Tree property — see the constructor.
 
     // Session-scoped store for pending inline-edit values, keyed by MemberNode
     // reference. Survives BuildRootMembersFromActiveDbs rebuilds — fresh VMs
@@ -137,8 +126,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private string _validationError = "";
     private string _constraintInfo = "";
     private Timer? _valueDebounceTimer;
-    private bool _showConstants;
-    private bool _constantsForced;
     private string _tagTableAge = "";
     // _isRefreshing moved to MemberTreeViewModel as Tree.IsRefreshing (slice 7a).
     private bool _lastApplySucceeded;
@@ -235,16 +222,16 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             getPendingCount: () => Pending?.PendingEdits.Count ?? 0,
             dispatcher: _dispatcher);
         ActiveSet.StateChanged += HandleActiveSetStateChanged;
-        // Slice 9a: the PropertyChanged forwarder that re-raised 11 derived
-        // notifications on the host VM was deleted. XAML, code-behind,
-        // DevLauncher and tests now bind / read through {Binding ActiveSet.X}
-        // directly, so the slice's own PropertyChanged is the single source
-        // of truth for repaints.
         _autocompleteProvider = tagTableCache != null
             ? new AutocompleteProvider(configLoader, tagTableCache)
             : null;
-        // Autocomplete suggestion slice (#80 slice 3).
+        // Autocomplete suggestion slice (#80 slice 3 + 9b). Owns
+        // ShowConstants / ConstantsForced; the host subscribes to
+        // ShowConstantsChanged and runs ReloadSuggestions because the
+        // reload pipeline composes SelectedFlatMember + config rules +
+        // tag-table cache (host-side state).
         Autocomplete = new AutocompleteViewModel();
+        Autocomplete.ShowConstantsChanged += ReloadSuggestions;
         // Search + tree-filter slice (#80 slice 6). Slice owns SearchQuery /
         // SetPoint toggle / banner state; the filter pass itself (ApplyAllFilters
         // + RefreshFlatList) stays here because it walks the multi-DB tree
@@ -270,9 +257,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                     config.Rules.Count, config.RulesDirectory ?? "(none)");
             }
         }
-
-        var version = typeof(BulkChangeViewModel).Assembly.GetName().Version;
-        _title = BuildTitle(version, ActiveSet.State.AnchorPlcName, dataBlockInfo.Name, ActiveSet.State.Dbs.Count);
 
         InlineRuleExtractor.ApplyTo(configLoader.GetConfig(), dataBlockInfo);
 
@@ -331,11 +315,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         ClearManualSelectionCommand = new RelayCommand(ExecuteClearManualSelection,
             () => Selection.ManualSelectionCount > 0);
 
-        // OpenDataBlocksDropdownCommand / CloseDataBlocksDropdownCommand /
-        // RefreshDataBlocksCommand / SwitchToStashedDbCommand moved to
-        // ActiveSetViewModel (#80 slice 8b). Host delegators expose them
-        // for the existing XAML / test surface — see the property block.
-
         // Apply initial filter and build flat list
         ApplyAllFilters();
         RefreshFlatList();
@@ -349,53 +328,24 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
     // --- Properties ---
 
-    // Slice 9a: the `State` delegator and the explicit
-    // OnPropertyChanged(nameof(HasMultipleActiveDbs)) re-raise were dropped.
-    // Internal host code reads ActiveSet.State directly; HasMultipleActiveDbs
-    // is owned by the slice, which raises its own PropertyChanged.
-
     /// <summary>
     /// Handler for <see cref="ActiveSetViewModel.StateChanged"/>. Diffs old
     /// vs new snapshot and runs only the cascade slices that actually
     /// changed. Reference equality on <c>Dbs</c> / <c>Stashes</c> works
     /// because every mutator constructs fresh List / Dictionary instances —
     /// "same instance" implies "no change."
+    ///
+    /// <para>Title / CurrentDataBlockName / CurrentPlcName / HasCurrentPlcName
+    /// re-raises live inside <see cref="ActiveSetViewModel.SetState"/> (slice 9b)
+    /// — the host only runs the cross-slice cascade
+    /// (<see cref="RebuildAfterActiveSetChanged"/>) on Dbs changes.</para>
     /// </summary>
     private void HandleActiveSetStateChanged(ActiveSetState old, ActiveSetState now)
     {
-        // CurrentPlcName / HasCurrentPlcName are derived from
-        // State.AnchorPlcName; re-raise them only on actual change.
-        if (!string.Equals(old.AnchorPlcName, now.AnchorPlcName, StringComparison.Ordinal))
-        {
-            OnPropertyChanged(nameof(CurrentPlcName));
-            OnPropertyChanged(nameof(HasCurrentPlcName));
-        }
-
-        bool dbsChanged = !ReferenceEquals(old.Dbs, now.Dbs);
-
-        if (dbsChanged) RebuildAfterActiveSetChanged();
-
-        // #91 — every cascade that changes the active set must refresh the
-        // title and CurrentDataBlockName, not just the anchor-remove path.
-        // Solo / reactivate / add all funnel through here, so single-DB
-        // ↔ multi-DB title transitions stay in sync without each gesture
-        // owning its own Title = BuildTitle(...) call.
-        if (dbsChanged) RefreshAnchorDisplay();
+        if (!ReferenceEquals(old.Dbs, now.Dbs))
+            RebuildAfterActiveSetChanged();
     }
 
-    private void RefreshAnchorDisplay()
-    {
-        var version = typeof(BulkChangeViewModel).Assembly.GetName().Version;
-        var anchorName = ActiveSet.State.Dbs.Count > 0 ? ActiveSet.State.Dbs[0].Info.Name : "";
-        Title = BuildTitle(version, ActiveSet.State.AnchorPlcName, anchorName, ActiveSet.State.Dbs.Count);
-        OnPropertyChanged(nameof(CurrentDataBlockName));
-    }
-
-    public string Title
-    {
-        get => _title;
-        private set => SetProperty(ref _title, value);
-    }
     /// <summary>
     /// Selection / scope / manual-selection slice (#80 slice 7b). Owns
     /// <c>SelectedFlatMember</c>, <c>SelectedScope</c>,
@@ -441,11 +391,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// XAML binds via <c>{Binding Filter.SearchQuery}</c> etc.
     /// </summary>
     public SearchFilterViewModel Filter { get; }
-
-    // Slice 9a: StashedDbs / HasStashedDbs delegators dropped — readers
-    // (XAML, code-behind, DevLauncher, tests) go through ActiveSet.X
-    // directly. The slice raises its own PropertyChanged / collection
-    // changes; binding observers see the slice's signals.
 
     public event Action? RequestClose;
 
@@ -634,13 +579,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     public ICommand EditConfigCommand { get; }
     public ICommand ClearManualSelectionCommand { get; }
 
-    // Slice 9a: DB-switcher command delegators (Open/Close/Refresh/SwitchToStashedDb)
-    // and HasDataBlockSwitcher dropped. XAML, code-behind, DevLauncher and tests
-    // read them through ActiveSet.X directly.
-
-    /// <summary>Header label — the DB name part of the title combo.</summary>
-    public string CurrentDataBlockName => _active.Info.Name;
-
     /// <summary>
     /// Populates <see cref="RootMembers"/> from every active DB (#58).
     /// Single-DB sessions get a flat list of the DB's
@@ -695,25 +633,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// it has no privilege over removability or Apply ordering.
     /// </summary>
     public IReadOnlyList<ActiveDb> AllActiveDbs => ActiveSet.State.Dbs;
-
-    // Slice 9a: HasMultipleActiveDbs / PlcPills / AddPlcToRow / InactiveProjectPlcs /
-    // CanAddPlc / IsAddDbPopupOpen / RequestRemoveActiveDb / IsDataBlocksDropdownOpen /
-    // IsLoadingDataBlocks / FilteredDataBlocks / FilteredDataBlockItems / SoloActiveDb /
-    // SoloActiveDbByReference / ReactivateStashedDb delegators dropped.
-    // External readers (XAML, code-behind, DevLauncher, tests) go through
-    // ActiveSet.X directly.
-
-    /// <summary>
-    /// Anchor PLC display, derived from <see cref="ActiveSet"/>'s
-    /// <c>State.AnchorPlcName</c>. Get-only — the slice's SetState is the
-    /// single path that updates the underlying field; the host re-raises
-    /// CurrentPlcName / HasCurrentPlcName from HandleActiveSetStateChanged
-    /// when the anchor changes.
-    /// </summary>
-    public string CurrentPlcName => ActiveSet.State.AnchorPlcName;
-
-    /// <summary>True when <see cref="CurrentPlcName"/> is non-empty.</summary>
-    public bool HasCurrentPlcName => !string.IsNullOrEmpty(ActiveSet.State.AnchorPlcName);
 
     /// <summary>
     /// Re-runs the full UI rebuild after State.Dbs changes (add / remove /
@@ -788,9 +707,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // which re-raises SetButtonText / SetButtonTooltip on the host channel.
         // No need to raise those a second time directly.
         Selection.RaiseManualSelectionChanged();
-        // Slice 9a: HasMultipleActiveDbs moved fully to the slice; the slice
-        // raises its own PropertyChanged when Dbs.Count crosses 1, so the
-        // host no longer needs to re-raise.
     }
 
     /// <summary>
@@ -835,14 +751,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // implicitly on the same PLC as the anchor.
         return new ActiveDb(info, xml, onApply: null, plcName: ActiveSet.State.AnchorPlcName);
     }
-
-    // AddActiveDbFromSummary, FindActiveDb, PendingDecision,
-    // PromptForPendingEditsOnRemove, CaptureStashForDb, TryComputeRemove,
-    // RemoveActiveDb, CountPendingEditsForDb moved to ActiveSetViewModel
-    // (#80 slice 8b). The dead-code IsSameSummary helper was dropped per
-    // PR #110 review (zero callers in src/). Slice 9a dropped the
-    // AddActiveDbFromSummary host delegator — tests drive the slice
-    // directly via env.Vm.ActiveSet.AddActiveDbFromSummary(...).
 
     /// <summary>
     /// Close-confirm prompt fired when both the active DB and stashed DBs
@@ -943,30 +851,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         }
     }
 
-    // Slice 9a: ShowEmptyDataBlocksMessage / DataBlockSearchText delegators
-    // dropped. XAML / tests read them through ActiveSet.X directly.
-
-    // ExecuteOpenDataBlocksDropdown / ExecuteRefreshDataBlocks /
-    // LoadAvailableDataBlocks / ApplyDataBlockFilter / StashKey all moved
-    // to ActiveSetViewModel (#80 slice 8b). Commands wired through
-    // ActiveSet.{Open,Close,Refresh}DataBlocksDropdownCommand.
-
-    /// <summary>
-    /// Builds the dialog window title. Single-DB sessions render
-    /// <c>"BlockParam v{version}: {PLC} / {DB}"</c>. Multi-DB sessions
-    /// drop the DB/PLC suffix entirely (#91): the chip strip is the
-    /// single source of truth for which DBs are in scope, so surfacing
-    /// one specific DB's name in the title contradicts the peer-DB
-    /// model. Single-PLC hosts (DevLauncher) pass an empty PLC name and
-    /// the prefix is dropped.
-    /// </summary>
-    private static string BuildTitle(System.Version? version, string plcName, string dbName, int activeDbCount)
-    {
-        if (activeDbCount > 1) return $"BlockParam v{version}";
-        var location = string.IsNullOrEmpty(plcName) ? dbName : $"{plcName} / {dbName}";
-        return $"BlockParam v{version}: {location}";
-    }
-
     /// <summary>
     /// Replays a stash's edits onto the live tree (#78). Pure write — does
     /// NOT pop the stash entry from <c>State.Stashes</c>. Callers
@@ -1020,10 +904,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             restored, state.Summary.Name, dropped);
         return (restored, dropped);
     }
-
-    // SyncStashedDbsCollection moved to ActiveSetViewModel (#80 slice 8a);
-    // ActiveSet.SetState mirrors State.Stashes into the bound collection
-    // automatically on every snapshot change.
 
     /// <summary>
     /// Inspector-panel expand/collapse state (#80 slice 1).
@@ -1100,7 +980,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         IReadOnlyList<AutocompleteSuggestion> all;
         if (rule?.TagTableReference != null && _autocompleteProvider != null)
             all = _autocompleteProvider.GetSuggestions(memberVm.Model, "");
-        else if (_showConstants)
+        else if (Autocomplete.ShowConstants)
             all = _tagTableCache.GetTableNames()
                 .SelectMany(name => _tagTableCache.GetEntries(name))
                 .Select(e => new AutocompleteSuggestion(e.Value, e.Name, e.Comment))
@@ -1139,27 +1019,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
     /// <summary>Toggle: show filtered suggestions or hide them.</summary>
     public void ToggleAllSuggestions() => Autocomplete.Toggle(_newValue?.Trim() ?? "");
-
-    /// <summary>Whether to show constant suggestions. Forced on when a rule with tagTableReference matches.</summary>
-    public bool ShowConstants
-    {
-        get => _showConstants;
-        set
-        {
-            if (!_constantsForced || value) // Can't uncheck when forced
-            {
-                if (SetProperty(ref _showConstants, value))
-                    ReloadSuggestions();
-            }
-        }
-    }
-
-    /// <summary>True when a config rule forces constants on (checkbox disabled).</summary>
-    public bool ConstantsForced
-    {
-        get => _constantsForced;
-        private set => SetProperty(ref _constantsForced, value);
-    }
 
     /// <summary>Display string showing how old the tag table data is.</summary>
     public string TagTableAge
@@ -1319,13 +1178,15 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         if (hasRuleWithTagTable)
         {
-            ConstantsForced = true;
-            _showConstants = true; // Set backing field to avoid triggering ReloadSuggestions twice
-            OnPropertyChanged(nameof(ShowConstants));
+            Autocomplete.ConstantsForced = true;
+            // Silent setter avoids triggering ReloadSuggestions twice — the
+            // explicit call below covers the rule-forced flip. The setter
+            // still raises PropertyChanged for XAML.
+            Autocomplete.SetShowConstantsSilent(true);
         }
         else
         {
-            ConstantsForced = false;
+            Autocomplete.ConstantsForced = false;
             // Keep user's previous ShowConstants choice
         }
 
@@ -1945,14 +1806,15 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     }
 
     /// <summary>
-    /// Reloads suggestions for the currently selected member based on ShowConstants state.
+    /// Reloads suggestions for the currently selected member based on
+    /// <see cref="AutocompleteViewModel.ShowConstants"/> state.
     /// </summary>
     private void ReloadSuggestions()
     {
         Autocomplete.ClearCandidates();
 
         if (Selection.SelectedFlatMember == null || !Selection.SelectedFlatMember.IsLeaf) return;
-        if (!_showConstants) return;
+        if (!Autocomplete.ShowConstants) return;
 
         EnsureTagTableCache();
         if (_tagTableCache == null) return;


### PR DESCRIPTION
## Summary

Final slice of #80. Folds the remaining host-VM members that
naturally belong to `ActiveSet` / `Autocomplete`, sweeps the
slice-9a tombstone comments, and updates stale doc references —
closing out the 9-slice refactor that took the host VM from
4,931 LOC to **3,073 LOC** (−38%).

### What moved into `ActiveSetViewModel`

The four members the slice 9a review flagged as "natural follow-ons
that should fold as a unit":

- `Title` (auto-property with backing field) + private static `BuildTitle`
- `CurrentDataBlockName`
- `CurrentPlcName`
- `HasCurrentPlcName`

`ActiveSetViewModel.SetState` now recomputes `Title` and raises
PropertyChanged for all four when `Dbs` or `AnchorPlcName` changes.
Constructor seeds `_title` from the initial snapshot so the XAML
binding has a non-empty value before the first active-set
transition. Version reads via `typeof(ActiveSetViewModel).Assembly`
— same assembly as before, no behavior change.

Host's `HandleActiveSetStateChanged` loses its
`OnPropertyChanged(CurrentPlcName)` / `OnPropertyChanged(HasCurrentPlcName)`
re-raise calls (the slice raises them now) and the
`RefreshAnchorDisplay` invocation (the slice rebuilds the title in
`SetState`).

### What moved into `AutocompleteViewModel`

- `ShowConstants` (auto-property)
- `ConstantsForced` (auto-property)
- New `ShowConstantsChanged` event
- New `SetShowConstantsSilent(bool)` method — for the rule-forced
  visibility bypass at `OnMemberSelected` that needs to update the
  property without firing the event (otherwise `ReloadSuggestions`
  loops with itself)

Host's ctor subscribes `Autocomplete.ShowConstantsChanged +=
ReloadSuggestions`. The rule-forced path that previously wrote
`_showConstants = value;` directly to bypass the setter now calls
`Autocomplete.SetShowConstantsSilent(value)` + `ReloadSuggestions()`
explicitly — exactly one reload per rule application, identical to
pre-PR.

### Comment hygiene

Per the slice 9a review (P4):

- **Stale doc-comment references**: class-level summary and field
  comments that still described storage in terms of bare
  `State.Dbs` / `State.Stashes` / `State.AnchorPlcName` rewritten
  to `ActiveSet.State.X` (the host's `State` getter is gone since
  slice 9a).
- **Tombstone trim**: dropped eight `Slice 9a:` removal markers
  and four older `moved to ActiveSetViewModel` WHAT markers. Kept
  the WHY tombstones — the `HandleActiveSetStateChanged` docstring
  documents why the host *doesn't* re-raise certain notifications
  anymore.

### Rebinds

- **XAML** (3): `{Binding Title}` → `{Binding ActiveSet.Title}`,
  `{Binding ShowConstants}` → `{Binding Autocomplete.ShowConstants}`,
  `{Binding ConstantsForced}` → `{Binding Autocomplete.ConstantsForced}`.
- **Tests** (7 sites):
  - `BulkChangeViewModelInvariantTests.cs` — `vm.Title` (4), `vm.CurrentDataBlockName` (1)
  - `BulkChangeViewModelDbSwitcherTests.cs` — `vm.Title` (2), `vm.HasCurrentPlcName` + `vm.CurrentPlcName` (2)
  - `BulkChangeViewModelRegressionTests.cs` — `vm.ShowConstants` / `vm.ConstantsForced` (3)

### What's intentionally left

Per the slice 9b spec and previous slice scopes:

- `PendingInlineEditCount` delegator (6 internal host uses, gated
  on the broader `_pendingEditStore` cleanup that's slice 4's
  follow-up).
- The `Subscription.StateChanged → ApplyTooltip` forwarder
  (unrelated; composes Apply-pipeline state).
- The 17 `_pendingEditStore` direct mutations on the host (slice 4
  explicit follow-up; not #80 scope).
- The `_active` derived alias (private host shorthand; removal
  affects too many internal call sites for marginal benefit).

### Numbers

- **Host VM**: 3,207 → **3,073 LOC** (−134 this PR;
  **−1,858 cumulative from the 4,931-LOC pre-slice baseline**, −38%).
- **ActiveSetViewModel**: 1,159 → 1,226 LOC (+67).
- **AutocompleteViewModel**: 160 → 210 LOC (+50).

### Closes

Closes #80.

Follow-up issues (not blocking #80):

- The 17 `_pendingEditStore` direct mutation sites on the host —
  slice 4's documented follow-up.
- The `PendingInlineEditCount` delegator — folds away once the
  `_pendingEditStore` cleanup lands.

## Test plan

- [ ] CI `Build & Test (V20, net48)` green
- [ ] CI `Build (V21, net48)` green
- [ ] All existing host VM + slice tests pass; 7 rebound tests
      verify the new `ActiveSet.Title` / `ActiveSet.CurrentPlcName` /
      `Autocomplete.ShowConstants` access paths

https://claude.ai/code/session_0168J7dK7tApviBaDquX6gUd

---
_Generated by [Claude Code](https://claude.ai/code/session_0168J7dK7tApviBaDquX6gUd)_