### PR TITLE
refactor(#122): tighten TreeIndexState atomicity — immutability + partial-state seam + honest tests

### DIFF
--- a/src/BlockParam.Tests/TreeIndexStateTests.cs
+++ b/src/BlockParam.Tests/TreeIndexStateTests.cs
@@ -182,11 +182,11 @@ public class TreeIndexStateTests
     }
 
     [Fact]
-    public void BuildIsAtomic_RootsRebuiltHandlerSeesConsistentSnapshot()
+    public void RootsRebuiltHandler_SeesFullyPopulatedIndex()
     {
-        // The slice's RootsRebuilt event fires after both RootMembers and
-        // _treeIndex are installed. Any handler — including the host's
-        // pending-edit seeder — must observe a consistent snapshot where
+        // Honest scope: RootsRebuilt fires after both _treeIndex and RootMembers
+        // are fully installed. Any handler — including the host's pending-edit
+        // seeder (SeedVmsFromStore) — must observe a consistent snapshot where
         // every reachable node is indexed (#79 atomicity guarantee).
         var (dbA, _, _) = MakeNestedDb("DB_A");
         var (dbB, _, _) = MakeNestedDb("DB_B");
@@ -212,6 +212,46 @@ public class TreeIndexStateTests
 
         sawConsistentState.Should().BeTrue(
             "RootsRebuilt must fire only after the index covers every reachable real node");
+    }
+
+    [Fact]
+    public void PropertyChanged_RootMembers_SeesFullyPopulatedIndex()
+    {
+        // Regression guard for the partial-state seam (#122): when RootMembers
+        // is replaced by a fresh ObservableCollection, PropertyChanged fires once.
+        // The index must already be fully populated at that point so any binding
+        // handler reading Tree.ModelToVm sees a consistent snapshot.
+        var (dbA, _, _) = MakeNestedDb("DB_A");
+        var (dbB, _, _) = MakeNestedDb("DB_B");
+        var vm = Build(activeDbs: new[] { dbA, dbB });
+
+        bool sawConsistentState = false;
+        int propertyChangedCount = 0;
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName != nameof(vm.RootMembers)) return;
+            propertyChangedCount++;
+
+            // At the moment the property fires the new collection must be
+            // fully populated and every real node must be in the index.
+            var syntheticModels = new HashSet<MemberNode>(
+                vm.TreeIndex.DbToSynthetic.Values.Select(v => v.Model));
+            var reachableReal = vm.RootMembers
+                .SelectMany(r => new[] { r }.Concat(r.AllDescendants()))
+                .Where(n => !syntheticModels.Contains(n.Model))
+                .ToList();
+            // RootMembers is the new fully-populated collection at this point
+            // (swap already done). Verify the index matches it completely.
+            sawConsistentState = reachableReal.Count > 0
+                && reachableReal.All(n => vm.TreeIndex.ModelToVm.ContainsKey(n.Model));
+        };
+
+        vm.BuildRootMembersFromActiveDbs();
+
+        propertyChangedCount.Should().Be(1,
+            "RootMembers swap must raise exactly one PropertyChanged, not N+1 CollectionChanged events");
+        sawConsistentState.Should().BeTrue(
+            "index must be fully populated before the RootMembers PropertyChanged fires (#122)");
     }
 
     // ─────────────────────────────────────────────────────────────────────

--- a/src/BlockParam/UI/MemberTreeViewModel.cs
+++ b/src/BlockParam/UI/MemberTreeViewModel.cs
@@ -74,6 +74,11 @@ public class MemberTreeViewModel : ViewModelBase
     private TreeIndexState _treeIndex = TreeIndexState.Empty;
 
     private bool _isRefreshing;
+    // #122: backing field for RootMembers so BuildRootMembersFromActiveDbs can
+    // swap the entire collection in one assignment and raise a single
+    // PropertyChanged — instead of Clear() + N×Add() firing N+1 CollectionChanged
+    // events while _treeIndex is already on the new snapshot.
+    private ObservableCollection<MemberNodeViewModel> _rootMembers;
 
     public MemberTreeViewModel(
         Func<IReadOnlyList<ActiveDb>> getActiveDbs,
@@ -86,7 +91,7 @@ public class MemberTreeViewModel : ViewModelBase
         _commentLanguagePolicy = commentLanguagePolicy;
         _subscribeToVm = subscribeToVm;
 
-        RootMembers = new ObservableCollection<MemberNodeViewModel>();
+        _rootMembers = new ObservableCollection<MemberNodeViewModel>();
         ExpandAllCommand = new RelayCommand(ExecuteExpandAll);
         CollapseAllCommand = new RelayCommand(ExecuteCollapseAll);
     }
@@ -96,8 +101,20 @@ public class MemberTreeViewModel : ViewModelBase
     /// member of the anchor DB; multi-DB session = one synthetic
     /// <c>Datatype="DB"</c> group per active DB whose children are that
     /// DB's real members.
+    ///
+    /// <para>
+    /// Backed by a writable field so <see cref="BuildRootMembersFromActiveDbs"/>
+    /// can swap to a fresh <see cref="ObservableCollection{T}"/> in one
+    /// assignment, raising a single <c>PropertyChanged</c> instead of
+    /// N+1 <c>CollectionChanged</c> events while the new index is already
+    /// installed (#122).
+    /// </para>
     /// </summary>
-    public ObservableCollection<MemberNodeViewModel> RootMembers { get; }
+    public ObservableCollection<MemberNodeViewModel> RootMembers
+    {
+        get => _rootMembers;
+        private set => SetProperty(ref _rootMembers, value);
+    }
 
     /// <summary>
     /// Flat-list projection of <see cref="RootMembers"/> respecting current
@@ -183,16 +200,18 @@ public class MemberTreeViewModel : ViewModelBase
         var (newRoots, newIndex) = BuildTreeIndex(
             activeDbs, anchorPlc, _commentLanguagePolicy, _subscribeToVm);
 
-        // Atomic install: replace the index in one assignment, then refresh
-        // RootMembers in place (kept as ObservableCollection for WPF
-        // bindings on the TreeView/ListView). Order matters: any handler
-        // wired to RootMembers' CollectionChanged would read TreeIndex via
+        // Atomic install: replace the index in one assignment, then swap
+        // RootMembers to a fresh ObservableCollection and raise a single
+        // PropertyChanged. Order matters: any handler wired to
+        // RootMembers.CollectionChanged (on the old collection) or
+        // PropertyChanged(nameof(RootMembers)) would read TreeIndex via
         // ModelToVm — assign the index first so those reads observe the
-        // new state.
+        // new state. Using a fresh collection instead of Clear()+N×Add()
+        // collapses N+1 CollectionChanged events into one PropertyChanged
+        // event, closing the partial-state seam where a handler could
+        // observe the new index but an incomplete RootMembers list (#122).
         _treeIndex = newIndex;
-        RootMembers.Clear();
-        foreach (var root in newRoots)
-            RootMembers.Add(root);
+        RootMembers = new ObservableCollection<MemberNodeViewModel>(newRoots);
 
         RootsRebuilt?.Invoke();
     }

--- a/src/BlockParam/UI/TreeIndexState.cs
+++ b/src/BlockParam/UI/TreeIndexState.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using BlockParam.Models;
 
 namespace BlockParam.UI;
@@ -35,14 +36,30 @@ namespace BlockParam.UI;
 /// </summary>
 public sealed class TreeIndexState
 {
+    /// <summary>
+    /// Wraps caller-supplied dictionaries in <see cref="ReadOnlyDictionary{TKey,TValue}"/>
+    /// so callers cannot cast back to <c>Dictionary&lt;,&gt;</c> and mutate the
+    /// snapshot (#122). One allocation per dictionary per rebuild; negligible cost.
+    /// </summary>
     public TreeIndexState(
         IReadOnlyDictionary<MemberNode, MemberNodeViewModel> modelToVm,
         IReadOnlyDictionary<MemberNode, ActiveDb> modelToDb,
         IReadOnlyDictionary<ActiveDb, MemberNodeViewModel> dbToSynthetic)
     {
-        ModelToVm = modelToVm;
-        ModelToDb = modelToDb;
-        DbToSynthetic = dbToSynthetic;
+        // Callers always pass Dictionary<,> (built in BuildTreeIndex locals).
+        // The is-cast avoids a second allocation on the happy path; the
+        // explicit-cast fallback handles any future caller that passes a
+        // pre-wrapped IDictionary. ReadOnlyDictionary<K,V> ctor takes
+        // IDictionary<K,V> (net48 BCL constraint — no IReadOnlyDictionary ctor).
+        ModelToVm = new ReadOnlyDictionary<MemberNode, MemberNodeViewModel>(
+            modelToVm is Dictionary<MemberNode, MemberNodeViewModel> d1
+                ? d1 : (IDictionary<MemberNode, MemberNodeViewModel>)modelToVm);
+        ModelToDb = new ReadOnlyDictionary<MemberNode, ActiveDb>(
+            modelToDb is Dictionary<MemberNode, ActiveDb> d2
+                ? d2 : (IDictionary<MemberNode, ActiveDb>)modelToDb);
+        DbToSynthetic = new ReadOnlyDictionary<ActiveDb, MemberNodeViewModel>(
+            dbToSynthetic is Dictionary<ActiveDb, MemberNodeViewModel> d3
+                ? d3 : (IDictionary<ActiveDb, MemberNodeViewModel>)dbToSynthetic);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Three independent contract tightenings from the post-#120 review (#122):

- **Fix 1 — Enforce immutability:** `TreeIndexState` constructor now wraps every incoming `Dictionary<,>` with `ReadOnlyDictionary<,>`. Previously, a caller receiving an `IReadOnlyDictionary` could cast back to `Dictionary<,>` and mutate the snapshot. The is-pattern avoids an extra allocation on the common path (callers always supply raw `Dictionary<,>` from `BuildTreeIndex`).

- **Fix 2 — Close partial-state seam in `RootMembers`:** `MemberTreeViewModel.RootMembers` changed from a readonly field to a property with a backing field. `BuildRootMembersFromActiveDbs` now assigns a fresh `ObservableCollection<MemberNodeViewModel>` in one assignment instead of `Clear()` + N×`Add()`. This collapses N+1 `CollectionChanged` events into a single `PropertyChanged(nameof(RootMembers))`, so any handler reading `Tree.ModelToVm` sees both a complete index and a complete `RootMembers` at the same time.

- **Fix 3 — Honest test naming + regression guard:** Renamed `BuildIsAtomic_RootsRebuiltHandlerSeesConsistentSnapshot` → `RootsRebuiltHandler_SeesFullyPopulatedIndex` (the old name claimed "atomicity inside CollectionChanged" but the test only covered the post-loop `RootsRebuilt` event). Added a new test `PropertyChanged_RootMembers_SeesFullyPopulatedIndex` that subscribes to `PropertyChanged(nameof(RootMembers))` and asserts both that exactly one event fires and that `ModelToVm` is fully populated at that moment — a direct regression guard for the Fix 2 seam.

## Quality gates

- `dotnet build` clean (0 warnings, 0 errors)
- 996/997 tests pass; the one pre-existing failure is `FileSystemBlockParamStorageTests.GetLastWriteTime_on_missing_file_returns_FILETIME_epoch` (timezone offset issue, unrelated)

Closes #122