### PR TITLE
fix(#123): guard OnNodeSelected against synthetic DB-root cascade

### DIFF
--- a/src/BlockParam.Tests/SelectionScopeViewModelTests.cs
+++ b/src/BlockParam.Tests/SelectionScopeViewModelTests.cs
@@ -355,6 +355,44 @@ public class SelectionScopeViewModelTests
         leafB.IsSelected.Should().BeTrue();
     }
 
+    /// <summary>
+    /// Guard for issue #123: if a future feature sets IsSelected = true on a
+    /// synthetic DB-group root, OnNodeSelected must bail early and must NOT
+    /// clear IsSelected on any real leaf. Without the guard the cascade would
+    /// walk every DB in the tree and deselect everything — the exact opposite
+    /// of a "select-all-in-DB" or header-click intent.
+    /// </summary>
+    [Fact]
+    public void OnNodeSelected_SyntheticDbGroupRoot_DoesNotCascadeDeselect()
+    {
+        // Arrange: multi-DB tree so that a cascade would affect leaves in both.
+        var (vm, tree, _) = BuildWithMultiDb();
+        var dbA = tree.RootMembers[0]; // synthetic group VM for DB_A
+        var dbB = tree.RootMembers[1]; // synthetic group VM for DB_B
+        var leafA = dbA.AllDescendants().First(n => n.IsLeaf);
+        var leafB = dbB.AllDescendants().First(n => n.IsLeaf);
+
+        // Pre-select a real leaf so we can detect whether it gets cleared.
+        leafA.IsSelected = true;
+        leafB.IsSelected = true;
+
+        // Act: simulate what would happen if a future feature set IsSelected
+        // on the synthetic DB group root and that triggered the SelectedChanged
+        // callback (OnNodeSelected) with the synthetic VM as the sender.
+        dbA.Datatype.Should().Be("DB",
+            "this fixture's synthetic root must carry the 'DB' marker for the guard to activate");
+        vm.OnNodeSelected(dbA);
+
+        // Assert: both real leaves must be untouched — the guard short-circuited
+        // before the cascade could clear them.
+        leafA.IsSelected.Should().BeTrue(
+            "OnNodeSelected must bail early for synthetic DB-group roots (#123): " +
+            "leafA must not be deselected by a cascade triggered on a non-leaf");
+        leafB.IsSelected.Should().BeTrue(
+            "OnNodeSelected must bail early for synthetic DB-group roots (#123): " +
+            "leafB in the other DB must also be untouched");
+    }
+
     [Fact]
     public void OnNodeSelected_ReEntry_IsSilentlyIgnored()
     {

--- a/src/BlockParam/UI/SelectionScopeViewModel.cs
+++ b/src/BlockParam/UI/SelectionScopeViewModel.cs
@@ -287,6 +287,15 @@ public class SelectionScopeViewModel : ViewModelBase
     /// </summary>
     public void OnNodeSelected(MemberNodeViewModel justSelected)
     {
+        // Guard: synthetic DB-group roots (Datatype == "DB") are tree
+        // structural nodes, not real members. If a future feature ever sets
+        // IsSelected = true on one (e.g. "select-all-in-DB" gesture or a
+        // keyboard shortcut on the DB header), the cascade below would clear
+        // IsSelected on every real leaf across every DB — the exact opposite
+        // of what the user would expect. Bail early so synthetic roots are
+        // inert from the single-focus perspective. (#123)
+        if (justSelected.Datatype == "DB") return;
+
         if (_inSelectionCascade) return;
         _inSelectionCascade = true;
         try


### PR DESCRIPTION
## Summary

- Adds an early-return guard at the top of `SelectionScopeViewModel.OnNodeSelected` that bails if the sender's `Datatype == "DB"` — the marker used by `MemberTreeViewModel.BuildDbGroupRoot` to identify synthetic group roots.
- Without this guard, any future feature that sets `IsSelected = true` on a DB header node (e.g. "select-all-in-DB" gesture, multi-DB drag-select, or a keyboard shortcut) would trigger the global single-focus cascade and deselect every real leaf across every active DB.
- Implements option (b) from the issue: smallest diff, preserves #108's "one callback per minted VM" contract — the `BuildFromActiveDbs_MultiDb_InvokesSubscribeCallbackExactlyOncePerNode` count stays at 8.

## Test plan

- [x] New test `OnNodeSelected_SyntheticDbGroupRoot_DoesNotCascadeDeselect`: constructs a multi-DB tree, pre-selects real leaves in both DBs, calls `OnNodeSelected` with the synthetic DB group root VM, asserts both leaves remain selected.
- [x] All 19 `SelectionScopeViewModelTests` pass.
- [x] `BuildFromActiveDbs_MultiDb_InvokesSubscribeCallbackExactlyOncePerNode` still passes (option b, not c).
- [x] `dotnet build BlockParam.sln -c Debug` — 0 warnings, 0 errors.
- [x] `dotnet test BlockParam.sln -c Debug --no-build` — 996/997 pass (1 pre-existing timezone failure in `FileSystemBlockParamStorageTests`).

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)