### PR TITLE
refactor(#82): make member identity (ActiveDb, MemberNode)-keyed

### DIFF
--- a/src/BlockParam.Tests/BulkChangeViewModelMultiDbTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelMultiDbTests.cs
@@ -823,6 +823,192 @@ public class BulkChangeViewModelMultiDbTests
         restoredLeaf.PendingValue.Should().Be(pending);
     }
 
+    // ── #82 path-identity tests ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Helper: builds two distinct <see cref="ActiveDb"/> instances that
+    /// share the same member <c>Path</c> strings. Used to exercise the
+    /// cross-DB path-collision scenario (#82) without having to fabricate
+    /// custom XML fixtures.
+    /// </summary>
+    private static (DataBlockInfo a, DataBlockInfo b, MemberNode speedA, MemberNode speedB)
+        BuildTwoDbsWithSamePaths()
+    {
+        var speedA = new MemberNode("Speed", "Int", "111", "Speed", null,
+            Array.Empty<MemberNode>());
+        var tempA = new MemberNode("Temperature", "Int", "21", "Temperature", null,
+            Array.Empty<MemberNode>());
+        var infoA = new DataBlockInfo(
+            "DB_Recipe_A", 1, "Optimized", "GlobalDB", new[] { speedA, tempA });
+
+        var speedB = new MemberNode("Speed", "Int", "222", "Speed", null,
+            Array.Empty<MemberNode>());
+        var tempB = new MemberNode("Temperature", "Int", "42", "Temperature", null,
+            Array.Empty<MemberNode>());
+        var infoB = new DataBlockInfo(
+            "DB_Recipe_B", 2, "Optimized", "GlobalDB", new[] { speedB, tempB });
+
+        return (infoA, infoB, speedA, speedB);
+    }
+
+    [Fact]
+    public void StashRestoration_TwoDbsSharePath_RestoresOntoCorrectDb()
+    {
+        // #82 — In multi-DB mode two ActiveDbs can share a member Path
+        // string verbatim (typical when both reference the same UDT, but
+        // also happens for any same-named scalar). Stash entries persist
+        // only the bare Path (no "DbName.MemberPath" prefix), so restore
+        // must resolve against the OWNING ActiveDb — not first-match
+        // across roots. Before the fix the restore would silently land
+        // on whichever DB sits at RootMembers[0].
+        var (infoA, infoB, _, _) = BuildTwoDbsWithSamePaths();
+
+        var configLoader = new ConfigLoader(null);
+        var bulkService = new BulkChangeService(new ChangeLogger(), configLoader);
+        var tracker = Substitute.For<IUsageTracker>();
+        tracker.GetStatus().Returns(new UsageStatus(0, 100));
+        tracker.RecordUsage(Arg.Any<int>()).Returns(true);
+
+        var mbx = new FakeMessageBox(YesNoCancelResult.No); // Keep on remove
+        var peer = new ActiveDb(infoB, "<Block name='DB_Recipe_B' />", onApply: _ => { });
+
+        // currentPlcName left empty: both DBs share PlcName "" — the path
+        // collision is what we're testing, not the PLC dimension.
+        var vm = new BulkChangeViewModel(
+            infoA, "<Block name='DB_Recipe_A' />",
+            new HierarchyAnalyzer(), bulkService, tracker, configLoader,
+            onApply: _ => { },
+            messageBox: mbx,
+            additionalActiveDbs: new[] { peer },
+            // Reactivation needs the factory so it can rebuild the stashed
+            // peer when the user reactivates from the inspector.
+            buildActiveDbForSummary: s => s.Name == infoB.Name
+                ? new ActiveDb(infoB, "<Block name='DB_Recipe_B' />", onApply: _ => { })
+                : null);
+
+        vm.AllActiveDbs.Should().HaveCount(2);
+
+        // Stage an inline edit on PEER's Speed (path "Speed", same string
+        // as anchor's Speed). The anchor's Speed must NOT receive this
+        // edit when we later restore the stash.
+        var peerSpeedVm = vm.Tree.RootMembers
+            .First(r => r.Name == infoB.Name)
+            .AllDescendants().First(n => n.Name == "Speed" && n.IsLeaf);
+        peerSpeedVm.EditableStartValue = "999";
+
+        // Remove peer → Keep (stash). Anchor stays active.
+        var peerRef = vm.AllActiveDbs.First(d => d.Info.Name == infoB.Name);
+        vm.ActiveSet.RequestRemoveActiveDb(peerRef);
+
+        vm.AllActiveDbs.Should().HaveCount(1);
+        vm.AllActiveDbs[0].Info.Name.Should().Be(infoA.Name);
+        vm.ActiveSet.StashedDbs.Should().ContainSingle(s => s.DbName == infoB.Name);
+
+        // Pre-condition: the anchor's Speed is untouched (its StartValue
+        // is 111, no pending edit applied). After the peer was removed the
+        // active set is single-DB, so RootMembers is flat — Speed is right
+        // at the top level.
+        var anchorSpeedVmBeforeReactivate = vm.Tree.RootMembers
+            .First(r => r.IsLeaf && r.Name == "Speed");
+        anchorSpeedVmBeforeReactivate.PendingValue.Should().BeNull(
+            "anchor's Speed must NOT carry the peer's pending edit before reactivation");
+
+        // Reactivate peer → Replace path (mbx returns No for AddOrReplace).
+        // This is the solo-reactivate path: peer becomes the only active DB,
+        // anchor is dropped. The restore must target the (now-only) peer's
+        // Speed, not the (already-gone) anchor's.
+        var stash = vm.ActiveSet.StashedDbs[0];
+        vm.ActiveSet.SwitchToStashedDbCommand.Execute(stash);
+
+        vm.AllActiveDbs.Should().HaveCount(1, "Replace path soloed to peer");
+        vm.AllActiveDbs[0].Info.Name.Should().Be(infoB.Name);
+
+        // The restored leaf must be the peer's Speed — same Path string,
+        // distinct model reference. Without the #82 fix this would be
+        // dropped or aliased.
+        var restoredLeaf = vm.Tree.RootMembers
+            .SelectMany(r => new[] { r }.Concat(r.AllDescendants()))
+            .First(n => n.IsLeaf && n.Name == "Speed");
+        restoredLeaf.PendingValue.Should().Be("999",
+            "stash restore must land on the peer's Speed, the DB the edit " +
+            "was made on — first-match across roots would silently route " +
+            "to the wrong DB when both share a Path");
+    }
+
+    [Fact]
+    public void CrossDbScopeRouting_PathCollision_EachDbStagesItsOwnNode()
+    {
+        // #82 — A bulk scope spans every active DB whose tree contains
+        // matching paths. When two DBs share a member Path, the scope's
+        // MatchingMembers carries two distinct MemberNode references
+        // (one per DB). Set Pending must stage exactly the per-DB VM each
+        // model maps to — not the first-match across roots.
+        var (infoA, infoB, _, _) = BuildTwoDbsWithSamePaths();
+
+        var configLoader = new ConfigLoader(null);
+        var bulkService = new BulkChangeService(new ChangeLogger(), configLoader);
+        var tracker = Substitute.For<IUsageTracker>();
+        tracker.GetStatus().Returns(new UsageStatus(0, 100));
+        tracker.RecordUsage(Arg.Any<int>()).Returns(true);
+
+        var peer = new ActiveDb(infoB, "<Block name='DB_Recipe_B' />", onApply: _ => { });
+
+        var vm = new BulkChangeViewModel(
+            infoA, "<Block name='DB_Recipe_A' />",
+            new HierarchyAnalyzer(), bulkService, tracker, configLoader,
+            onApply: _ => { },
+            additionalActiveDbs: new[] { peer });
+
+        vm.AllActiveDbs.Should().HaveCount(2);
+
+        // Find each DB's Speed VM. AllDescendants() crosses the synthetic
+        // root, so we filter by the synthetic root's Name (the DB's name).
+        var anchorRoot = vm.Tree.RootMembers.First(r => r.Name == infoA.Name);
+        var peerRoot = vm.Tree.RootMembers.First(r => r.Name == infoB.Name);
+        var anchorSpeedVm = anchorRoot.AllDescendants()
+            .First(n => n.IsLeaf && n.Name == "Speed");
+        var peerSpeedVm = peerRoot.AllDescendants()
+            .First(n => n.IsLeaf && n.Name == "Speed");
+
+        // Sanity: distinct model refs, identical Path string.
+        anchorSpeedVm.Should().NotBeSameAs(peerSpeedVm);
+        anchorSpeedVm.Path.Should().Be(peerSpeedVm.Path);
+
+        // Make sure both Speed leaves are visible in the flat list (the
+        // synthetic group roots start expanded in multi-DB mode, but
+        // RefreshFlatList wires the projection).
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
+        vm.RefreshFlatList();
+
+        // Select anchor's Speed → SelectedScope automatically extends to
+        // every active DB whose tree contains a matching path (cross-DB
+        // lift). Bulk-stage value "777".
+        vm.Selection.SelectedFlatMember = anchorSpeedVm;
+        // Pick the broadest scope — the cross-DB lift produces a scope
+        // whose MatchingMembers spans every active DB with the path.
+        var scope = vm.Selection.AvailableScopes
+            .OrderByDescending(s => s.MatchCount)
+            .FirstOrDefault();
+        scope.Should().NotBeNull("cross-DB selection must produce at least one scope");
+        vm.Selection.SelectedScope = scope;
+        vm.NewValue = "777";
+
+        // Sanity: the scope picked up Speed in BOTH DBs.
+        vm.Selection.SelectedScope!.MatchingMembers.Should().HaveCountGreaterOrEqualTo(2,
+            "cross-DB scope must include the Speed model from each active DB");
+
+        vm.SetPendingCommand.Execute(null);
+
+        // Per #82: each DB's Speed VM must carry the staged value via its
+        // own MemberNode reference. A first-match-by-path bug would stage
+        // on anchor's Speed twice and leave peer's untouched.
+        anchorSpeedVm.PendingValue.Should().Be("777",
+            "anchor's Speed (model A) must be staged");
+        peerSpeedVm.PendingValue.Should().Be("777",
+            "peer's Speed (model B) must be staged — first-match across " +
+            "roots would silently miss this and stage on anchor's Speed twice");
+    }
+
     // ── Pill-row tests (#pill-refactor) ──────────────────────────────────────
 
     [Fact]

--- a/src/BlockParam.Tests/MemberTreeViewModelTests.cs
+++ b/src/BlockParam.Tests/MemberTreeViewModelTests.cs
@@ -293,17 +293,20 @@ public class MemberTreeViewModelTests
     }
 
     [Fact]
-    public void FindNodeByPath_LocatesByPathString()
+    public void FindNodeByPathInDb_SingleDb_LocatesByPathString()
     {
+        // Single-DB shape (no synthetic root): the in-db lookup still
+        // works because the slice falls back to walking RootMembers when
+        // owner is the sole active DB (#82).
         var (db, _, _) = MakeFlatDb("DB_F");
         var vm = Build(activeDbs: new[] { db });
         vm.BuildRootMembersFromActiveDbs();
 
-        var found = vm.FindNodeByPath("Speed");
+        var found = vm.FindNodeByPathInDb("Speed", db);
         found.Should().NotBeNull();
         found!.Name.Should().Be("Speed");
 
-        vm.FindNodeByPath("DoesNotExist").Should().BeNull();
+        vm.FindNodeByPathInDb("DoesNotExist", db).Should().BeNull();
     }
 
     [Fact]
@@ -324,6 +327,22 @@ public class MemberTreeViewModelTests
         vm.FindActiveDbForModel(foundInB!.Model).Should().BeSameAs(dbB);
         foundInB.Should().NotBeSameAs(foundInA,
             "same path string in two DBs must resolve to distinct VMs");
+    }
+
+    [Fact]
+    public void FindNodeByPathInDb_NotInActiveSet_ReturnsNull()
+    {
+        // The single-DB fallback only resolves when owner IS the sole
+        // active DB. An owner from a different fixture must NOT silently
+        // fall through to the first root in RootMembers (#82).
+        var (dbA, _, _) = MakeFlatDb("DB_A");
+        var (dbStranger, _, _) = MakeFlatDb("DB_Stranger");
+        var vm = Build(activeDbs: new[] { dbA });
+        vm.BuildRootMembersFromActiveDbs();
+
+        vm.FindNodeByPathInDb("Speed", dbStranger).Should().BeNull(
+            "stranger DB is not in the active set — fall-through would " +
+            "be exactly the cross-DB aliasing the in-db variant exists to prevent");
     }
 
     [Fact]

--- a/src/BlockParam/Services/PlcPillGroupsService.cs
+++ b/src/BlockParam/Services/PlcPillGroupsService.cs
@@ -52,9 +52,13 @@ public static class PlcPillGroupsService
         for (int i = 0; i < activeDbs.Count; i++)
         {
             var db = activeDbs[i];
-            // Index 0 reads PLC name from anchorPlcName (the host signals
-            // the anchor's PLC explicitly; for non-anchor DBs use db.PlcName).
-            var plc = (i == 0 ? anchorPlcName : db.PlcName) ?? "";
+            // #82: every ActiveDb (anchor included) carries its own PlcName,
+            // so the grouping key is uniform. anchorPlcName stays as a
+            // back-compat fallback for legacy hosts that may still seed the
+            // anchor with an empty PlcName.
+            var plc = !string.IsNullOrEmpty(db.PlcName)
+                ? db.PlcName
+                : (i == 0 ? (anchorPlcName ?? "") : "");
             // DataBlockInfo.Number is int (never null for a parsed block).
             var item = new DataBlockListItem(
                 new DataBlockSummary(

--- a/src/BlockParam/UI/ActiveSetViewModel.cs
+++ b/src/BlockParam/UI/ActiveSetViewModel.cs
@@ -435,14 +435,14 @@ public sealed class ActiveSetViewModel : ViewModelBase
     {
         // Match on (Name, PlcName) — multi-PLC projects can host two DBs
         // with the same name on different PLCs (#58 review must-fix #4).
-        // For index 0 the PLC name comes from State.AnchorPlcName (display
-        // state); for the rest we read each ActiveDb.PlcName directly.
+        // Every ActiveDb (including index 0) carries its own PlcName now,
+        // so identity matching is uniform across the set (#82). Anchor is
+        // still position-based — that's display state, not identity.
         for (int i = 0; i < _state.Dbs.Count; i++)
         {
             var db = _state.Dbs[i];
-            var plc = i == 0 ? _state.AnchorPlcName : db.PlcName;
             if (string.Equals(db.Info.Name, summary.Name, StringComparison.Ordinal)
-                && string.Equals(plc, summary.PlcName, StringComparison.Ordinal))
+                && string.Equals(db.PlcName, summary.PlcName, StringComparison.Ordinal))
                 return (true, i == 0);
         }
         return (false, false);
@@ -670,10 +670,13 @@ public sealed class ActiveSetViewModel : ViewModelBase
     private IReadOnlyList<DataBlockListItem> GetActiveItemsForPlc(PlcPillViewModel pill)
     {
         var result = new List<DataBlockListItem>();
+        // Identity is by ActiveDb.PlcName uniformly across indices (#82) —
+        // the anchor is no longer special. isAnchor stays position-based:
+        // it's display state, not identity.
         for (int i = 0; i < _state.Dbs.Count; i++)
         {
             var db = _state.Dbs[i];
-            var plc = (i == 0 ? _state.AnchorPlcName : db.PlcName) ?? "";
+            var plc = db.PlcName ?? "";
             if (!string.Equals(plc, pill.PlcName, StringComparison.Ordinal)) continue;
             result.Add(new DataBlockListItem(
                 new DataBlockSummary(db.Info.Name, "", plcName: plc, number: db.Info.Number),
@@ -934,9 +937,15 @@ public sealed class ActiveSetViewModel : ViewModelBase
         // State assignment so the cascade has already rebuilt RootMembers
         // — otherwise the new PendingValue assignments would land on VMs
         // the rebuild is about to discard.
+        //
+        // Pass `target` as the owner so the restore resolves paths within
+        // its subtree only (#82). After ComposeRemoveOthers the active set
+        // is usually solo'd to `target`, but a partial cancel can leave
+        // peers — without scoping, a stashed edit would silently land on
+        // whichever DB happens to share the path string first.
         if (_restoreStashOntoLive != null)
         {
-            var (restored, dropped) = _restoreStashOntoLive(stash, null);
+            var (restored, dropped) = _restoreStashOntoLive(stash, target);
             if (restored > 0 || dropped > 0)
             {
                 _setStatus?.Invoke(dropped == 0
@@ -1028,18 +1037,16 @@ public sealed class ActiveSetViewModel : ViewModelBase
     /// <summary>
     /// Looks up an active DB by (Name, PlcName) so dropdown rows resolve to
     /// the right ActiveDb instance even in multi-PLC projects where two
-    /// PLCs share a DB name (#58 review must-fix #4).
+    /// PLCs share a DB name (#58 review must-fix #4). Every ActiveDb —
+    /// including index 0 — now carries its own PlcName (#82), so identity
+    /// resolution no longer special-cases the anchor.
     /// </summary>
     private ActiveDb? FindActiveDb(DataBlockSummary summary)
     {
-        for (int i = 0; i < _state.Dbs.Count; i++)
+        foreach (var db in _state.Dbs)
         {
-            var db = _state.Dbs[i];
-            // Index 0 reads its display PLC from State.AnchorPlcName; the
-            // rest read it from each ActiveDb directly.
-            var plc = i == 0 ? _state.AnchorPlcName : db.PlcName;
             if (string.Equals(db.Info.Name, summary.Name, StringComparison.Ordinal)
-                && string.Equals(plc, summary.PlcName, StringComparison.Ordinal))
+                && string.Equals(db.PlcName, summary.PlcName, StringComparison.Ordinal))
                 return db;
         }
         return null;
@@ -1121,12 +1128,15 @@ public sealed class ActiveSetViewModel : ViewModelBase
             entries.Add(new StashedEditEntry(node.Path, startValue, pendingValue));
         }
         if (entries.Count == 0) return null;
+        // #82: stash the captured DB under its own PlcName, not the anchor's
+        // — a peer DB on a different PLC must match its own dropdown summary
+        // when reactivated, otherwise the stash key won't line up.
         var summary = new DataBlockSummary(
             db.Info.Name,
             "",
             blockType: db.Info.BlockType,
             isInstanceDb: string.Equals(db.Info.BlockType, "InstanceDB", StringComparison.Ordinal),
-            plcName: _state.AnchorPlcName);
+            plcName: db.PlcName ?? "");
         return new StashedDbState(summary, entries);
     }
 

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -117,7 +117,10 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     // SelectionScopeViewModel slice (#80 slice 7b). Host accesses via
     // Selection.SelectedFlatMember / SelectedScope / ManualSelectedPaths.
     private string _newValue = "";
-    private readonly HashSet<string> _bulkErrorPaths = new(StringComparer.Ordinal);
+    // VM references — not path strings — because the same Path can exist in
+    // multiple active DBs and ClearBulkRowHighlights must target the exact
+    // node that was painted, not the first-match across roots (#82).
+    private readonly HashSet<MemberNodeViewModel> _bulkErrorNodes = new();
     // True once the user has typed in the NewValue textbox. Prefills from the
     // current selection are skipped while this is true, so user-entered input
     // isn't clobbered by selection changes.
@@ -197,7 +200,16 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // are wired through callbacks so the slice never reaches into
         // _writer / Tree / Subscription. The host subscribes to
         // StateChanged to drive the cross-slice cascade.
-        var initialDbs = new List<ActiveDb> { new ActiveDb(dataBlockInfo, currentXml, onApply) };
+        // Seed the anchor's PlcName from currentPlcName so index-0's identity
+        // (Name, PlcName) matches every other ActiveDb in the set (#82). Before
+        // this, the anchor was constructed with PlcName="" while AnchorPlcName
+        // held the real PLC, forcing every identity check to special-case
+        // index 0. Aligning them lets FindActiveDb / SyncSelectedDbs drop the
+        // fallback and treat index 0 like any peer.
+        var initialDbs = new List<ActiveDb>
+        {
+            new ActiveDb(dataBlockInfo, currentXml, onApply, plcName: currentPlcName ?? ""),
+        };
         if (additionalActiveDbs != null)
             initialDbs.AddRange(additionalActiveDbs);
         ActiveSet = new ActiveSetViewModel(
@@ -852,22 +864,36 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     }
 
     /// <summary>
-    /// Replays a stash's edits onto the live tree (#78). Pure write — does
-    /// NOT pop the stash entry from <c>State.Stashes</c>. Callers
+    /// Replays a stash's edits onto the live tree (#78, #82). Pure write —
+    /// does NOT pop the stash entry from <c>State.Stashes</c>. Callers
     /// that need the entry popped do that separately, ideally as part of
     /// composing the next <see cref="ActiveSetState"/> so the cascade
     /// fires once.
+    ///
+    /// <para>
+    /// <paramref name="scopedTo"/> is the <see cref="ActiveDb"/> that owns
+    /// the stashed edits. It must be passed even on the solo path: the
+    /// member <c>Path</c> string is not unique across DBs, so a null-scope
+    /// fallback would silently land edits on whichever DB happens to be
+    /// first in <see cref="MemberTreeViewModel.RootMembers"/> (#82).
+    /// </para>
     /// </summary>
     private (int restored, int dropped) RestoreStashOntoLive(StashedDbState state, ActiveDb? scopedTo = null)
     {
+        if (scopedTo == null)
+        {
+            Log.Warning(
+                "RestoreStashOntoLive called without scopedTo for {Db} — " +
+                "every edit will be reported as dropped (#82 identity guard)",
+                state.Summary.Name);
+            return (0, state.Edits.Count);
+        }
         int restored = 0;
         int dropped = 0;
         var validator = BuildValidator();
         foreach (var edit in state.Edits)
         {
-            var node = scopedTo != null
-                ? FindNodeByPathInDb(edit.Path, scopedTo)
-                : Tree.FindNodeByPath(edit.Path);
+            var node = FindNodeByPathInDb(edit.Path, scopedTo);
             if (node is { IsLeaf: true })
             {
                 // Restore-without-quota: setting EditableStartValue would route
@@ -1475,22 +1501,24 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     }
 
     /// <summary>
-    /// Diagnostic wrapper around <see cref="MemberTreeViewModel.FindNodeByPathInDb"/>:
-    /// the slice returns null when the active set isn't in multi-DB shape
-    /// yet (its <c>_dbToSynthetic</c> doesn't have an entry for
-    /// <paramref name="owner"/>), the host adds the warn-log so a future
-    /// ordering bug surfaces as "stashed edit dropped" in the log instead
-    /// of silently aliasing onto another DB. The slice intentionally has
-    /// no <c>Serilog</c> dependency.
+    /// Diagnostic wrapper around <see cref="MemberTreeViewModel.FindNodeByPathInDb"/>.
+    /// The slice already handles both tree shapes (multi-DB synthetic
+    /// subtree, and single-DB flat root when <paramref name="owner"/> is
+    /// the sole active DB); the host wrapper only adds a warn-log when the
+    /// active set doesn't include <paramref name="owner"/> at all — that's
+    /// an ordering bug (e.g. resolving against a DB that was just removed)
+    /// and we want it visible in the log instead of silently dropped. The
+    /// slice intentionally has no <c>Serilog</c> dependency.
     /// </summary>
     private MemberNodeViewModel? FindNodeByPathInDb(string path, ActiveDb owner)
     {
-        if (!Tree.DbToSynthetic.ContainsKey(owner))
+        bool ownerIsActive = AllActiveDbs.Any(d => ReferenceEquals(d, owner));
+        if (!ownerIsActive)
         {
             Log.Warning(
-                "FindNodeByPathInDb({Path}) called for {Db} but no synthetic " +
-                "root is registered — active set may not be in multi-DB shape " +
-                "yet; returning null to avoid cross-DB path aliasing",
+                "FindNodeByPathInDb({Path}) called for {Db} but the DB is " +
+                "not in the active set — returning null to avoid cross-DB " +
+                "path aliasing (#82)",
                 path, owner.Info.Name);
             return null;
         }
@@ -1686,7 +1714,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                     {
                         node.HasInlineError = true;
                         node.InlineErrorMessage = memberError;
-                        _bulkErrorPaths.Add(node.Path);
+                        _bulkErrorNodes.Add(node);
                     }
                     if (firstError == null)
                     {
@@ -1712,20 +1740,23 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// <summary>
     /// Clears row-level error highlights set by manual-mode bulk validation,
     /// without touching rows that have their own pending inline edit error.
+    ///
+    /// <para>Identity is by VM reference (#82): the same path can exist in
+    /// multiple active DBs, so a path-string lookup here would clear the
+    /// highlight on the wrong row in multi-DB sessions.</para>
     /// </summary>
     private void ClearBulkRowHighlights()
     {
-        if (_bulkErrorPaths.Count == 0) return;
-        foreach (var path in _bulkErrorPaths)
+        if (_bulkErrorNodes.Count == 0) return;
+        foreach (var n in _bulkErrorNodes)
         {
-            var n = Tree.FindNodeByPath(path);
-            if (n != null && !n.IsPendingInlineEdit)
+            if (!n.IsPendingInlineEdit)
             {
                 n.HasInlineError = false;
                 n.InlineErrorMessage = null;
             }
         }
-        _bulkErrorPaths.Clear();
+        _bulkErrorNodes.Clear();
     }
 
     /// <summary>
@@ -1955,9 +1986,12 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         return Selection.SelectedScope.MatchingMembers.Count(m =>
         {
-            var node = Tree.FindNodeByPath(m.Path);
-            // Unresolved paths can't be staged by SetPendingOnNodes, so don't
-            // count them — that's exactly the inflation the old label had.
+            // Identity by MemberNode reference (#82): MatchingMembers holds
+            // model refs, FindVmByModel is O(1) and resolves to the right
+            // DB's tree VM even when the same Path string exists in
+            // multiple active DBs. Unresolved models (stale from a prior
+            // tree) can't be staged, so don't count them.
+            var node = Tree.FindVmByModel(m);
             return node != null && WouldChange(node);
         });
     }

--- a/src/BlockParam/UI/MemberTreeViewModel.cs
+++ b/src/BlockParam/UI/MemberTreeViewModel.cs
@@ -114,10 +114,9 @@ public class MemberTreeViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// <c>MemberNode</c> → owning tree VM. O(1) replacement for the
-    /// path-string walk in <see cref="FindNodeByPath"/>; unambiguous in
-    /// multi-DB sessions where the same path string can appear in
-    /// multiple DBs.
+    /// <c>MemberNode</c> → owning tree VM. O(1) replacement for any
+    /// path-string walk; unambiguous in multi-DB sessions where the same
+    /// path string can appear in multiple DBs (#82).
     /// </summary>
     public IReadOnlyDictionary<MemberNode, MemberNodeViewModel> ModelToVm => _modelToVm;
 
@@ -130,9 +129,11 @@ public class MemberTreeViewModel : ViewModelBase
 
     /// <summary>
     /// <c>ActiveDb</c> → its synthetic group root in the multi-DB tree.
-    /// Empty in single-DB sessions. Used by <see cref="FindNodeByPathInDb"/>
-    /// and by the host's <c>ApplyAllFilters</c> to route per-DB filter
-    /// sets to the correct subtree.
+    /// Empty in single-DB sessions (the slice routes those callers
+    /// through <see cref="RootMembers"/> directly). Used by
+    /// <see cref="FindNodeByPathInDb"/> and by the host's
+    /// <c>ApplyAllFilters</c> to route per-DB filter sets to the correct
+    /// subtree.
     /// </summary>
     public IReadOnlyDictionary<ActiveDb, MemberNodeViewModel> DbToSynthetic => _dbToSynthetic;
 
@@ -193,6 +194,12 @@ public class MemberTreeViewModel : ViewModelBase
             // Cross-PLC name collision: two PLCs can each host a DB called
             // "DB_Foo". Tag any colliding synthetic root with its PLC prefix so
             // the user can tell them apart in the tree.
+            //
+            // #82: every ActiveDb (including the anchor) carries its own
+            // PlcName now, so the prefix lookup is uniform — no index-0
+            // special case. The getCurrentPlcName callback is kept for
+            // back-compat with hosts that may still seed the anchor with an
+            // empty PlcName; we prefer db.PlcName when it's non-empty.
             var anchorPlc = _getCurrentPlcName();
             var nameCounts = activeDbs
                 .GroupBy(d => d.Info.Name, StringComparer.Ordinal)
@@ -200,7 +207,9 @@ public class MemberTreeViewModel : ViewModelBase
             for (int i = 0; i < activeDbs.Count; i++)
             {
                 var db = activeDbs[i];
-                var plc = i == 0 ? anchorPlc : db.PlcName;
+                var plc = !string.IsNullOrEmpty(db.PlcName)
+                    ? db.PlcName
+                    : (i == 0 ? anchorPlc : "");
                 bool collides = nameCounts.TryGetValue(db.Info.Name, out var c) && c > 1;
                 var displayName = collides && !string.IsNullOrEmpty(plc)
                     ? $"{plc} / {db.Info.Name}"
@@ -340,10 +349,10 @@ public class MemberTreeViewModel : ViewModelBase
 
     /// <summary>
     /// O(1) resolve of a <see cref="MemberNode"/> to its tree VM via
-    /// <see cref="ModelToVm"/>. Preferred over <see cref="FindNodeByPath"/>
+    /// <see cref="ModelToVm"/>. Preferred over any path-string lookup
     /// when the caller already has the model — same path string in a
     /// different DB is a different model instance, so this disambiguates
-    /// naturally.
+    /// naturally (#82).
     /// </summary>
     public MemberNodeViewModel? FindVmByModel(MemberNode model) =>
         _modelToVm.TryGetValue(model, out var vm) ? vm : null;
@@ -357,44 +366,45 @@ public class MemberTreeViewModel : ViewModelBase
         _modelToDb.TryGetValue(model, out var db) ? db : null;
 
     /// <summary>
-    /// Walks <see cref="RootMembers"/> for a node with the given
-    /// <paramref name="path"/>. In multi-DB sessions prefer
-    /// <see cref="FindNodeByPathInDb"/> — bare path lookup can hit any DB
-    /// that happens to share the path string.
-    /// </summary>
-    public MemberNodeViewModel? FindNodeByPath(string path)
-    {
-        foreach (var root in RootMembers)
-        {
-            var found = FindNodeByPathRecursive(root, path);
-            if (found != null) return found;
-        }
-        return null;
-    }
-
-    /// <summary>
-    /// DB-scoped variant of <see cref="FindNodeByPath"/>. Callers pass this
-    /// when member Paths can repeat across DBs (the stash holds the bare
-    /// member path, not "DbName.MemberPath") — without scoping, a
-    /// reactivate-additive would replay edits onto whichever DB happened
-    /// to be checked first.
+    /// DB-scoped path lookup (#82). The bare-path overload was removed
+    /// because path strings aren't unique across DBs in multi-DB
+    /// sessions — every caller now passes the owning <see cref="ActiveDb"/>
+    /// so the resolution is unambiguous regardless of tree shape.
     ///
-    /// Strict: callers must only invoke this when the active set is in
-    /// multi-DB shape (i.e. after the State cascade has populated
-    /// <see cref="_dbToSynthetic"/> for <paramref name="owner"/>). If the
-    /// synthetic root isn't found, returns null — a future ordering bug
-    /// surfaces as "stashed edit dropped" instead of silently aliasing
-    /// onto another DB. (The diagnostic log call lives on the host;
-    /// the slice intentionally has no <c>Serilog</c> dependency.)
+    /// Works in both tree shapes:
+    /// <list type="bullet">
+    ///   <item>Multi-DB shape: walks <paramref name="owner"/>'s synthetic
+    ///   subtree via <see cref="_dbToSynthetic"/>.</item>
+    ///   <item>Single-DB shape: walks <see cref="RootMembers"/> directly
+    ///   when <paramref name="owner"/> is the (one) active DB. Anything
+    ///   else returns null instead of falling through to a different DB —
+    ///   that's exactly the cross-DB aliasing this method exists to prevent.</item>
+    /// </list>
     /// </summary>
     public MemberNodeViewModel? FindNodeByPathInDb(string path, ActiveDb owner)
     {
-        if (!_dbToSynthetic.TryGetValue(owner, out var synthetic))
-            return null;
-        foreach (var child in synthetic.Children)
+        if (_dbToSynthetic.TryGetValue(owner, out var synthetic))
         {
-            var found = FindNodeByPathRecursive(child, path);
-            if (found != null) return found;
+            foreach (var child in synthetic.Children)
+            {
+                var found = FindNodeByPathRecursive(child, path);
+                if (found != null) return found;
+            }
+            return null;
+        }
+
+        // Single-DB shape: only resolve when owner is the sole active DB.
+        // The lookup dictionaries already pin every model to its owning DB,
+        // so we use _modelToDb as the authoritative "is owner active?" check
+        // without touching the active-set slice.
+        var activeDbs = _getActiveDbs();
+        if (activeDbs.Count == 1 && ReferenceEquals(activeDbs[0], owner))
+        {
+            foreach (var root in RootMembers)
+            {
+                var found = FindNodeByPathRecursive(root, path);
+                if (found != null) return found;
+            }
         }
         return null;
     }


### PR DESCRIPTION
## Summary

Make member identity `(ActiveDb, MemberNode)` everywhere, not bare path strings.

Path strings are unique within a DB but not across DBs in multi-DB mode. Any code path resolving a `MemberNode` by path risked silently landing on whichever DB sat first in `RootMembers` — masked today by the solo-on-reactivate behaviour (#74) but real for stash restore, manual bulk row clearing, and the `SetPending` count helper.

### Key changes

- **`MemberTreeViewModel`** — bare `FindNodeByPath(string)` removed. `FindNodeByPathInDb(path, owner)` handles both multi-DB synthetic and single-DB flat shapes; never falls through to a different DB.
- **`BulkChangeViewModel`** — stash restore now requires `scopedTo` (drops edits if null with a warn). `_bulkErrorPaths : HashSet<string>` → `_bulkErrorNodes : HashSet<MemberNodeViewModel>` for exact-node highlight clearing. `CountWouldChangeMembers` resolves via `Tree.FindVmByModel(m)`. Anchor `ActiveDb` is seeded with `currentPlcName` at construction so index 0's identity matches every peer uniformly.
- **`ActiveSetViewModel`** — `ReactivateStashedDb` passes `target` to `RestoreStashOntoLive` (not null). Index-0 `AnchorPlcName` fallback dropped from `FindActiveDb` / `GetActiveStatusFor` / `GetActiveItemsForPlc`. `CaptureStashForDb` now stashes a peer under its **own** `PlcName`, not the anchor's — a real bug where a peer on a different PLC couldn't re-match its dropdown summary key after reactivation.
- **`PlcPillGroupsService`, `MemberTreeViewModel.AddDbGroupRoot`** — prefer `db.PlcName` uniformly; keep `anchorPlcName` only as a back-compat fallback for legacy hosts.

### Regression tests

- `StashRestoration_TwoDbsSharePath_RestoresOntoCorrectDb` — verifies stash lands on the right DB when paths collide.
- `CrossDbScopeRouting_PathCollision_EachDbStagesItsOwnNode` — each DB's bulk change targets its own `MemberNode` reference.
- `FindNodeByPathInDb_SingleDb_LocatesByPathString` (renamed from old single-arg test).
- `FindNodeByPathInDb_NotInActiveSet_ReturnsNull` — explicit owner-out-of-set behaviour.

Closes #82

## Test plan

- [ ] v20 CI job — build + xUnit pass
- [ ] v21 CI job — build pass
- [ ] Manual TIA Portal smoke after merge: open a multi-DB session with paths colliding between DBs, edit + stash, reactivate, confirm restoration lands on the correct DB


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dc5qhHAQts7v8YXetq29aj)_