### PR TITLE
test(#105): add cascade-seam regression tests + CLAUDE.md refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,15 +248,16 @@ folder) over enlarging the host:
 
 | Hotspot | Current LOC | Owning issue |
 |---|---:|---|
-| `UI/BulkChangeViewModel.cs` | 4,563 | #80 |
-| `AddIn/BulkChangeContextMenu.cs` | 981 | #81 |
-| `UI/BulkChangeDialog.xaml.cs` | 1,033 | (no issue yet) |
-| `Licensing/OnlineLicenseService.cs` | 565 | (no issue yet) |
+| `UI/BulkChangeViewModel.cs` | 3,073 | #80 closed (was 4,931 pre-split; composed of 9 slice VMs) |
+| `UI/BulkChangeDialog.xaml.cs` | 1,123 | #84 |
+| `Licensing/OnlineLicenseService.cs` | 595 | (no issue yet) |
 | `Services/TiaDataTypeValidator.cs` | 556 | (no issue yet) |
+| `AddIn/BulkChangeContextMenu.cs` | 384 | #81 (significantly reduced; check before deciding scope) |
 
-Adding 50 lines of new feature logic to a 4,500-line ViewModel is not
-"a small change" — it cements the god class. Add a sibling class, wire it
-from the constructor, and bind through it.
+Adding 50 lines of new feature logic to a 3,000-line ViewModel is not
+"a small change" — it re-cements what #80 just spent nine slices breaking
+apart. Add a sibling class, wire it from the constructor, and bind
+through it.
 
 ### DRY checklist before merging
 

--- a/src/BlockParam.Tests/BulkChangeViewModelDerivedBindingsTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelDerivedBindingsTests.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using BlockParam.Config;
+using BlockParam.Licensing;
+using BlockParam.Localization;
+using BlockParam.Models;
+using BlockParam.Services;
+using BlockParam.SimaticML;
+using BlockParam.UI;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Regression tests for the cascade seams that PR #104's review caught
+/// (#105). Each test locks in a guarantee that the existing unit-test
+/// surface missed in slices 1–5:
+///
+/// <list type="number">
+///   <item><c>RebuildAfterActiveSetChanged_RefreshesBulkPreviewBindings</c>
+///     — after any active-set transition, the bulk-preview slice's
+///     derived bindings (HasEntries, Count, Summary, ConflictCount,
+///     HasConflict, ConflictWarning) must refresh, not just Entries.
+///     Without this, the inspector header badge / summary line keeps
+///     the pre-clear state until the next unrelated PropertyChanged
+///     sweep.</item>
+///   <item><c>ExecuteApplyMultiDb_PartialCommit_RefreshesPendingDisplay</c>
+///     — when the second DB's import cancels after the first DB's
+///     succeeded, the host must clear pending edits on the committed DB
+///     and re-raise PendingInlineEditCount / PendingStatusText so the
+///     bound count + tooltip don't stay showing the pre-commit total.</item>
+///   <item><c>Derived_StringProperties_RouteThroughResX</c> — pending
+///     status text and conflict warnings must compose from
+///     <see cref="Res"/> resource keys, not inline English. Catches the
+///     "slice author copy-pasted a one-line getter and forgot the Res
+///     hop" regression class.</item>
+/// </list>
+/// </summary>
+public class BulkChangeViewModelDerivedBindingsTests
+{
+    // ----- 1. RebuildAfterActiveSetChanged refreshes BulkPreview bindings -----
+
+    [Fact]
+    public void RebuildAfterActiveSetChanged_RefreshesBulkPreviewBindings()
+    {
+        var (vm, _, _, _, _) = CreateMultiDbVm();
+
+        // Seed bulk-preview entries directly. Production paths route through
+        // ComputeBulkPreview (host-side, gated on scope/manual-mode), but
+        // that's outside this test's scope — what we're locking in is that
+        // the cascade's Clear+RaiseDerivedChanged pair fires after an
+        // active-set change, regardless of how the entries got there.
+        var anchor = vm.Tree.RootMembers.First(r => r.Datatype == "DB" && r.Name == "FlatDB");
+        var leaves = anchor.AllDescendants().Where(n => n.IsLeaf).Take(2).ToList();
+        vm.BulkPreview.Add(new BulkPreviewEntry(leaves[0], "0", "1", hasPendingConflict: false));
+        vm.BulkPreview.Add(new BulkPreviewEntry(leaves[1], "0", "1", hasPendingConflict: true));
+        vm.BulkPreview.RaiseDerivedChanged();
+        vm.BulkPreview.Entries.Should().HaveCount(2);
+
+        var changed = new List<string?>();
+        vm.BulkPreview.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        // Trigger an active-set transition that funnels through
+        // RebuildAfterActiveSetChanged. Solo onto the anchor (no pending
+        // edits anywhere → no prompt) → clean cascade test.
+        vm.ActiveSet.SoloActiveDbByReference(vm.AllActiveDbs[0]);
+
+        vm.BulkPreview.Entries.Should().BeEmpty("cascade cleared the preview");
+        changed.Should().Contain(nameof(BulkPreviewViewModel.HasEntries));
+        changed.Should().Contain(nameof(BulkPreviewViewModel.Count));
+        changed.Should().Contain(nameof(BulkPreviewViewModel.Summary));
+        changed.Should().Contain(nameof(BulkPreviewViewModel.ConflictCount));
+        changed.Should().Contain(nameof(BulkPreviewViewModel.HasConflict));
+        changed.Should().Contain(nameof(BulkPreviewViewModel.ConflictWarning));
+    }
+
+    // ----- 2. Partial-commit refreshes pending display -----
+
+    [Fact]
+    public void ExecuteApplyMultiDb_PartialCommit_RefreshesPendingDisplay()
+    {
+        // The "committed DB clears, cancelled DB retains its edits" half of
+        // the contract is what production needs. The 8-line cascade fix from
+        // PR #104 commit c15ab21 added RefreshPendingAndPreview at the early
+        // return; this test fails if that call disappears in a future edit.
+        var anchorXml = TestFixtures.LoadXml("flat-db.xml");
+        var peerXml = TestFixtures.LoadXml("nested-struct-db.xml");
+        var parser = new SimaticMLParser();
+        var anchorInfo = parser.Parse(anchorXml);
+        var peerInfo = parser.Parse(peerXml);
+
+        var configLoader = new ConfigLoader(null);
+        var bulkService = new BulkChangeService(new ChangeLogger(), configLoader);
+        var tracker = Substitute.For<IUsageTracker>();
+        tracker.GetStatus().Returns(new UsageStatus(0, 100));
+        tracker.RecordUsage(Arg.Any<int>()).Returns(true);
+
+        // Peer's OnApply throws OperationCanceledException → simulates the
+        // user dismissing the second DB's TIA import dialog. Anchor's
+        // OnApply records that it succeeded.
+        var anchorApplied = false;
+        var peerDb = new ActiveDb(peerInfo, peerXml,
+            onApply: _ => throw new OperationCanceledException("simulated user cancel"));
+
+        var vm = new BulkChangeViewModel(
+            anchorInfo, anchorXml,
+            new HierarchyAnalyzer(), bulkService, tracker, configLoader,
+            onApply: _ => anchorApplied = true,
+            additionalActiveDbs: new[] { peerDb });
+
+        // Stage one inline edit in each DB through the production
+        // EditableStartValue path so PendingEdits picks them up.
+        var anchorRoot = vm.Tree.RootMembers.First(r => r.Datatype == "DB" && r.Name == anchorInfo.Name);
+        var peerRoot = vm.Tree.RootMembers.First(r => r.Datatype == "DB" && r.Name == peerInfo.Name);
+        var anchorLeaf = anchorRoot.AllDescendants().First(n => n.IsLeaf && !string.IsNullOrEmpty(n.StartValue));
+        var peerLeaf = peerRoot.AllDescendants().First(n => n.IsLeaf && !string.IsNullOrEmpty(n.StartValue));
+        anchorLeaf.EditableStartValue = anchorLeaf.StartValue == "0" ? "1" : "0";
+        peerLeaf.EditableStartValue = peerLeaf.StartValue == "0" ? "1" : "0";
+
+        vm.Pending.PendingInlineEditCount.Should().Be(2, "setup: 1 edit per DB staged");
+
+        var pendingNotifications = new List<string?>();
+        ((INotifyPropertyChanged)vm.Pending).PropertyChanged
+            += (_, e) => pendingNotifications.Add(e.PropertyName);
+
+        // ApplyCommand → ExecuteApply → ExecuteApplyMultiDb → anchor commits,
+        // peer throws → partial-commit branch clears anchor's pending state
+        // and calls RefreshPendingAndPreview.
+        vm.ApplyCommand.Execute(null);
+
+        anchorApplied.Should().BeTrue("anchor's OnApply ran before the peer threw");
+        vm.Pending.PendingInlineEditCount.Should().Be(1,
+            "anchor's edit got cleared by ClearPendingValuesForDb; peer's survived the cancel");
+        pendingNotifications.Should().Contain(nameof(PendingEditsViewModel.PendingInlineEditCount),
+            "the binding cannot repaint without this notification");
+        pendingNotifications.Should().Contain(nameof(PendingEditsViewModel.PendingStatusText),
+            "status text is derived from the count");
+    }
+
+    // ----- 3. Derived string properties route through Res.X -----
+
+    [Fact]
+    public void PendingStatusText_RouteThroughResX_Plural()
+    {
+        // Catches the "slice author wrote `=> $\"{Count} pending\"` instead
+        // of going through Res" regression class. Test asserts byte-equality
+        // against the Res key's formatted output — any inline-English fork
+        // would diverge from a localized build.
+        var (vm, _, _, _, _) = CreateMultiDbVm();
+        StageEdits(vm, "FlatDB", count: 2);
+
+        vm.Pending.PendingInlineEditCount.Should().Be(2);
+        vm.Pending.PendingStatusText.Should().Be(Res.Format("Pending_StatusText_Plural", 2),
+            "PendingStatusText must compose via the Res key, not inline strings");
+    }
+
+    [Fact]
+    public void PendingStatusText_RouteThroughResX_Singular()
+    {
+        var (vm, _, _, _, _) = CreateMultiDbVm();
+        StageEdits(vm, "FlatDB", count: 1);
+
+        vm.Pending.PendingInlineEditCount.Should().Be(1);
+        vm.Pending.PendingStatusText.Should().Be(Res.Format("Pending_StatusText_Singular", 1));
+    }
+
+    [Fact]
+    public void BulkPreviewConflictWarning_RouteThroughResX()
+    {
+        // Same regression-class as PendingStatusText. Conflict-overlap count
+        // is computed from Entries; staging entries directly is the focused
+        // path — production's ComputeBulkPreview is exercised by other tests.
+        var (vm, _, _, _, _) = CreateMultiDbVm();
+        var roots = vm.Tree.RootMembers.First(r => r.Datatype == "DB");
+        var leaves = roots.AllDescendants().Where(n => n.IsLeaf).Take(3).ToList();
+        vm.BulkPreview.Add(new BulkPreviewEntry(leaves[0], "0", "1", hasPendingConflict: true));
+        vm.BulkPreview.Add(new BulkPreviewEntry(leaves[1], "0", "1", hasPendingConflict: true));
+        vm.BulkPreview.Add(new BulkPreviewEntry(leaves[2], "0", "1", hasPendingConflict: false));
+
+        vm.BulkPreview.ConflictCount.Should().Be(2);
+        vm.BulkPreview.ConflictWarning.Should().Be(Res.Format("BulkPreview_ConflictWarning_Plural", 2),
+            "ConflictWarning must compose via the Res key");
+    }
+
+    [Fact]
+    public void BulkPreviewConflictWarning_RouteThroughResX_Singular()
+    {
+        var (vm, _, _, _, _) = CreateMultiDbVm();
+        var roots = vm.Tree.RootMembers.First(r => r.Datatype == "DB");
+        var leaf = roots.AllDescendants().First(n => n.IsLeaf);
+        vm.BulkPreview.Add(new BulkPreviewEntry(leaf, "0", "1", hasPendingConflict: true));
+
+        vm.BulkPreview.ConflictCount.Should().Be(1);
+        vm.BulkPreview.ConflictWarning.Should().Be(Res.Get("BulkPreview_ConflictWarning_Singular"));
+    }
+
+    [Fact]
+    public void BulkPreviewConflictWarning_EmptyWhenNoConflicts()
+    {
+        var (vm, _, _, _, _) = CreateMultiDbVm();
+        var roots = vm.Tree.RootMembers.First(r => r.Datatype == "DB");
+        var leaf = roots.AllDescendants().First(n => n.IsLeaf);
+        vm.BulkPreview.Add(new BulkPreviewEntry(leaf, "0", "1", hasPendingConflict: false));
+
+        vm.BulkPreview.ConflictCount.Should().Be(0);
+        vm.BulkPreview.ConflictWarning.Should().BeEmpty(
+            "no conflicts → no warning string, regardless of how many entries are staged");
+    }
+
+    // ----- helpers -----
+
+    private static (BulkChangeViewModel vm, IUsageTracker tracker,
+                    string anchorXml, string peerXml,
+                    List<string> applyOrder)
+        CreateMultiDbVm()
+    {
+        var anchorXml = TestFixtures.LoadXml("flat-db.xml");
+        var peerXml = TestFixtures.LoadXml("nested-struct-db.xml");
+        var parser = new SimaticMLParser();
+        var anchor = parser.Parse(anchorXml);
+        var peer = parser.Parse(peerXml);
+
+        var configLoader = new ConfigLoader(null);
+        var bulkService = new BulkChangeService(new ChangeLogger(), configLoader);
+        var tracker = Substitute.For<IUsageTracker>();
+        tracker.GetStatus().Returns(new UsageStatus(0, 100));
+        tracker.RecordUsage(Arg.Any<int>()).Returns(true);
+
+        var applyOrder = new List<string>();
+        var peerDb = new ActiveDb(peer, peerXml,
+            onApply: _ => applyOrder.Add(peer.Name));
+
+        var vm = new BulkChangeViewModel(
+            anchor, anchorXml,
+            new HierarchyAnalyzer(), bulkService, tracker, configLoader,
+            onApply: _ => applyOrder.Add(anchor.Name),
+            additionalActiveDbs: new[] { peerDb });
+
+        return (vm, tracker, anchorXml, peerXml, applyOrder);
+    }
+
+    private static void StageEdits(BulkChangeViewModel vm, string dbName, int count)
+    {
+        var root = vm.Tree.RootMembers.First(r => r.Datatype == "DB" && r.Name == dbName);
+        var leaves = root.AllDescendants()
+            .Where(n => n.IsLeaf && !string.IsNullOrEmpty(n.StartValue))
+            .Take(count)
+            .ToList();
+        if (leaves.Count < count)
+            throw new InvalidOperationException(
+                $"DB '{dbName}' has only {leaves.Count} primitive leaves with start values, requested {count}");
+        foreach (var leaf in leaves)
+            leaf.EditableStartValue = leaf.StartValue == "0" ? "1" : "0";
+    }
+}


### PR DESCRIPTION
## Summary

Post-#80 housekeeping. Two concerns bundled in one small PR because
both are pure follow-up to the slice refactor.

### 1. Regression tests for the cascade seams (#105)

#105 carved out the test gap that PR #104's sonnet code-review pass
surfaced — three real bugs that the existing test suite didn't
flag:

- `RebuildAfterActiveSetChanged` cleared `BulkPreview` but didn't
  call `RaiseDerivedChanged()`, so the inspector header badge /
  summary line stayed stale until the next unrelated
  PropertyChanged sweep.
- `ExecuteApplyMultiDb`'s partial-commit branch cleared pending
  values per committed DB but returned without
  `RefreshPendingAndPreview()`, leaving the pending list / count /
  `ApplyTooltip` stale.
- Inline English strings carried over verbatim from the host VM
  into `PendingStatusText` and `BulkPreview.ConflictWarning`
  (caught by review against the CLAUDE.md guardrail, not by tests).

Each was fixed in #104 commit `c15ab21` — but none had a regression
net. The seams they touch are the same ones #80 slices 6-8b kept
rebuilding, so a regression here could ship undetected.

New file
`src/BlockParam.Tests/BulkChangeViewModelDerivedBindingsTests.cs`
with **seven `[Fact]`s**:

| Test | What it locks in |
|---|---|
| `RebuildAfterActiveSetChanged_RefreshesBulkPreviewBindings` | All 6 derived `PropertyChanged` names (`HasEntries`/`Count`/`Summary`/`ConflictCount`/`HasConflict`/`ConflictWarning`) fire on the slice after an active-set transition. |
| `ExecuteApplyMultiDb_PartialCommit_RefreshesPendingDisplay` | 2-DB VM with peer's `OnApply` throwing `OperationCanceledException`. After `ApplyCommand.Execute`, `Pending.PendingInlineEditCount` drops to the peer's edit count (anchor cleared) AND `PropertyChanged` fired for `PendingInlineEditCount` + `PendingStatusText`. |
| `PendingStatusText_RouteThroughResX_{Plural,Singular}` | Byte-equality against `Res.Format("Pending_StatusText_Plural", n)` / `_Singular`. Inline English forks fail at PR build, not in a localized release. |
| `BulkPreviewConflictWarning_RouteThroughResX{,_Singular,_EmptyWhenNoConflicts}` | Same regression class against `BulkPreview_ConflictWarning_*` keys. Empty case: no entries with `HasPendingConflict=true` → empty string, regardless of total entry count. |

The "guardrail-as-test" framing (#105's term) means future slice
authors who copy-paste a one-line getter and forget the `Res` hop
get caught at PR build time instead of relying on review.

### 2. CLAUDE.md hotspots table refresh

Post-#80 the table was stale:

- `UI/BulkChangeViewModel.cs`: 4,563 → **3,073** LOC; owning issue
  #80 closed.
- `AddIn/BulkChangeContextMenu.cs`: 981 → **384** (significantly
  reduced by some separate refactor outside #80's scope; #81 still
  owns the class but the scope description should be re-read before
  taking it on).
- `UI/BulkChangeDialog.xaml.cs`: 1,033 → **1,123** (slice 7b moved
  selection orchestration into the code-behind, per its narrow-cut
  decision; #84 still owns it).
- `Licensing/OnlineLicenseService.cs`: 565 → **595**.
- `Services/TiaDataTypeValidator.cs`: 556 unchanged.

Reordered by current LOC descending. Prose updated: "Adding 50 lines
of new feature logic to a 4,500-line ViewModel" → "to a 3,000-line
ViewModel" + "re-cements what #80 just spent nine slices breaking
apart."

### Closes

Closes #105.

(#84, #81 remain open for their respective targets; #80 was already
closed by #114.)

## Test plan

- [ ] CI `Build & Test (V20, net48)` green — includes 7 new
      `[Fact]`s
- [ ] CI `Build (V21, net48)` green
- [ ] Manual confirmation that the `PendingStatusText` /
      `ConflictWarning` Res keys exist with the expected
      `{0}`-formatted singular and plural variants (already
      verified by grep against `Strings.resx`)

https://claude.ai/code/session_0168J7dK7tApviBaDquX6gUd

---
_Generated by [Claude Code](https://claude.ai/code/session_0168J7dK7tApviBaDquX6gUd)_