### PR TITLE
refactor(#79): introduce TreeIndexState snapshot for tree-rebuild storage

### DIFF
--- a/src/BlockParam.Tests/BulkChangeViewModelMultiDbTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelMultiDbTests.cs
@@ -213,7 +213,7 @@ public class BulkChangeViewModelMultiDbTests
     /// <summary>
     /// Regression for #108: in multi-DB mode the host's
     /// <c>SubscribeStartValueEdited</c> used to be recursive AND
-    /// <see cref="MemberTreeViewModel.AddDbGroupRoot"/> also walked every
+    /// <c>MemberTreeViewModel.BuildDbGroupRoot</c> also walked every
     /// descendant — so non-leaf nodes ended up with depth-many
     /// <c>StartValueEdited</c> and <c>SelectedChanged</c> handlers each.
     /// Editing a leaf still produced the correct pending value (the store

--- a/src/BlockParam.Tests/MemberTreeViewModelTests.cs
+++ b/src/BlockParam.Tests/MemberTreeViewModelTests.cs
@@ -175,7 +175,7 @@ public class MemberTreeViewModelTests
     }
 
     /// <summary>
-    /// Multi-DB rebuilds go through <c>AddDbGroupRoot</c>, which iterates
+    /// Multi-DB rebuilds go through <c>BuildDbGroupRoot</c>, which iterates
     /// every descendant of the synthetic group VM and invokes
     /// <c>_subscribeToVm</c> per node. Single-DB coverage (above) only
     /// exercises the flat top-level + descendant walk on a fixture without
@@ -204,7 +204,7 @@ public class MemberTreeViewModelTests
 
         // MakeNestedDb produces one struct ("Group") with two leaves
         // ("Speed", "Temp") per DB. Per #108's non-recursive contract,
-        // AddDbGroupRoot subscribes the synthetic root + every descendant:
+        // BuildDbGroupRoot subscribes the synthetic root + every descendant:
         // synthetic + Group + Speed + Temp = 4 per DB. Two DBs = 8 total.
         // An accidental "subscribe roots only" or "subscribe leaves only"
         // regression would shift this number.
@@ -224,7 +224,7 @@ public class MemberTreeViewModelTests
     /// non-recursive by contract — register on the passed node only, do
     /// NOT walk <c>node.Children</c>. A previous host implementation was
     /// itself recursive, and combined with <see cref="MemberTreeViewModel"/>'s
-    /// per-descendant loop in <c>AddDbGroupRoot</c> produced one
+    /// per-descendant loop in <c>BuildDbGroupRoot</c> produced one
     /// <c>StartValueEdited</c> / <c>SelectedChanged</c> handler per node
     /// for every ancestor between the root and the leaf — so an inline
     /// edit on a deeply-nested leaf fired N (= depth) sweeps of the tree.

--- a/src/BlockParam.Tests/TreeIndexStateTests.cs
+++ b/src/BlockParam.Tests/TreeIndexStateTests.cs
@@ -1,0 +1,353 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BlockParam.Localization;
+using BlockParam.Models;
+using BlockParam.UI;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Phase 3 of #79 — locks in the cross-cutting invariants of the
+/// <see cref="TreeIndexState"/> snapshot owned by
+/// <see cref="MemberTreeViewModel"/>. Each test drives a single tree
+/// transition (build, add, remove, stash+reactivate, solo) by mutating
+/// the active-DB list the slice's factory closes over and re-invoking
+/// <see cref="MemberTreeViewModel.BuildRootMembersFromActiveDbs"/>, then
+/// asserts every invariant via <see cref="AssertTreeIndexInvariants"/>.
+///
+/// <para>
+/// The shared helper exists so any future #79 follow-up (manual-selection
+/// snapshot, picker-filter snapshot) can pick the same shape up: every
+/// rebuild observable from outside the slice must satisfy the same five
+/// rules regardless of which gesture got us there.
+/// </para>
+/// </summary>
+public class TreeIndexStateTests
+{
+    [Fact]
+    public void SingleDbBuild_NoSyntheticRoots_AllRealNodesIndexed()
+    {
+        var (db, _, _) = MakeFlatDb("DB_A");
+        var vm = Build(activeDbs: new[] { db });
+
+        vm.BuildRootMembersFromActiveDbs();
+
+        AssertTreeIndexInvariants(vm);
+        vm.TreeIndex.DbToSynthetic.Should().BeEmpty(
+            "single-DB session never mints a synthetic group root");
+    }
+
+    [Fact]
+    public void MultiDbBuild_OneSyntheticPerDb_ModelToDbCoversEveryRealDescendant()
+    {
+        var (dbA, _, _) = MakeNestedDb("DB_A");
+        var (dbB, _, _) = MakeNestedDb("DB_B");
+        var vm = Build(activeDbs: new[] { dbA, dbB });
+
+        vm.BuildRootMembersFromActiveDbs();
+
+        AssertTreeIndexInvariants(vm);
+        vm.TreeIndex.DbToSynthetic.Should().HaveCount(2);
+        vm.TreeIndex.DbToSynthetic.Keys.Should().BeEquivalentTo(new[] { dbA, dbB },
+            "DbToSynthetic keys must reference-equal the live active-DB instances");
+    }
+
+    [Fact]
+    public void MultiDbAdd_AddingAnotherDb_NewIndexCoversNewDbsNodes()
+    {
+        var (dbA, _, _) = MakeNestedDb("DB_A");
+        var (dbB, speedB, _) = MakeNestedDb("DB_B");
+        var activeDbs = new List<ActiveDb> { dbA };
+        var vm = Build(activeDbsFactory: () => activeDbs);
+
+        vm.BuildRootMembersFromActiveDbs();
+
+        // Add a second DB — slice goes from single-DB to multi-DB shape.
+        activeDbs.Add(dbB);
+        vm.BuildRootMembersFromActiveDbs();
+
+        AssertTreeIndexInvariants(vm);
+        vm.TreeIndex.ModelToDb.Should().ContainKey(speedB);
+        vm.TreeIndex.ModelToDb[speedB].Should().BeSameAs(dbB,
+            "newly-added DB's nodes route to that DB instance");
+    }
+
+    [Fact]
+    public void MultiDbRemoveOne_OrphanCleanup_NoStaleKeys()
+    {
+        var (dbA, _, _) = MakeNestedDb("DB_A");
+        var (dbB, speedB, tempB) = MakeNestedDb("DB_B");
+        var activeDbs = new List<ActiveDb> { dbA, dbB };
+        var vm = Build(activeDbsFactory: () => activeDbs);
+
+        vm.BuildRootMembersFromActiveDbs();
+        vm.TreeIndex.ModelToVm.Should().ContainKey(speedB,
+            "setup: dbB's leaf should be indexed before the remove");
+
+        // Remove dbB → slice goes back to single-DB shape.
+        activeDbs.Remove(dbB);
+        vm.BuildRootMembersFromActiveDbs();
+
+        AssertTreeIndexInvariants(vm);
+        vm.TreeIndex.ModelToVm.Should().NotContainKey(speedB,
+            "removed DB's nodes must be evicted from the index");
+        vm.TreeIndex.ModelToVm.Should().NotContainKey(tempB,
+            "every leaf of the removed DB must be evicted, not just the first");
+        vm.TreeIndex.ModelToDb.Should().NotContainKey(speedB,
+            "ModelToDb keys must mirror ModelToVm keys exactly");
+        vm.TreeIndex.DbToSynthetic.Should().NotContainKey(dbB,
+            "removed DB must lose its synthetic mapping");
+    }
+
+    [Fact]
+    public void StashAndReactivate_RestoredDbsNodesAreIndexedAgain()
+    {
+        // Simulates the stash-then-reactivate lifecycle from the slice's
+        // perspective: the same ActiveDb reference leaves the active set,
+        // then re-enters. The index must reflect both transitions cleanly.
+        var (dbA, _, _) = MakeNestedDb("DB_A");
+        var (dbB, speedB, _) = MakeNestedDb("DB_B");
+        var activeDbs = new List<ActiveDb> { dbA, dbB };
+        var vm = Build(activeDbsFactory: () => activeDbs);
+
+        vm.BuildRootMembersFromActiveDbs();
+        var dbBVmBeforeStash = vm.TreeIndex.ModelToVm[speedB];
+
+        // Stash (drop) dbB.
+        activeDbs.Remove(dbB);
+        vm.BuildRootMembersFromActiveDbs();
+        AssertTreeIndexInvariants(vm);
+        vm.TreeIndex.ModelToVm.Should().NotContainKey(speedB);
+
+        // Reactivate (re-add) dbB.
+        activeDbs.Add(dbB);
+        vm.BuildRootMembersFromActiveDbs();
+
+        AssertTreeIndexInvariants(vm);
+        vm.TreeIndex.ModelToVm.Should().ContainKey(speedB,
+            "reactivated DB's leaves must be re-indexed");
+        // Same Model, but the VM must be a fresh instance — the slice
+        // mints new VMs on every rebuild.
+        vm.TreeIndex.ModelToVm[speedB].Should().NotBeSameAs(dbBVmBeforeStash,
+            "rebuild mints fresh VMs even when the underlying Model reference is reused");
+    }
+
+    [Fact]
+    public void SoloPeer_AllOthersGoneFromIndex()
+    {
+        // "Solo dbB" means: active set becomes [dbB] alone. From the
+        // slice's perspective that's an active-set replacement, then
+        // rebuild — same shape regardless of which higher-level command
+        // triggered it.
+        var (dbA, speedA, _) = MakeNestedDb("DB_A");
+        var (dbB, speedB, _) = MakeNestedDb("DB_B");
+        var (dbC, speedC, _) = MakeNestedDb("DB_C");
+        var activeDbs = new List<ActiveDb> { dbA, dbB, dbC };
+        var vm = Build(activeDbsFactory: () => activeDbs);
+
+        vm.BuildRootMembersFromActiveDbs();
+        AssertTreeIndexInvariants(vm);
+
+        // Solo dbB: drop the other two.
+        activeDbs.Clear();
+        activeDbs.Add(dbB);
+        vm.BuildRootMembersFromActiveDbs();
+
+        AssertTreeIndexInvariants(vm);
+        vm.TreeIndex.ModelToVm.Should().ContainKey(speedB,
+            "the soloed DB's nodes remain indexed");
+        vm.TreeIndex.ModelToVm.Should().NotContainKey(speedA,
+            "non-soloed peers must be evicted");
+        vm.TreeIndex.ModelToVm.Should().NotContainKey(speedC,
+            "every non-soloed peer must be evicted, not just the first");
+        vm.TreeIndex.DbToSynthetic.Should().BeEmpty(
+            "single-DB shape: solo collapses to flat top-level, no synthetic roots");
+    }
+
+    [Fact]
+    public void EmptyToSingle_EmptyStartingStateHasEmptyIndex()
+    {
+        // Slice's default state has the Empty snapshot installed; the
+        // first build switches to a real one.
+        var vm = Build(activeDbs: Array.Empty<ActiveDb>());
+
+        vm.TreeIndex.Should().BeSameAs(TreeIndexState.Empty,
+            "default snapshot is the shared Empty instance");
+        vm.TreeIndex.ModelToVm.Should().BeEmpty();
+        vm.TreeIndex.ModelToDb.Should().BeEmpty();
+        vm.TreeIndex.DbToSynthetic.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildIsAtomic_RootsRebuiltHandlerSeesConsistentSnapshot()
+    {
+        // The slice's RootsRebuilt event fires after both RootMembers and
+        // _treeIndex are installed. Any handler — including the host's
+        // pending-edit seeder — must observe a consistent snapshot where
+        // every reachable node is indexed (#79 atomicity guarantee).
+        var (dbA, _, _) = MakeNestedDb("DB_A");
+        var (dbB, _, _) = MakeNestedDb("DB_B");
+        var vm = Build(activeDbs: new[] { dbA, dbB });
+
+        bool sawConsistentState = false;
+        vm.RootsRebuilt += () =>
+        {
+            // Inside the handler, capture the live snapshot + reachable
+            // real nodes (skipping the synthetic DB roots, which are
+            // bookkeeping only) and assert every one is indexed — exactly
+            // as the host's SeedVmsFromStore does after this event fires.
+            var syntheticModels = new HashSet<MemberNode>(
+                vm.TreeIndex.DbToSynthetic.Values.Select(v => v.Model));
+            var reachableReal = vm.RootMembers
+                .SelectMany(r => new[] { r }.Concat(r.AllDescendants()))
+                .Where(n => !syntheticModels.Contains(n.Model))
+                .ToList();
+            sawConsistentState = reachableReal.All(n => vm.TreeIndex.ModelToVm.ContainsKey(n.Model));
+        };
+
+        vm.BuildRootMembersFromActiveDbs();
+
+        sawConsistentState.Should().BeTrue(
+            "RootsRebuilt must fire only after the index covers every reachable real node");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Invariant helper
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Cross-cutting invariants on <see cref="MemberTreeViewModel.TreeIndex"/>
+    /// that must hold after every rebuild (#79). Mirrors the
+    /// <c>AssertInvariants(vm)</c> pattern in
+    /// <c>BulkChangeViewModelInvariantTests</c> but scoped to the
+    /// tree-rebuild snapshot.
+    ///
+    /// <list type="number">
+    ///   <item>Every reachable non-synthetic node is keyed in
+    ///   <see cref="TreeIndexState.ModelToVm"/>.</item>
+    ///   <item>Single-DB shape: no synthetic group roots; multi-DB shape:
+    ///   exactly N synthetic <c>Datatype="DB"</c> roots (N = active-DB
+    ///   count); <see cref="TreeIndexState.DbToSynthetic"/> count == N.</item>
+    ///   <item>Multi-DB shape: every real descendant has
+    ///   <see cref="TreeIndexState.ModelToDb"/> pointing to the owning
+    ///   <see cref="ActiveDb"/> (by reference, never by name — #82).</item>
+    ///   <item>No orphan keys: every key in
+    ///   <see cref="TreeIndexState.ModelToVm"/> corresponds to a reachable
+    ///   real node; no stale entries from a prior tree.</item>
+    ///   <item><see cref="TreeIndexState.ModelToVm"/> and
+    ///   <see cref="TreeIndexState.ModelToDb"/> have identical key sets —
+    ///   they're built together and must stay in lockstep.</item>
+    /// </list>
+    /// </summary>
+    private static void AssertTreeIndexInvariants(MemberTreeViewModel vm)
+    {
+        var index = vm.TreeIndex;
+        var rootsList = vm.RootMembers.ToList();
+        var reachable = rootsList
+            .SelectMany(r => new[] { r }.Concat(r.AllDescendants()))
+            .ToList();
+
+        // The synthetic group roots created for multi-DB shape carry a
+        // Model with Datatype="DB" and are NOT in ModelToVm — they're
+        // bookkeeping only. Filter them out for the reachable-node sweep.
+        // MemberNode uses default (reference) equality so HashSet works.
+        var syntheticModels = new HashSet<MemberNode>(
+            index.DbToSynthetic.Values.Select(v => v.Model));
+        var reachableReal = reachable
+            .Where(n => !syntheticModels.Contains(n.Model))
+            .ToList();
+
+        // (1) every reachable real node is keyed in ModelToVm
+        foreach (var node in reachableReal)
+        {
+            index.ModelToVm.Should().ContainKey(node.Model,
+                $"invariant 1: every reachable real node ('{node.Path}') must be indexed");
+            index.ModelToVm[node.Model].Should().BeSameAs(node,
+                "invariant 1: ModelToVm must point at the live VM for the model");
+        }
+
+        // (2) tree shape matches active-set count
+        if (index.DbToSynthetic.Count == 0)
+        {
+            // Single-DB (or empty): no synthetic group roots in RootMembers.
+            rootsList.Should().AllSatisfy(r => r.Datatype.Should().NotBe("DB",
+                "invariant 2 (single-DB): top-level members are flat, no synthetic group"));
+        }
+        else
+        {
+            // Multi-DB: exactly one synthetic root per ActiveDb mapped.
+            rootsList.Should().HaveCount(index.DbToSynthetic.Count,
+                "invariant 2 (multi-DB): one synthetic root per active DB");
+            rootsList.Should().AllSatisfy(r => r.Datatype.Should().Be("DB",
+                "invariant 2 (multi-DB): every root is a synthetic Datatype='DB' group"));
+            index.DbToSynthetic.Values.Should().BeEquivalentTo(rootsList,
+                "invariant 2 (multi-DB): DbToSynthetic values are exactly the RootMembers (order-independent — dict enumeration order is implementation-defined)");
+        }
+
+        // (3) multi-DB: every real descendant routes to its owning DB
+        if (index.DbToSynthetic.Count > 0)
+        {
+            foreach (var kvp in index.DbToSynthetic)
+            {
+                var owningDb = kvp.Key;
+                var syntheticVm = kvp.Value;
+                foreach (var realDescendant in syntheticVm.AllDescendants())
+                {
+                    if (ReferenceEquals(realDescendant.Model, syntheticVm.Model)) continue;
+                    index.ModelToDb.Should().ContainKey(realDescendant.Model,
+                        $"invariant 3: real descendant '{realDescendant.Path}' must be in ModelToDb");
+                    index.ModelToDb[realDescendant.Model].Should().BeSameAs(owningDb,
+                        "invariant 3: ModelToDb routes to the synthetic root's owning ActiveDb by reference (#82)");
+                }
+            }
+        }
+
+        // (4) no orphan keys — every ModelToVm key is one of the
+        // currently reachable real nodes.
+        var reachableRealModels = new HashSet<MemberNode>(reachableReal.Select(n => n.Model));
+        index.ModelToVm.Keys.Should().AllSatisfy(k =>
+            reachableRealModels.Contains(k).Should().BeTrue(
+                "invariant 4: no orphan keys in ModelToVm — every key " +
+                "must correspond to a reachable real node in the current tree"));
+
+        // (5) ModelToVm and ModelToDb have matching key sets
+        index.ModelToDb.Keys.Should().BeEquivalentTo(index.ModelToVm.Keys,
+            "invariant 5: ModelToVm and ModelToDb are built in lockstep");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Fixtures (mirror MemberTreeViewModelTests so tests stay slice-local)
+    // ─────────────────────────────────────────────────────────────────────
+
+    private static MemberTreeViewModel Build(
+        IReadOnlyList<ActiveDb>? activeDbs = null,
+        Func<IReadOnlyList<ActiveDb>>? activeDbsFactory = null,
+        string currentPlcName = "") =>
+        new MemberTreeViewModel(
+            getActiveDbs: activeDbsFactory ?? (() => activeDbs ?? Array.Empty<ActiveDb>()),
+            getCurrentPlcName: () => currentPlcName,
+            commentLanguagePolicy: new CommentLanguagePolicy(null, null, new[] { "en-GB" }),
+            subscribeToVm: _ => { });
+
+    private static (ActiveDb db, MemberNode group, MemberNode leaf) MakeNestedDb(string name)
+    {
+        var leafA = new MemberNode("Speed", "Int", "0", "Group.Speed", null, Array.Empty<MemberNode>());
+        var leafB = new MemberNode("Temp", "Int", "0", "Group.Temp", null, Array.Empty<MemberNode>());
+        var group = new MemberNode("Group", "Struct", null, "Group", null, new[] { leafA, leafB });
+        var info = new DataBlockInfo(name, 1, "Optimized", "GlobalDB", new[] { group });
+        return (new ActiveDb(info, $"<Block name='{name}' />"), leafA, leafB);
+    }
+
+    private static (ActiveDb db, MemberNode speed, MemberNode enableFlag) MakeFlatDb(
+        string name, string plcName = "")
+    {
+        var speed = new MemberNode("Speed", "Int", "0", "Speed", null, Array.Empty<MemberNode>());
+        var enableFlag = new MemberNode("Enable", "Bool", "false", "Enable", null, Array.Empty<MemberNode>());
+        var info = new DataBlockInfo(name, 1, "Optimized", "GlobalDB", new[] { speed, enableFlag });
+        return (new ActiveDb(info, $"<Block name='{name}' />", onApply: null, plcName: plcName),
+                speed, enableFlag);
+    }
+}

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -1568,7 +1568,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private void ApplyAllFilters()
     {
         // Multi-DB safe (#58): build per-DB search/exclude sets and route
-        // them to each synthetic root via _dbToSynthetic. Path strings are
+        // them to each synthetic root via Tree.DbToSynthetic. Path strings are
         // unique within a DB but identical across DBs that share the
         // structure, so a single shared HashSet<string> would mis-mark same-
         // path leaves in other active DBs as search hits.
@@ -2351,7 +2351,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         // Pair every synthetic root with its ActiveDb so each pending edit
         // is routed to the correct XML buffer + OnApply callback. Multi-PLC
-        // safe (#58 review must-fix #4): _dbToSynthetic is keyed by
+        // safe (#58 review must-fix #4): Tree.DbToSynthetic is keyed by
         // ActiveDb reference, never by name — two PLCs hosting DBs with
         // identical names map to two distinct synthetic roots.
         var perDb = new List<(ActiveDb db, List<(MemberNode Member, string Value)> edits)>();
@@ -2695,7 +2695,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// <para>
     /// <b>Non-recursive by contract (#108).</b> Callers passing this as the
     /// <c>subscribeToVm</c> callback to <see cref="MemberTreeViewModel"/> are
-    /// responsible for iterating per node — the slice's <c>AddDbGroupRoot</c>
+    /// responsible for iterating per node — the slice's <c>BuildDbGroupRoot</c>
     /// already walks every descendant of the synthetic group VM, and a
     /// previous recursive implementation here doubled (then N-tupled, by
     /// depth) the handler registrations on every non-leaf descendant in

--- a/src/BlockParam/UI/MemberTreeViewModel.cs
+++ b/src/BlockParam/UI/MemberTreeViewModel.cs
@@ -60,14 +60,18 @@ public class MemberTreeViewModel : ViewModelBase
     /// handlers on the passed node only, never recurse into <c>node.Children</c>.
     /// A previous recursive host doubled (then N-tupled, by depth) the
     /// handler registrations on every non-leaf descendant in multi-DB mode
-    /// because <see cref="AddDbGroupRoot"/> already walks every descendant.
+    /// because <see cref="BuildDbGroupRoot"/> already walks every descendant.
     /// </para>
     /// </summary>
     private readonly Action<MemberNodeViewModel> _subscribeToVm;
 
-    private readonly Dictionary<MemberNode, MemberNodeViewModel> _modelToVm = new();
-    private readonly Dictionary<MemberNode, ActiveDb> _modelToDb = new();
-    private readonly Dictionary<ActiveDb, MemberNodeViewModel> _dbToSynthetic = new();
+    // #79: the three model→VM / model→DB / DB→synthetic dictionaries are
+    // owned by a single immutable snapshot. Every tree rebuild builds the
+    // snapshot in locals and installs it in one atomic assignment via
+    // <see cref="BuildTreeIndex"/>, so readers never observe a partial state
+    // where roots have been minted but a descendant is still missing from
+    // ModelToVm, or where DbToSynthetic still has keys from the prior tree.
+    private TreeIndexState _treeIndex = TreeIndexState.Empty;
 
     private bool _isRefreshing;
 
@@ -114,18 +118,27 @@ public class MemberTreeViewModel : ViewModelBase
     }
 
     /// <summary>
+    /// Immutable snapshot of the three model→VM / model→DB / DB→synthetic
+    /// lookup dictionaries (#79). Assigned exactly once per tree rebuild;
+    /// callers can capture the reference and read it concurrently with a
+    /// subsequent rebuild without observing a partial state.
+    /// </summary>
+    public TreeIndexState TreeIndex => _treeIndex;
+
+    /// <summary>
     /// <c>MemberNode</c> → owning tree VM. O(1) replacement for any
     /// path-string walk; unambiguous in multi-DB sessions where the same
-    /// path string can appear in multiple DBs (#82).
+    /// path string can appear in multiple DBs (#82). Backed by
+    /// <see cref="TreeIndex"/>.
     /// </summary>
-    public IReadOnlyDictionary<MemberNode, MemberNodeViewModel> ModelToVm => _modelToVm;
+    public IReadOnlyDictionary<MemberNode, MemberNodeViewModel> ModelToVm => _treeIndex.ModelToVm;
 
     /// <summary>
     /// <c>MemberNode</c> → owning <c>ActiveDb</c>. Used by the host's
     /// pending-edit store + multi-DB scope routing to write back to the
-    /// right tree / xml.
+    /// right tree / xml. Backed by <see cref="TreeIndex"/>.
     /// </summary>
-    public IReadOnlyDictionary<MemberNode, ActiveDb> ModelToDb => _modelToDb;
+    public IReadOnlyDictionary<MemberNode, ActiveDb> ModelToDb => _treeIndex.ModelToDb;
 
     /// <summary>
     /// <c>ActiveDb</c> → its synthetic group root in the multi-DB tree.
@@ -133,9 +146,9 @@ public class MemberTreeViewModel : ViewModelBase
     /// through <see cref="RootMembers"/> directly). Used by
     /// <see cref="FindNodeByPathInDb"/> and by the host's
     /// <c>ApplyAllFilters</c> to route per-DB filter sets to the correct
-    /// subtree.
+    /// subtree. Backed by <see cref="TreeIndex"/>.
     /// </summary>
-    public IReadOnlyDictionary<ActiveDb, MemberNodeViewModel> DbToSynthetic => _dbToSynthetic;
+    public IReadOnlyDictionary<ActiveDb, MemberNodeViewModel> DbToSynthetic => _treeIndex.DbToSynthetic;
 
     public ICommand ExpandAllCommand { get; }
     public ICommand CollapseAllCommand { get; }
@@ -149,23 +162,65 @@ public class MemberTreeViewModel : ViewModelBase
     public event Action? RootsRebuilt;
 
     /// <summary>
-    /// Rebuilds <see cref="RootMembers"/> + the three lookup dictionaries
-    /// from the current active-DB set. Single-DB session puts top-level
-    /// members of the anchor DB directly at root; multi-DB session creates
-    /// one synthetic group per DB. Fires <see cref="RootsRebuilt"/> when
-    /// the new shape is ready.
+    /// Rebuilds <see cref="RootMembers"/> + the <see cref="TreeIndex"/>
+    /// snapshot from the current active-DB set. Single-DB session puts
+    /// top-level members of the anchor DB directly at root; multi-DB
+    /// session creates one synthetic group per DB. Fires
+    /// <see cref="RootsRebuilt"/> once <see cref="RootMembers"/> and
+    /// <see cref="_treeIndex"/> are both fully populated — readers in the
+    /// handler observe a consistent tree (#79).
     /// </summary>
     public void BuildRootMembersFromActiveDbs()
     {
-        // Always rebuild the routing dictionaries so every model node is
-        // mapped to its current VM + owning DB. Stale entries from a prior
-        // tree would route writes to disposed VMs.
-        _modelToVm.Clear();
-        _modelToDb.Clear();
-        _dbToSynthetic.Clear();
-        RootMembers.Clear();
-
         var activeDbs = _getActiveDbs();
+        var anchorPlc = _getCurrentPlcName();
+
+        // Build the new roots + new index snapshot into local builders. No
+        // mutation of _treeIndex or RootMembers happens until the walk is
+        // complete, so a subscribe callback that touches MemberTreeViewModel
+        // mid-build (e.g. a property-changed handler) still sees the prior
+        // consistent snapshot.
+        var (newRoots, newIndex) = BuildTreeIndex(
+            activeDbs, anchorPlc, _commentLanguagePolicy, _subscribeToVm);
+
+        // Atomic install: replace the index in one assignment, then refresh
+        // RootMembers in place (kept as ObservableCollection for WPF
+        // bindings on the TreeView/ListView). Order matters: any handler
+        // wired to RootMembers' CollectionChanged would read TreeIndex via
+        // ModelToVm — assign the index first so those reads observe the
+        // new state.
+        _treeIndex = newIndex;
+        RootMembers.Clear();
+        foreach (var root in newRoots)
+            RootMembers.Add(root);
+
+        RootsRebuilt?.Invoke();
+    }
+
+    /// <summary>
+    /// Pure tree-build (#79 Phase 2): consumes the current active-DB set +
+    /// anchor PLC name and produces the new top-level VM list paired with a
+    /// fresh <see cref="TreeIndexState"/>. No side effects on
+    /// <see cref="MemberTreeViewModel"/> state — callers install the result
+    /// atomically.
+    ///
+    /// <para>
+    /// The per-VM <paramref name="subscribeToVm"/> callback is invoked
+    /// during the walk (non-recursive contract, #108). That's the only
+    /// observable side effect — every other store touched here is a local
+    /// builder.
+    /// </para>
+    /// </summary>
+    private static (List<MemberNodeViewModel> Roots, TreeIndexState Index) BuildTreeIndex(
+        IReadOnlyList<ActiveDb> activeDbs,
+        string anchorPlc,
+        CommentLanguagePolicy commentLanguagePolicy,
+        Action<MemberNodeViewModel> subscribeToVm)
+    {
+        var roots = new List<MemberNodeViewModel>();
+        var modelToVm = new Dictionary<MemberNode, MemberNodeViewModel>();
+        var modelToDb = new Dictionary<MemberNode, ActiveDb>();
+        var dbToSynthetic = new Dictionary<ActiveDb, MemberNodeViewModel>();
 
         if (activeDbs.Count == 1)
         {
@@ -173,19 +228,19 @@ public class MemberTreeViewModel : ViewModelBase
             var only = activeDbs[0];
             foreach (var member in only.Info.Members)
             {
-                var vm = new MemberNodeViewModel(member, null, _commentLanguagePolicy);
-                // #108: _subscribeToVm is non-recursive by contract, so the
-                // slice walks the subtree itself. Subscribe the root, then
+                var vm = new MemberNodeViewModel(member, null, commentLanguagePolicy);
+                // #108: subscribeToVm is non-recursive by contract, so the
+                // builder walks the subtree itself. Subscribe the root, then
                 // every descendant — same per-node fan-out as the multi-DB
-                // path in AddDbGroupRoot.
-                _subscribeToVm(vm);
+                // path in BuildDbGroupRoot.
+                subscribeToVm(vm);
                 foreach (var descendant in vm.AllDescendants())
-                    _subscribeToVm(descendant);
-                IndexSubtree(vm, only);
-                RootMembers.Add(vm);
+                    subscribeToVm(descendant);
+                IndexSubtree(vm, only, modelToVm, modelToDb);
+                roots.Add(vm);
             }
         }
-        else
+        else if (activeDbs.Count > 1)
         {
             // Multi-DB: one synthetic group node per DB. Children are the DB's
             // real top-level members, reused by reference — Path strings stay
@@ -197,10 +252,9 @@ public class MemberTreeViewModel : ViewModelBase
             //
             // #82: every ActiveDb (including the anchor) carries its own
             // PlcName now, so the prefix lookup is uniform — no index-0
-            // special case. The getCurrentPlcName callback is kept for
-            // back-compat with hosts that may still seed the anchor with an
-            // empty PlcName; we prefer db.PlcName when it's non-empty.
-            var anchorPlc = _getCurrentPlcName();
+            // special case. The anchorPlc fallback is kept for back-compat
+            // with hosts that may still seed the anchor with an empty
+            // PlcName; we prefer db.PlcName when it's non-empty.
             var nameCounts = activeDbs
                 .GroupBy(d => d.Info.Name, StringComparer.Ordinal)
                 .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
@@ -214,14 +268,26 @@ public class MemberTreeViewModel : ViewModelBase
                 var displayName = collides && !string.IsNullOrEmpty(plc)
                     ? $"{plc} / {db.Info.Name}"
                     : db.Info.Name;
-                AddDbGroupRoot(db, displayName);
+                var groupVm = BuildDbGroupRoot(
+                    db, displayName, commentLanguagePolicy, subscribeToVm,
+                    modelToVm, modelToDb);
+                dbToSynthetic[db] = groupVm;
+                roots.Add(groupVm);
             }
         }
+        // activeDbs.Count == 0: roots/index stay empty — same as legacy
+        // (the old method cleared the dicts and never populated them).
 
-        RootsRebuilt?.Invoke();
+        return (roots, new TreeIndexState(modelToVm, modelToDb, dbToSynthetic));
     }
 
-    private void AddDbGroupRoot(ActiveDb db, string displayName)
+    private static MemberNodeViewModel BuildDbGroupRoot(
+        ActiveDb db,
+        string displayName,
+        CommentLanguagePolicy commentLanguagePolicy,
+        Action<MemberNodeViewModel> subscribeToVm,
+        Dictionary<MemberNode, MemberNodeViewModel> modelToVm,
+        Dictionary<MemberNode, ActiveDb> modelToDb)
     {
         var info = db.Info;
         var synthetic = new MemberNode(
@@ -231,18 +297,17 @@ public class MemberTreeViewModel : ViewModelBase
             path: info.Name,
             parent: null,
             children: info.Members);
-        var groupVm = new MemberNodeViewModel(synthetic, null, _commentLanguagePolicy);
+        var groupVm = new MemberNodeViewModel(synthetic, null, commentLanguagePolicy);
         // Subscribe edited-value events on every minted VM (the synthetic
         // group root + every real descendant) so inline edits in any active
         // DB bubble up to the VM the same way single-DB edits do. The
         // synthetic group's StartValue is null and never raises the event,
         // but subscribing it keeps the "one callback per minted VM" contract
         // simple — see #108.
-        _subscribeToVm(groupVm);
+        subscribeToVm(groupVm);
         foreach (var descendant in groupVm.AllDescendants())
-            _subscribeToVm(descendant);
+            subscribeToVm(descendant);
         groupVm.IsExpanded = true;
-        _dbToSynthetic[db] = groupVm;
         // Map every real (non-synthetic) descendant to its VM + owning DB so
         // multi-DB scope hits route writes to the right tree / xml.
         foreach (var descendant in groupVm.AllDescendants())
@@ -252,26 +317,30 @@ public class MemberTreeViewModel : ViewModelBase
             // against the synthetic instance avoids relying on Datatype string
             // matching, which is fragile.
             if (ReferenceEquals(descendant.Model, synthetic)) continue;
-            _modelToVm[descendant.Model] = descendant;
-            _modelToDb[descendant.Model] = db;
+            modelToVm[descendant.Model] = descendant;
+            modelToDb[descendant.Model] = db;
         }
-        RootMembers.Add(groupVm);
+        return groupVm;
     }
 
     /// <summary>
     /// Indexes every node in <paramref name="rootVm"/>'s subtree (root
-    /// included) into <see cref="_modelToVm"/> + <see cref="_modelToDb"/>.
-    /// Used by the single-DB code path; multi-DB indexes inside
-    /// <see cref="AddDbGroupRoot"/> with the synthetic-skip rule.
+    /// included) into the supplied builder dicts. Used by the single-DB
+    /// code path; multi-DB indexes inside <see cref="BuildDbGroupRoot"/>
+    /// with the synthetic-skip rule.
     /// </summary>
-    private void IndexSubtree(MemberNodeViewModel rootVm, ActiveDb db)
+    private static void IndexSubtree(
+        MemberNodeViewModel rootVm,
+        ActiveDb db,
+        Dictionary<MemberNode, MemberNodeViewModel> modelToVm,
+        Dictionary<MemberNode, ActiveDb> modelToDb)
     {
-        _modelToVm[rootVm.Model] = rootVm;
-        _modelToDb[rootVm.Model] = db;
+        modelToVm[rootVm.Model] = rootVm;
+        modelToDb[rootVm.Model] = db;
         foreach (var descendant in rootVm.AllDescendants())
         {
-            _modelToVm[descendant.Model] = descendant;
-            _modelToDb[descendant.Model] = db;
+            modelToVm[descendant.Model] = descendant;
+            modelToDb[descendant.Model] = db;
         }
     }
 
@@ -355,7 +424,7 @@ public class MemberTreeViewModel : ViewModelBase
     /// naturally (#82).
     /// </summary>
     public MemberNodeViewModel? FindVmByModel(MemberNode model) =>
-        _modelToVm.TryGetValue(model, out var vm) ? vm : null;
+        _treeIndex.ModelToVm.TryGetValue(model, out var vm) ? vm : null;
 
     /// <summary>
     /// Returns the active DB that owns <paramref name="model"/>, or null
@@ -363,7 +432,7 @@ public class MemberTreeViewModel : ViewModelBase
     /// from before the last <c>RefreshTree</c>).
     /// </summary>
     public ActiveDb? FindActiveDbForModel(MemberNode model) =>
-        _modelToDb.TryGetValue(model, out var db) ? db : null;
+        _treeIndex.ModelToDb.TryGetValue(model, out var db) ? db : null;
 
     /// <summary>
     /// DB-scoped path lookup (#82). The bare-path overload was removed
@@ -374,7 +443,7 @@ public class MemberTreeViewModel : ViewModelBase
     /// Works in both tree shapes:
     /// <list type="bullet">
     ///   <item>Multi-DB shape: walks <paramref name="owner"/>'s synthetic
-    ///   subtree via <see cref="_dbToSynthetic"/>.</item>
+    ///   subtree via <see cref="DbToSynthetic"/>.</item>
     ///   <item>Single-DB shape: walks <see cref="RootMembers"/> directly
     ///   when <paramref name="owner"/> is the (one) active DB. Anything
     ///   else returns null instead of falling through to a different DB —
@@ -383,7 +452,10 @@ public class MemberTreeViewModel : ViewModelBase
     /// </summary>
     public MemberNodeViewModel? FindNodeByPathInDb(string path, ActiveDb owner)
     {
-        if (_dbToSynthetic.TryGetValue(owner, out var synthetic))
+        // Capture the snapshot once so we read DbToSynthetic and the
+        // dependent walk against the same _treeIndex (#79).
+        var index = _treeIndex;
+        if (index.DbToSynthetic.TryGetValue(owner, out var synthetic))
         {
             foreach (var child in synthetic.Children)
             {
@@ -395,8 +467,8 @@ public class MemberTreeViewModel : ViewModelBase
 
         // Single-DB shape: only resolve when owner is the sole active DB.
         // The lookup dictionaries already pin every model to its owning DB,
-        // so we use _modelToDb as the authoritative "is owner active?" check
-        // without touching the active-set slice.
+        // so we use the active-DB callback as the authoritative "is owner
+        // active?" check without touching the active-set slice.
         var activeDbs = _getActiveDbs();
         if (activeDbs.Count == 1 && ReferenceEquals(activeDbs[0], owner))
         {

--- a/src/BlockParam/UI/TreeIndexState.cs
+++ b/src/BlockParam/UI/TreeIndexState.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using BlockParam.Models;
+
+namespace BlockParam.UI;
+
+/// <summary>
+/// Immutable snapshot of the three model→VM / model→DB / DB→synthetic
+/// lookup dictionaries owned by <see cref="MemberTreeViewModel"/> (#79).
+///
+/// <para>
+/// Every tree rebuild
+/// (<see cref="MemberTreeViewModel.BuildRootMembersFromActiveDbs"/>) builds
+/// one fresh <see cref="TreeIndexState"/> in locals and installs it in a
+/// single atomic assignment — readers never observe a partial state where
+/// roots have been minted but a descendant is still missing from
+/// <see cref="ModelToVm"/>, or where <see cref="DbToSynthetic"/> still has
+/// keys from the prior tree.
+/// </para>
+///
+/// <para>
+/// Storage uses plain <see cref="IReadOnlyDictionary{TKey,TValue}"/> rather
+/// than the <c>System.Collections.Immutable</c> NuGet types so net48 builds
+/// don't pull a new transitive dependency — same trade-off as
+/// <see cref="ActiveSetState"/> (#78). Per-rebuild allocation cost is
+/// negligible compared to the per-node <see cref="MemberNodeViewModel"/>
+/// construction the rebuild already performs.
+/// </para>
+///
+/// <para>
+/// Member identity is the <c>(ActiveDb, MemberNode)</c> pair per #82 — the
+/// same path string in two DBs is two distinct <see cref="MemberNode"/>
+/// instances, so the by-reference dictionary keying disambiguates without
+/// any path-string scanning.
+/// </para>
+/// </summary>
+public sealed class TreeIndexState
+{
+    public TreeIndexState(
+        IReadOnlyDictionary<MemberNode, MemberNodeViewModel> modelToVm,
+        IReadOnlyDictionary<MemberNode, ActiveDb> modelToDb,
+        IReadOnlyDictionary<ActiveDb, MemberNodeViewModel> dbToSynthetic)
+    {
+        ModelToVm = modelToVm;
+        ModelToDb = modelToDb;
+        DbToSynthetic = dbToSynthetic;
+    }
+
+    /// <summary>
+    /// <c>MemberNode</c> → owning tree VM. O(1) replacement for any
+    /// path-string walk; unambiguous in multi-DB sessions where the same
+    /// path string can appear in multiple DBs (#82).
+    /// </summary>
+    public IReadOnlyDictionary<MemberNode, MemberNodeViewModel> ModelToVm { get; }
+
+    /// <summary>
+    /// <c>MemberNode</c> → owning <c>ActiveDb</c>. Used by the host's
+    /// pending-edit store + multi-DB scope routing to write back to the
+    /// right tree / xml.
+    /// </summary>
+    public IReadOnlyDictionary<MemberNode, ActiveDb> ModelToDb { get; }
+
+    /// <summary>
+    /// <c>ActiveDb</c> → its synthetic group root in the multi-DB tree.
+    /// Empty in single-DB sessions (the slice routes those callers through
+    /// <c>RootMembers</c> directly). Used by
+    /// <see cref="MemberTreeViewModel.FindNodeByPathInDb"/> and by the
+    /// host's per-DB filter routing.
+    /// </summary>
+    public IReadOnlyDictionary<ActiveDb, MemberNodeViewModel> DbToSynthetic { get; }
+
+    /// <summary>Empty snapshot — the initial state before any tree build.</summary>
+    public static TreeIndexState Empty { get; } = new(
+        new Dictionary<MemberNode, MemberNodeViewModel>(0),
+        new Dictionary<MemberNode, ActiveDb>(0),
+        new Dictionary<ActiveDb, MemberNodeViewModel>(0));
+}


### PR DESCRIPTION
## Summary

Extends the immutable-snapshot pattern (#78) to the three tree-rebuild storage fields on `MemberTreeViewModel`. The three dicts (`_modelToVm`, `_modelToDb`, `_dbToSynthetic`) were rebuilt together on every active-set change but mutated in-place — a partial-state read during the rebuild was possible. Now they live in a single `TreeIndexState` value installed atomically.

### Key changes

- **New `src/BlockParam/UI/TreeIndexState.cs`** — sealed class with init-only `ModelToVm`, `ModelToDb`, `DbToSynthetic` (typed against `(ActiveDb, MemberNode)` identity per #82) + `Empty` singleton. Shape mirrors `ActiveSetState`; uses `IReadOnlyDictionary<,>` to match `ActiveSetState`'s precedent (the codebase deliberately avoids `System.Collections.Immutable` per #78's NuGet hygiene).
- **`MemberTreeViewModel`** — single `_treeIndex` backing field replaces three mutable dicts. `BuildTreeIndex(...)` extracted as a pure static function returning `(Roots, Index)`. `BuildRootMembersFromActiveDbs` performs one atomic `_treeIndex = newIndex` install before clearing/refilling `RootMembers` (kept as `ObservableCollection` for WPF binding). Find lookups (`FindVmByModel`, `FindActiveDbForModel`, `FindNodeByPathInDb`) delegate to the snapshot.
- **Doc cleanups** — three stale `AddDbGroupRoot` doc-comments updated to `BuildDbGroupRoot`.

### Regression tests

New `src/BlockParam.Tests/TreeIndexStateTests.cs` with an `AssertTreeIndexInvariants` helper checking five invariants:

1. Every reachable real node is keyed in `ModelToVm`.
2. Tree shape matches active-set count (single-DB → no synthetic roots; multi-DB → exactly N).
3. Multi-DB descendants route to the owning DB by reference (per #82's identity contract).
4. No orphan keys after `RemoveActiveDb`.
5. `ModelToVm`/`ModelToDb` key-sets stay in lockstep.

7 transition tests cover: empty default, single-DB build, multi-DB add, multi-DB remove (orphan cleanup), stash+reactivate (restored DB indexed), solo (other DBs gone from index), atomicity-inside-handler.

### Scope boundaries (intentionally NOT in this PR)

The original #79 listed six fields. After the slice work landed, three of those (`_modelToVm`/`_modelToDb`/`_dbToSynthetic`) co-located on `MemberTreeViewModel` and form the right snapshot. The other two:

- `_manualSelectedPaths` (`SelectionScopeViewModel`) — user-gesture lifecycle; different cascade.
- `_filteredDataBlockItems` (`ActiveSetViewModel`) — picker filter lifecycle.

These have independent triggers and don't benefit from being bundled into `TreeIndexState`. File follow-up issues if drift surfaces. `_collapsedPlcGroups` from the original issue body doesn't exist in current code (expand state moved to per-node `MemberNodeViewModel.IsExpanded`).

Closes #79

## Test plan

- [ ] v20 CI job — build + xUnit pass (`TreeIndexStateTests` + existing suites)
- [ ] v21 CI job — build pass
- [ ] Manual TIA Portal smoke: multi-DB session, add/remove DBs, stash+reactivate, confirm no stale index entries cause cross-DB drift


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dc5qhHAQts7v8YXetq29aj)_