### PR TITLE
fix: FileSystemBlockParamStorage.GetLastWriteTime timezone-safe epoch

### DIFF
--- a/src/BlockParam/Services/Storage/FileSystemBlockParamStorage.cs
+++ b/src/BlockParam/Services/Storage/FileSystemBlockParamStorage.cs
@@ -64,7 +64,10 @@ public sealed class FileSystemBlockParamStorage : IBlockParamStorage
             Directory.Delete(path.FullPath);
     }
 
-    public DateTime GetLastWriteTime(StoragePath path) => File.GetLastWriteTime(path.FullPath);
+    public DateTime GetLastWriteTime(StoragePath path) =>
+        File.Exists(path.FullPath)
+            ? File.GetLastWriteTime(path.FullPath)
+            : new DateTime(1601, 1, 1); // FILETIME epoch; matches in-memory contract
 
     public IEnumerable<StoragePath> EnumerateFiles(
         StoragePath directory, string pattern = "*", bool recursive = false)

--- a/src/BlockParam/Services/Storage/IBlockParamStorage.cs
+++ b/src/BlockParam/Services/Storage/IBlockParamStorage.cs
@@ -55,10 +55,10 @@ public interface IBlockParamStorage
     void DeleteDirectory(StoragePath path);
 
     /// <summary>
-    /// Returns the last write time, or the FILETIME epoch
-    /// (<c>1601-01-01</c>) if the file does not exist. Mirrors
-    /// <see cref="File.GetLastWriteTime"/> so callers don't need a separate
-    /// existence check before stat'ing.
+    /// Returns the last write time (local time), or exactly
+    /// <c>new DateTime(1601, 1, 1)</c> (the FILETIME epoch, Kind=Unspecified)
+    /// if the file does not exist — so callers don't need a separate existence
+    /// check before stat'ing and the sentinel is timezone-independent.
     /// </summary>
     DateTime GetLastWriteTime(StoragePath path);
 


### PR DESCRIPTION
## Root cause and fix

`File.GetLastWriteTime` returns the FILETIME epoch (1601-01-01 00:00) in **local time** for missing files. On a CET machine (UTC+1) this resolves to `1601-01-01 01:00:00`, causing the test `GetLastWriteTime_on_missing_file_returns_FILETIME_epoch` to fail with "expected `1601-01-01` but found `1601-01-01 01:00:00`".

The fix adds a `File.Exists` guard in `FileSystemBlockParamStorage.GetLastWriteTime`: for missing files the FILETIME epoch is returned directly as `new DateTime(1601, 1, 1)` (Kind=Unspecified), exactly matching the in-memory implementation's contract and making the sentinel value timezone-independent. For existing files the existing behavior is preserved — `File.GetLastWriteTime` still returns local time, which is consistent with callers like `TempCacheCleanup` that compare against `DateTime.Now`.

The interface doc comment is updated to be explicit that the sentinel is timezone-independent rather than claiming it "mirrors `File.GetLastWriteTime`" (which is the source of the confusion).

This was surfaced as the pre-existing baseline failure during the housekeeping batch — no GitHub issue exists for it.