### PR TITLE
refactor(#117): migrate AutocompleteViewModel.Match to StringMatcher.MatchesAny

### DIFF
--- a/src/BlockParam.Tests/AutocompleteViewModelTests.cs
+++ b/src/BlockParam.Tests/AutocompleteViewModelTests.cs
@@ -199,4 +199,46 @@ public class AutocompleteViewModelTests
         staticResult.Select(s => s.Value).Should().BeEquivalentTo(
             instanceResult.FilteredSuggestions.Select(s => s.Value));
     }
+
+    // Regression: the inline IndexOf triple was replaced with StringMatcher.MatchesAny in
+    // issue #117. The following tests pin the exact semantics that must survive the migration.
+
+    [Fact]
+    public void Match_NullComment_DoesNotThrow_AndCanMatchOnOtherFields()
+    {
+        // Suggestions whose Comment is null must not NRE after the migration
+        // (StringMatcher.MatchesAny skips null fields rather than crashing).
+        var items = new[]
+        {
+            S("42", "NullComment", comment: null),
+            S("99", "HasComment", "the-keyword"),
+        };
+
+        var result = AutocompleteViewModel.Match(items, "the-keyword");
+
+        result.Should().ContainSingle(s => s.Value == "99",
+            "match via Comment must still work when another item has a null Comment");
+        result.Should().NotContain(s => s.Value == "42",
+            "item with null Comment and no DisplayName/Value hit must not appear");
+    }
+
+    [Fact]
+    public void Match_FilterHitsDisplayNameOnly_ReturnsThatItem()
+    {
+        var items = new[] { S("val", "UniqueDisplay", null) };
+
+        var result = AutocompleteViewModel.Match(items, "UniqueDisplay");
+
+        result.Should().ContainSingle(s => s.Value == "val");
+    }
+
+    [Fact]
+    public void Match_FilterHitsValueOnly_ReturnsThatItem()
+    {
+        var items = new[] { S("unique-val", "SomeDisplay", null) };
+
+        var result = AutocompleteViewModel.Match(items, "unique-val");
+
+        result.Should().ContainSingle(s => s.Value == "unique-val");
+    }
 }

--- a/src/BlockParam/UI/AutocompleteViewModel.cs
+++ b/src/BlockParam/UI/AutocompleteViewModel.cs
@@ -202,9 +202,7 @@ public class AutocompleteViewModel : ViewModelBase
 
         var terms = filter.Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
         return source.Where(s => terms.All(term =>
-            s.DisplayName.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0 ||
-            s.Value.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0 ||
-            (s.Comment != null && s.Comment.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0)))
+            StringMatcher.MatchesAny(term, s.DisplayName, s.Value, s.Comment)))
             .ToList();
     }
 }


### PR DESCRIPTION
## Summary

- Removes the last inline triple-`IndexOf` block in `AutocompleteViewModel.Match` (lines 204–207), replacing it with a single call to `StringMatcher.MatchesAny`.
- Semantics are identical: `OrdinalIgnoreCase`, null fields are skipped rather than crashing — `StringMatcher` already handles this via its null-check loop.
- The `StringComparison` enum reference is no longer needed in that file (removed implicitly by the replacement).

## What changed

**`src/BlockParam/UI/AutocompleteViewModel.cs`** — `Match` static method:

Before:
```csharp
var terms = filter.Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
return source.Where(s => terms.All(term =>
    s.DisplayName.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0 ||
    s.Value.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0 ||
    (s.Comment != null && s.Comment.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0)))
    .ToList();
```

After:
```csharp
var terms = filter.Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
return source.Where(s => terms.All(term =>
    StringMatcher.MatchesAny(term, s.DisplayName, s.Value, s.Comment)))
    .ToList();
```

**`src/BlockParam.Tests/AutocompleteViewModelTests.cs`** — three new regression tests:
- `Match_NullComment_DoesNotThrow_AndCanMatchOnOtherFields` — pins that null Comment fields don't NRE
- `Match_FilterHitsDisplayNameOnly_ReturnsThatItem`
- `Match_FilterHitsValueOnly_ReturnsThatItem`

## Test plan

- [x] `dotnet build BlockParam.sln -c Debug` — 0 warnings, 0 errors
- [x] `dotnet test BlockParam.sln -c Debug --no-build` — 998/999 pass; only the known pre-existing timezone failure (`FileSystemBlockParamStorageTests.GetLastWriteTime_on_missing_file_returns_FILETIME_epoch`) remains
- [x] Three new regression tests added and passing

Closes #117