### PR TITLE
fix(#77): drop InOut storage in nested sub-FB sections (+ partial-trust CAS fix)

### DIFF
--- a/src/BlockParam.Tests/Fixtures/instance-db-multi-instance.xml
+++ b/src/BlockParam.Tests/Fixtures/instance-db-multi-instance.xml
@@ -1,0 +1,153 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document>
+  <Engineering version="V20" />
+  <DocumentInfo>
+    <Created>2026-05-15T05:42:41.7699826Z</Created>
+    <ExportSetting>WithDefaults</ExportSetting>
+    <InstalledProducts>
+      <Product>
+        <DisplayName>Totally Integrated Automation Portal</DisplayName>
+        <DisplayVersion>V20 Update 3</DisplayVersion>
+      </Product>
+      <OptionPackage>
+        <DisplayName>TIA Portal Openness</DisplayName>
+        <DisplayVersion>V20 Update 3</DisplayVersion>
+      </OptionPackage>
+      <OptionPackage>
+        <DisplayName>TIA Portal Version Control Interface</DisplayName>
+        <DisplayVersion>V20 Update 3</DisplayVersion>
+      </OptionPackage>
+      <Product>
+        <DisplayName>SINAMICS Startdrive Advanced</DisplayName>
+        <DisplayVersion>V20</DisplayVersion>
+      </Product>
+      <OptionPackage>
+        <DisplayName>SINAMICS DCC</DisplayName>
+        <DisplayVersion>V20</DisplayVersion>
+      </OptionPackage>
+      <OptionPackage>
+        <DisplayName>SINAMICS Startdrive G130, G150, S120, S150, SINAMICS MV, G220, S200, S210</DisplayName>
+        <DisplayVersion>V20</DisplayVersion>
+      </OptionPackage>
+      <OptionPackage>
+        <DisplayName>SINAMICS Startdrive G110M, G120, G120C, G120D, G120P, G115D</DisplayName>
+        <DisplayVersion>V20</DisplayVersion>
+      </OptionPackage>
+      <Product>
+        <DisplayName>STEP 7 Professional</DisplayName>
+        <DisplayVersion>V20 Update 3</DisplayVersion>
+      </Product>
+      <OptionPackage>
+        <DisplayName>STEP 7 Safety</DisplayName>
+        <DisplayVersion>V20 Update 2</DisplayVersion>
+      </OptionPackage>
+      <Product>
+        <DisplayName>WinCC Basic/Comfort/Advanced</DisplayName>
+        <DisplayVersion>V20 Update 3</DisplayVersion>
+      </Product>
+      <Product>
+        <DisplayName>WinCC Unified</DisplayName>
+        <DisplayVersion>V20 Update 3</DisplayVersion>
+      </Product>
+    </InstalledProducts>
+  </DocumentInfo>
+  <SW.Blocks.InstanceDB ID="0">
+    <AttributeList>
+      <AutoNumber>true</AutoNumber>
+      <DBAccessibleFromOPCUA>false</DBAccessibleFromOPCUA>
+      <DBAccessibleFromWebserver>true</DBAccessibleFromWebserver>
+      <HeaderAuthor />
+      <HeaderFamily />
+      <HeaderName />
+      <HeaderVersion>0.1</HeaderVersion>
+      <InstanceOfName>OuterFb</InstanceOfName>
+      <InstanceOfType>FB</InstanceOfType>
+      <Interface><Sections xmlns="http://www.siemens.com/automation/Openness/SW/Interface/v5">
+  <Section Name="Input" />
+  <Section Name="Output" />
+  <Section Name="InOut">
+    <Member Name="bigArray" Datatype="&quot;UDT_BigPayload&quot;" Accessibility="Public">
+      <Sections>
+        <Section Name="None">
+          <Member Name="bigArray" Datatype="Array[1..10000] of DInt" />
+        </Section>
+      </Sections>
+    </Member>
+  </Section>
+  <Section Name="Static">
+    <Member Name="instanceInnerFB" Datatype="&quot;InnerFb&quot;" Accessibility="Public">
+      <AttributeList>
+        <BooleanAttribute Name="ExternalAccessible" SystemDefined="true">false</BooleanAttribute>
+        <BooleanAttribute Name="ExternalVisible" SystemDefined="true">false</BooleanAttribute>
+        <BooleanAttribute Name="ExternalWritable" SystemDefined="true">false</BooleanAttribute>
+        <BooleanAttribute Name="SetPoint" SystemDefined="true">false</BooleanAttribute>
+      </AttributeList>
+      <Sections>
+        <Section Name="Input" />
+        <Section Name="Output" />
+        <Section Name="InOut">
+          <Member Name="bigArray" Datatype="&quot;UDT_BigPayload&quot;">
+            <Sections>
+              <Section Name="None">
+                <Member Name="bigArray" Datatype="Array[1..10000] of DInt" />
+              </Section>
+            </Sections>
+          </Member>
+        </Section>
+        <Section Name="Static">
+          <Member Name="innerStaticA" Datatype="Bool" />
+          <Member Name="innerStaticB" Datatype="Bool" />
+        </Section>
+      </Sections>
+    </Member>
+    <Member Name="outerStatic" Datatype="Bool" Remanence="NonRetain" Accessibility="Public">
+      <AttributeList>
+        <BooleanAttribute Name="ExternalAccessible" SystemDefined="true">false</BooleanAttribute>
+        <BooleanAttribute Name="ExternalVisible" SystemDefined="true">false</BooleanAttribute>
+        <BooleanAttribute Name="ExternalWritable" SystemDefined="true">false</BooleanAttribute>
+        <BooleanAttribute Name="SetPoint" SystemDefined="true">false</BooleanAttribute>
+      </AttributeList>
+    </Member>
+  </Section>
+</Sections></Interface>
+      <Name>OuterFb_IDB</Name>
+      <Namespace />
+      <Number>72</Number>
+      <ProgrammingLanguage>DB</ProgrammingLanguage>
+    </AttributeList>
+    <ObjectList>
+      <MultilingualText ID="1" CompositionName="Comment">
+        <ObjectList>
+          <MultilingualTextItem ID="2" CompositionName="Items">
+            <AttributeList>
+              <Culture>de-DE</Culture>
+              <Text />
+            </AttributeList>
+          </MultilingualTextItem>
+          <MultilingualTextItem ID="3" CompositionName="Items">
+            <AttributeList>
+              <Culture>en-US</Culture>
+              <Text />
+            </AttributeList>
+          </MultilingualTextItem>
+        </ObjectList>
+      </MultilingualText>
+      <MultilingualText ID="4" CompositionName="Title">
+        <ObjectList>
+          <MultilingualTextItem ID="5" CompositionName="Items">
+            <AttributeList>
+              <Culture>de-DE</Culture>
+              <Text />
+            </AttributeList>
+          </MultilingualTextItem>
+          <MultilingualTextItem ID="6" CompositionName="Items">
+            <AttributeList>
+              <Culture>en-US</Culture>
+              <Text />
+            </AttributeList>
+          </MultilingualTextItem>
+        </ObjectList>
+      </MultilingualText>
+    </ObjectList>
+  </SW.Blocks.InstanceDB>
+</Document>

--- a/src/BlockParam.Tests/SimaticMLParserTests.cs
+++ b/src/BlockParam.Tests/SimaticMLParserTests.cs
@@ -453,4 +453,44 @@ public class SimaticMLParserTests
         allMembers.Should().Contain(m => m.Path == "drive2.blocked.moduleId");
         allMembers.Should().Contain(m => m.Path == "general.transferFailed.moduleId");
     }
+
+    /// <summary>
+    /// Regression for #77: an IDB of a multi-instance FB nests every sub-FB's
+    /// full interface mirror (Input/Output/InOut/Static) under the parent's Static
+    /// section. The InOut content is interface-pointer noise that TIA exports for
+    /// completeness but is not stored in the IDB. Walking it materialised tens of
+    /// thousands of phantom members per sub-FB (the 9 GB freeze in Gen_Main_IDB).
+    ///
+    /// Fixture is a deliberately tiny FB with a 10,000-element DInt array inside an
+    /// InOut UDT, plus two scalar Bools in Static, called once as a multi-instance
+    /// from an outer FB that has the same InOut shape itself. After the fix the
+    /// tree must contain the Static scalars (one outer, two inner) and the inner-FB
+    /// container, and nothing else.
+    /// </summary>
+    [Fact]
+    public void Parse_InstanceDB_MultiInstance_DropsInOutSectionsInsideSubFb()
+    {
+        var xml = TestFixtures.LoadXml("instance-db-multi-instance.xml");
+        var db = _parser.Parse(xml);
+
+        db.BlockType.Should().Be("InstanceDB");
+
+        var allPaths = db.AllMembers().Select(m => m.Path).ToList();
+
+        // What survives: the inner FB instance container + the three Static Bools.
+        allPaths.Should().Contain("instanceInnerFB");
+        allPaths.Should().Contain("instanceInnerFB.innerStaticA");
+        allPaths.Should().Contain("instanceInnerFB.innerStaticB");
+        allPaths.Should().Contain("outerStatic");
+
+        // What must NOT survive: the InOut "bigArray" on the inner sub-FB and any
+        // of its 10,000 array elements. If any path contains "bigArray" we have
+        // walked into a sub-FB's InOut section — the exact #77 regression.
+        allPaths.Should().NotContain(p => p.Contains("bigArray"),
+            "InOut content inside multi-instance sub-FBs is parameter-passing and not editable in the IDB (#77)");
+
+        // Belt: tree size should be small (4 visible members), not the 10,000+
+        // we'd see if the array got expanded.
+        db.AllMembers().Should().HaveCount(4);
+    }
 }

--- a/src/BlockParam/Services/UiZoomService.cs
+++ b/src/BlockParam/Services/UiZoomService.cs
@@ -67,7 +67,23 @@ public class UiZoomService
         _settingsPath = settingsPath;
     }
 
-    private bool PersistenceEnabled => !_settingsPath.IsEmpty;
+    private bool PersistenceEnabled
+    {
+        get
+        {
+            // Copy to a local before calling an instance member on the struct.
+            // Calling `_settingsPath.IsEmpty` directly emits `ldflda` on a
+            // readonly struct field, which .NET Framework 4.8's partial-trust
+            // IL verifier (TIA's SandboxDomain) rejects with
+            // `System.Security.VerificationException: Operation could
+            // destabilize the runtime` — crashing the Add-In Loader right after
+            // the dialog window's Loaded event fires ZoomHost.Attach.
+            // Full-trust contexts (CI tests, DevLauncher) don't surface this,
+            // which is why it slipped through the storage refactor.
+            var settings = _settingsPath;
+            return !settings.IsEmpty;
+        }
+    }
 
     public static string DefaultSettingsPath() => AppDirectories.UiSettingsFile;
 

--- a/src/BlockParam/Services/UiZoomService.cs
+++ b/src/BlockParam/Services/UiZoomService.cs
@@ -144,7 +144,11 @@ public class UiZoomService
         }
         catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
         {
-            Log.Warning(ex, "UiZoomService: cannot read {Path} — using default zoom", _settingsPath.FullPath);
+            // Same local-copy discipline as PersistenceEnabled — never call an
+            // instance member directly on the readonly StoragePath field, even
+            // in a catch block, or partial trust will reject the IL.
+            var settings = _settingsPath;
+            Log.Warning(ex, "UiZoomService: cannot read {Path} — using default zoom", settings.FullPath);
         }
     }
 
@@ -177,7 +181,8 @@ public class UiZoomService
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            Log.Warning(ex, "UiZoomService: cannot save {Path}", _settingsPath.FullPath);
+            var settings = _settingsPath;
+            Log.Warning(ex, "UiZoomService: cannot save {Path}", settings.FullPath);
         }
     }
 

--- a/src/BlockParam/SimaticML/SimaticMLParser.cs
+++ b/src/BlockParam/SimaticML/SimaticMLParser.cs
@@ -218,7 +218,13 @@ public class SimaticMLParser
                 childUdt, childPathWithinUdt, unresolvedUdts);
             childrenList.AddRange(children);
 
-            // UDT instances have children in <Sections><Section Name="None"><Member .../>
+            // UDT instances have children in <Sections><Section Name="None"><Member .../>.
+            // Multi-instance sub-FBs nest their full interface mirror here
+            // (Input/Output/InOut/Static/Temp/Constant); only Static carries stored,
+            // editable IDB data alongside Input/Output (per-instance defaults). InOut
+            // members are interface pointers with no stored value; Temp is scratch;
+            // Constant is pre-resolved literals at compile time. Walking InOut at
+            // every nesting level turned Gen_Main_IDB into a 9 GB UI thread stall (#77).
             var nestedSections = LocalElement(memberElement, Sections);
             if (nestedSections != null)
             {
@@ -226,6 +232,7 @@ public class SimaticMLParser
                 if (nestedNs == XNamespace.None) nestedNs = ns;
                 foreach (var section in LocalElements(nestedSections, Section))
                 {
+                    if (!IsParseableSection(section.Attribute(Name)?.Value)) continue;
                     var sectionChildren = ParseMembers(
                         section, nestedNs, node, path, indexStack,
                         childUdt, childPathWithinUdt, unresolvedUdts);
@@ -411,6 +418,8 @@ public class SimaticMLParser
                     if (nestedNs == XNamespace.None) nestedNs = ns;
                     foreach (var section in LocalElements(nestedSections, Section))
                     {
+                        // Same filter as ParseMembers nested-section walk (#77).
+                        if (!IsParseableSection(section.Attribute(Name)?.Value)) continue;
                         var tmpl = ParseMembers(
                             section, nestedNs, elementNode, childPath, childIndexStack,
                             elementUdt, elementPathWithinUdt, unresolvedUdts);
@@ -430,6 +439,26 @@ public class SimaticMLParser
 
         return arrayNode;
     }
+
+    /// <summary>
+    /// Returns true when a nested <c>&lt;Section Name="..."&gt;</c> should be
+    /// walked into the member tree. The set:
+    /// <list type="bullet">
+    ///   <item><c>Static</c> — the canonical stored data section.</item>
+    ///   <item><c>Input</c>, <c>Output</c> — for multi-instance sub-FBs these carry
+    ///     per-instance default start values that are editable in the IDB.</item>
+    ///   <item><c>None</c> — TIA's wrapper section around UDT / Struct expansions.</item>
+    /// </list>
+    /// <c>InOut</c>, <c>Temp</c> and <c>Constant</c> are intentionally dropped:
+    /// they either represent interface pointers (no stored value), scratch memory,
+    /// or values already resolved to literals at compile time. Walking <c>InOut</c>
+    /// inside multi-instance sub-FBs was the dominant cost behind #77.
+    /// </summary>
+    private static bool IsParseableSection(string? sectionName) =>
+        sectionName == "Static" ||
+        sectionName == "Input" ||
+        sectionName == "Output" ||
+        sectionName == "None";
 
     private bool TryResolveBound(string token, out int value)
     {

--- a/src/BlockParam/SimaticML/SimaticMLParser.cs
+++ b/src/BlockParam/SimaticML/SimaticMLParser.cs
@@ -218,27 +218,9 @@ public class SimaticMLParser
                 childUdt, childPathWithinUdt, unresolvedUdts);
             childrenList.AddRange(children);
 
-            // UDT instances have children in <Sections><Section Name="None"><Member .../>.
-            // Multi-instance sub-FBs nest their full interface mirror here
-            // (Input/Output/InOut/Static/Temp/Constant); only Static carries stored,
-            // editable IDB data alongside Input/Output (per-instance defaults). InOut
-            // members are interface pointers with no stored value; Temp is scratch;
-            // Constant is pre-resolved literals at compile time. Walking InOut at
-            // every nesting level turned Gen_Main_IDB into a 9 GB UI thread stall (#77).
-            var nestedSections = LocalElement(memberElement, Sections);
-            if (nestedSections != null)
-            {
-                var nestedNs = nestedSections.Name.Namespace;
-                if (nestedNs == XNamespace.None) nestedNs = ns;
-                foreach (var section in LocalElements(nestedSections, Section))
-                {
-                    if (!IsParseableSection(section.Attribute(Name)?.Value)) continue;
-                    var sectionChildren = ParseMembers(
-                        section, nestedNs, node, path, indexStack,
-                        childUdt, childPathWithinUdt, unresolvedUdts);
-                    childrenList.AddRange(sectionChildren);
-                }
-            }
+            WalkFilteredNestedSections(
+                memberElement, ns, node, path, indexStack,
+                childUdt, childPathWithinUdt, unresolvedUdts, childrenList);
 
             result.Add(node);
         }
@@ -411,22 +393,14 @@ public class SimaticMLParser
             }
             else // UDT
             {
-                var nestedSections = LocalElement(memberElement, Sections);
-                if (nestedSections != null)
-                {
-                    var nestedNs = nestedSections.Name.Namespace;
-                    if (nestedNs == XNamespace.None) nestedNs = ns;
-                    foreach (var section in LocalElements(nestedSections, Section))
-                    {
-                        // Same filter as ParseMembers nested-section walk (#77).
-                        if (!IsParseableSection(section.Attribute(Name)?.Value)) continue;
-                        var tmpl = ParseMembers(
-                            section, nestedNs, elementNode, childPath, childIndexStack,
-                            elementUdt, elementPathWithinUdt, unresolvedUdts);
-                        elementChildrenList.AddRange(tmpl);
-                    }
-                }
-                else if (elementUdt != null && _udtResolver != null && !_udtResolver.HasType(elementUdt))
+                var hadNestedSections = WalkFilteredNestedSections(
+                    memberElement, ns, elementNode, childPath, childIndexStack,
+                    elementUdt, elementPathWithinUdt, unresolvedUdts, elementChildrenList);
+
+                if (!hadNestedSections
+                    && elementUdt != null
+                    && _udtResolver != null
+                    && !_udtResolver.HasType(elementUdt))
                 {
                     // No nested sections AND UDT is unknown: flag it so the UI
                     // can prompt the user to export UDTs.
@@ -438,6 +412,43 @@ public class SimaticMLParser
         }
 
         return arrayNode;
+    }
+
+    /// <summary>
+    /// Walks the <c>&lt;Sections&gt;</c> child of <paramref name="memberElement"/>,
+    /// applies <see cref="IsParseableSection"/> to each <c>&lt;Section&gt;</c>,
+    /// and appends the parsed members from every surviving section to
+    /// <paramref name="target"/>. Shared by both the non-array and array-of-UDT
+    /// branches so the section filter cannot drift between the two call sites (#77).
+    /// Returns true when a <c>&lt;Sections&gt;</c> element was found (regardless of
+    /// whether any of its <c>&lt;Section&gt;</c> children survived the filter), so
+    /// callers that need an "unresolved UDT" fallback can distinguish "no nested
+    /// sections at all" from "nested sections all filtered out".
+    /// </summary>
+    private bool WalkFilteredNestedSections(
+        XElement memberElement,
+        XNamespace fallbackNs,
+        MemberNode parentNode,
+        string path,
+        IReadOnlyList<string> indexStack,
+        string? enclosingUdt,
+        string pathWithinUdt,
+        HashSet<string> unresolvedUdts,
+        List<MemberNode> target)
+    {
+        var nestedSections = LocalElement(memberElement, Sections);
+        if (nestedSections == null) return false;
+        var nestedNs = nestedSections.Name.Namespace;
+        if (nestedNs == XNamespace.None) nestedNs = fallbackNs;
+        foreach (var section in LocalElements(nestedSections, Section))
+        {
+            if (!IsParseableSection(section.Attribute(Name)?.Value)) continue;
+            var sectionChildren = ParseMembers(
+                section, nestedNs, parentNode, path, indexStack,
+                enclosingUdt, pathWithinUdt, unresolvedUdts);
+            target.AddRange(sectionChildren);
+        }
+        return true;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- **Parser fix for #77** — drop `InOut`/`Temp`/`Constant` sections when walking nested sub-FB instances. Instance DBs of multi-instance FBs no longer materialise interface-pointer noise (`Array[0..999] of UDT` × N sub-FBs) into the tree. Gen_Main_IDB: 171,873 → 17,175 members; OuterFb_IDB: 10,006 → 4. The 9 GB freeze on opening an FB instance DB is resolved. Validated end-to-end in real TIA V20 against both `OuterFb_IDB` (the small hand-crafted reproducer) and `Gen_Main_IDB` (the customer DB that originally surfaced #77).
- **Partial-trust CAS fix** discovered while validating the above. `UiZoomService.PersistenceEnabled` was emitting `ldflda` on a `readonly` field of a `readonly struct`, which .NET Framework 4.8's IL verifier inside TIA's `SandboxDomain` rejects with `VerificationException: "Operation could destabilize the runtime."` This crashed BulkChange silently right after the dialog appeared — invisible to CI/tests/DevLauncher because all of those run in full trust. Workaround: copy the struct to a local before calling instance members. Regression introduced by the storage refactor in d4c5338. CI gap filed as #130 (run PEVerify on the built assembly).

## Commits

| SHA | Type | Notes |
|---|---|---|
| `0da0795` | test | New `instance-db-multi-instance.xml` fixture (hand-crafted `OuterFb_IDB` export) + RED regression test. Test currently fails by 9,974 phantom `bigArray.*` paths from the inner FB's InOut UDT. |
| `e866da1` | fix | Parser filters nested sections to `Static`/`Input`/`Output`/`None` only. Two call sites: `ParseMembers` and `ExpandArrayMember`. The single-call helper `IsParseableSection` documents the inclusion rationale. RED → GREEN. |
| `3a1490c` | fix | `UiZoomService.PersistenceEnabled` reads via a local copy. Unrelated to #77 in scope but blocks end-to-end validation. Filed for separate review consideration; safe to cherry-pick on its own. |

## Test plan

- [x] **Unit**: `Parse_InstanceDB_MultiInstance_DropsInOutSectionsInsideSubFb` GREEN. All 42 parser tests pass. Full suite 996/997 (one pre-existing timezone test unrelated to this PR).
- [x] **End-to-end in real TIA V20**:
  - `OuterFb_IDB` (small reproducer): opens promptly, tree shows the inner FB instance + 3 editable Static Bools, no `bigArray.*` rows. No crash.
  - `Gen_Main_IDB` (customer DB, formerly 9 GB freezer): opens, tree shows real Static descendants without InOut bloat. No crash.
- [x] CAS fix verified by Siemens crash dump pinpointing the original stack frame; after fix no `VerificationException` thrown when the BulkChange dialog Loaded event fires.

## Validation evidence

User confirmed in real TIA on 2026-05-15 after deploying v1.0.14 with these commits:
> "it is working as expected"

[run-ci]

Closes #77