### PR TITLE
fix(#130): partial-trust IL fix + PEVerify gate, sandbox test, flake fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,16 @@ jobs:
           path: '**/TestResults/*.trx'
 
   # Split into its own job so Build+Test (above) and the partial-trust IL
-  # gate report as separate check-runs. This job is EXPECTED RED until the
-  # remaining readonly-struct IL fix lands (issue #130): a red here means
-  # the static gate is catching unverifiable partial-trust IL, NOT that the
-  # build is broken (see PR #133). The *green* runtime regression gate for
-  # the same bug class is PartialTrustSandboxTests in the v20 job — keep
-  # both: PEVerify is the static net, the AppDomain smoke test is the
-  # behavioral one (PEVerify alone does not flag this pattern).
+  # gate report as separate check-runs. This job MUST be GREEN: issue #130
+  # is fixed (PR #133), so a clean run prints
+  # "All Classes and Methods in BlockParam.dll Verified." A red here means
+  # a NEW partial-trust IL regression has landed (unverifiable IL that
+  # crashes under TIA's Add-In Loader sandbox but passes full-trust
+  # CI/DevLauncher) — treat it as a real failure, not "by design". The
+  # *runtime* regression gate for the same bug class is
+  # PartialTrustSandboxTests in the v20 job — keep both: PEVerify is the
+  # static net, the AppDomain smoke test is the behavioral one (PEVerify
+  # alone does not flag every variant of this pattern).
   peverify:
     name: Partial-trust IL gate (V20 PEVerify)
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,49 @@ jobs:
       - name: Test
         run: dotnet test src/BlockParam.Tests/BlockParam.Tests.csproj -c Release --no-build -p:UseSiemensStubs=true --logger "trx;LogFileName=test-results.trx"
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: '**/TestResults/*.trx'
+
+  # Split into its own job so Build+Test (above) and the partial-trust IL
+  # gate report as separate check-runs. This job is EXPECTED RED until the
+  # remaining readonly-struct IL fix lands (issue #130): a red here means
+  # the static gate is catching unverifiable partial-trust IL, NOT that the
+  # build is broken (see PR #133). The *green* runtime regression gate for
+  # the same bug class is PartialTrustSandboxTests in the v20 job — keep
+  # both: PEVerify is the static net, the AppDomain smoke test is the
+  # behavioral one (PEVerify alone does not flag this pattern).
+  peverify:
+    name: Partial-trust IL gate (V20 PEVerify)
+    runs-on: windows-latest
+    if: |
+      github.event_name != 'push' ||
+      contains(github.event.head_commit.message, '[run-ci]')
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-v20-${{ hashFiles('**/*.csproj') }}
+          restore-keys: ${{ runner.os }}-nuget-v20-
+
+      - name: Restore
+        run: dotnet restore src/BlockParam/BlockParam.csproj -p:UseSiemensStubs=true
+
+      - name: Build (Release)
+        run: dotnet build src/BlockParam/BlockParam.csproj -c Release --no-restore -p:UseSiemensStubs=true
+
       # PEVerify catches partial-trust IL patterns that crash the assembly
       # under TIA's Add-In Loader sandbox but pass full-trust CI/DevLauncher.
       # Greatest-hit regression: `ldflda` + `call` on a readonly-struct field
@@ -91,13 +134,6 @@ jobs:
           name: peverify-log
           path: peverify-output/peverify.log
           if-no-files-found: ignore
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: '**/TestResults/*.trx'
 
   v21:
     name: Build (V21, net48)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,45 @@ jobs:
       - name: Test
         run: dotnet test src/BlockParam.Tests/BlockParam.Tests.csproj -c Release --no-build -p:UseSiemensStubs=true --logger "trx;LogFileName=test-results.trx"
 
+      # PEVerify catches partial-trust IL patterns that crash the assembly
+      # under TIA's Add-In Loader sandbox but pass full-trust CI/DevLauncher.
+      # Greatest-hit regression: `ldflda` + `call` on a readonly-struct field
+      # (e.g. `!_settingsPath.IsEmpty` on a readonly StoragePath), which the
+      # .NET Framework 4.8 partial-trust verifier rejects as
+      # `VerificationException: Operation could destabilize the runtime`.
+      # See issue #130 for the full story; #77 is the freeze that exposed it.
+      #
+      # Expected output on a clean build:
+      #   All Classes and Methods in BlockParam.dll Verified.
+      #
+      # If a false positive lands on a compiler-generated type, mask it with
+      # `/IGNORE=0x<hex>` and leave a one-line comment per masked code.
+      - name: PEVerify (catch partial-trust IL regressions)
+        shell: pwsh
+        run: |
+          $peverify = Get-ChildItem 'C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\PEVerify.exe' | Select-Object -First 1
+          if (-not $peverify) { throw "PEVerify.exe not found on the runner — check the NETFX 4.8 Tools path." }
+          New-Item -ItemType Directory -Force -Path peverify-output | Out-Null
+          $logPath = "peverify-output/peverify.log"
+          & $peverify.FullName src\BlockParam\bin\Release\net48\BlockParam.dll /IL /UNIQUE *>&1 | Tee-Object -FilePath $logPath
+          $peExit = $LASTEXITCODE
+          Write-Host ""
+          Write-Host "=== PEVerify exit code: $peExit ==="
+          if ($peExit -ne 0) {
+            Write-Host ""
+            Write-Host "=== First 80 diagnostic lines ==="
+            Get-Content $logPath -TotalCount 80
+            exit 1
+          }
+
+      - name: Upload PEVerify log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: peverify-log
+          path: peverify-output/peverify.log
+          if-no-files-found: ignore
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,18 +80,32 @@ After deployment, restart TIA Portal to load the new version.
 
 ## CI (GitHub Actions)
 
-One workflow: `.github/workflows/ci.yml`. Two jobs, both on `windows-latest`:
+One workflow: `.github/workflows/ci.yml`. Three jobs, all on `windows-latest`:
 
 | Job | Runs |
 |---|---|
-| `v20` | Build + xUnit tests + PEVerify against the V20 stub set |
+| `v20` | Build + xUnit tests against the V20 stub set (incl. `PartialTrustSandboxTests`) |
+| `peverify` | Build BlockParam.dll + `PEVerify.exe /IL /UNIQUE` (issue #130) |
 | `v21` | Build only (V21 output dir `bin\…\v21\` isn't on the Tests/DevLauncher resolution path) |
 
-The `v20` PEVerify step (issue #130) runs `PEVerify.exe /IL /UNIQUE`
-on `src\BlockParam\bin\Release\net48\BlockParam.dll` after tests. It catches
-partial-trust IL patterns (e.g. `ldflda` + `call` on a readonly-struct field)
-that would crash the assembly under TIA's Add-In Loader sandbox but pass
-full-trust CI/DevLauncher. A clean green run prints:
+The partial-trust IL gate is **two layers, kept separate on purpose**:
+
+- **`peverify` job (static):** runs `PEVerify.exe /IL /UNIQUE` on
+  `src\BlockParam\bin\Release\net48\BlockParam.dll`. Split out of `v20`
+  so its conclusion is its own check-run — it is **expected RED** until
+  the remaining readonly-struct IL fix lands (#130); a red here means
+  the gate is catching unverifiable IL, not that the build broke.
+- **`PartialTrustSandboxTests` (behavioral, in `v20`):** re-creates TIA's
+  Add-In Loader sandbox in a homogeneous Execution-only AppDomain and
+  JITs the method under partial trust. PEVerify/ILVerify both *pass*
+  `ldflda`+`call` on a readonly-struct field, so this runtime test is the
+  only **green** regression gate for the class of bug #131 fixed; it
+  includes a self-test canary that fails loudly if the runner stops
+  enforcing verification (so a green is never a false negative).
+
+PEVerify catches partial-trust IL patterns (e.g. `ldflda` + `call` on a
+readonly-struct field) that would crash the assembly under TIA's Add-In
+Loader sandbox but pass full-trust CI/DevLauncher. A clean green run prints:
 
 ```
 All Classes and Methods in BlockParam.dll Verified.
@@ -107,7 +121,7 @@ If a real false positive lands on a compiler-generated type, mask the
 specific diagnostic with `/IGNORE=0x<hex>` and leave a one-line comment per
 masked code in the workflow.
 
-Both jobs build with `-p:UseSiemensStubs=true`. The stubs live in
+All build jobs use `-p:UseSiemensStubs=true`. The stubs live in
 `ci/stubs/Siemens.Engineering.Stubs/` (clean-room API-surface only — no
 Siemens code, never shipped). Hosted runners have no TIA Portal install,
 so without the stubs the real Openness references can't resolve.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,9 +92,12 @@ The partial-trust IL gate is **two layers, kept separate on purpose**:
 
 - **`peverify` job (static):** runs `PEVerify.exe /IL /UNIQUE` on
   `src\BlockParam\bin\Release\net48\BlockParam.dll`. Split out of `v20`
-  so its conclusion is its own check-run — it is **expected RED** until
-  the remaining readonly-struct IL fix lands (#130); a red here means
-  the gate is catching unverifiable IL, not that the build broke.
+  so its conclusion is its own check-run. It **must be GREEN** — #130 is
+  fixed (PR #133), so a clean run prints
+  `All Classes and Methods in BlockParam.dll Verified.` A red here means
+  a **new** partial-trust IL regression landed (unverifiable IL that
+  crashes under TIA's sandbox but passes full-trust CI) — treat it as a
+  real failure, not "by design".
 - **`PartialTrustSandboxTests` (behavioral, in `v20`):** re-creates TIA's
   Add-In Loader sandbox in a homogeneous Execution-only AppDomain and
   JITs the method under partial trust. PEVerify/ILVerify both *pass*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,28 @@ One workflow: `.github/workflows/ci.yml`. Two jobs, both on `windows-latest`:
 
 | Job | Runs |
 |---|---|
-| `v20` | Build + xUnit tests against the V20 stub set |
+| `v20` | Build + xUnit tests + PEVerify against the V20 stub set |
 | `v21` | Build only (V21 output dir `bin\…\v21\` isn't on the Tests/DevLauncher resolution path) |
+
+The `v20` PEVerify step (issue #130) runs `PEVerify.exe /IL /UNIQUE`
+on `src\BlockParam\bin\Release\net48\BlockParam.dll` after tests. It catches
+partial-trust IL patterns (e.g. `ldflda` + `call` on a readonly-struct field)
+that would crash the assembly under TIA's Add-In Loader sandbox but pass
+full-trust CI/DevLauncher. A clean green run prints:
+
+```
+All Classes and Methods in BlockParam.dll Verified.
+```
+
+A failure looks like:
+
+```
+[IL]: Error: [...::get_PersistenceEnabled][offset 0x...] Unmanaged pointers are not a verifiable type.
+```
+
+If a real false positive lands on a compiler-generated type, mask the
+specific diagnostic with `/IGNORE=0x<hex>` and leave a one-line comment per
+masked code in the workflow.
 
 Both jobs build with `-p:UseSiemensStubs=true`. The stubs live in
 `ci/stubs/Siemens.Engineering.Stubs/` (clean-room API-surface only — no

--- a/src/BlockParam.Tests/AssemblyInfo.cs
+++ b/src/BlockParam.Tests/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using Xunit;
+
+// WPF has process-wide static state (default collection views, theme/
+// resource dictionaries, TypeDescriptor) that is not safe to touch from
+// multiple STA threads at once. xUnit runs test collections in parallel
+// by default, so [UIFact] classes across files raced and intermittently
+// threw ArgumentOutOfRangeException inside a WPF control constructor
+// (e.g. PillMultiSelect). The suite runs in ~7s, so serializing is a
+// negligible cost for removing the entire class of WPF/STA flakiness.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/src/BlockParam.Tests/PartialTrustSandboxTests.cs
+++ b/src/BlockParam.Tests/PartialTrustSandboxTests.cs
@@ -38,10 +38,18 @@ public sealed class PartialTrustSandboxTests
     [Fact]
     public void PersistenceEnabled_is_verifiable_under_partial_trust()
     {
-        var domain = CreateTiaLikeSandbox();
+        var baseDir = ProbeDir();
+        var domain = CreateTiaLikeSandbox(baseDir);
         try
         {
             var worker = CreateWorker(domain);
+            // vstest resolves BlockParam.dll in the default domain via its
+            // own AssemblyResolver; a bare child-domain ApplicationBase
+            // context does not. Install a resolver in the sandbox BEFORE
+            // ProbeUiZoomService is JIT-compiled (the JIT binds UiZoomService
+            // on method entry, so a missing resolver throws FileNotFound
+            // before the probe's own try/catch can run).
+            worker.InstallAssemblyResolver(baseDir);
             var result = worker.ProbeUiZoomService();
 
             // "A:OK"  -> #131 local-copy discipline present; IL verifies.
@@ -62,10 +70,12 @@ public sealed class PartialTrustSandboxTests
     [Fact]
     public void Sandbox_actually_enforces_IL_verification()
     {
-        var domain = CreateTiaLikeSandbox();
+        var baseDir = ProbeDir();
+        var domain = CreateTiaLikeSandbox(baseDir);
         try
         {
             var worker = CreateWorker(domain);
+            worker.InstallAssemblyResolver(baseDir);
             var result = worker.ProbeCanary();
 
             // "B:REJECTED" is the GOOD outcome: the sandbox verified IL and
@@ -85,21 +95,40 @@ public sealed class PartialTrustSandboxTests
         }
     }
 
+    // Directory holding the built BlockParam.dll + deps (the test output
+    // dir). Not a storage-layer concern: this only computes an AppDomain
+    // ApplicationBase for the test harness — no production path literal,
+    // no File.*/Directory.* against a BlockParam data location.
+    private static string ProbeDir()
+    {
+        var loc = typeof(PartialTrustSandboxTests).Assembly.Location;
+        return !string.IsNullOrEmpty(loc)
+            ? Path.GetDirectoryName(loc)!
+            : AppDomain.CurrentDomain.BaseDirectory;
+    }
+
     /// <summary>
     /// Homogeneous (sandboxed) AppDomain whose grant set mirrors what TIA's
-    /// Add-In Loader gives an Add-In: execution only, no full-trust assembly
-    /// list — so BlockParam.dll receives the partial grant and the CLR runs
-    /// the IL verifier on its methods at JIT, just like inside TIA Portal.
-    /// No FileIOPermission is needed: the probe uses an empty settings path,
-    /// which disables persistence before any storage call is reached.
+    /// Add-In Loader gives an Add-In: a restricted partial-trust set — so
+    /// BlockParam.dll receives the partial grant and the CLR runs the IL
+    /// verifier on its methods at JIT, just like inside TIA Portal.
+    ///
+    /// The grant adds Read/PathDiscovery for <paramref name="baseDir"/> and
+    /// ControlAppDomain purely so the in-sandbox <c>AssemblyResolve</c> hook
+    /// can <c>LoadFrom</c> BlockParam.dll + deps (vstest's own resolver does
+    /// not extend into a child domain). Critically this stays *partial*
+    /// trust — IL verification remains active, which the canary fact
+    /// independently re-proves on every run, so it is never a false green.
     /// </summary>
-    private static AppDomain CreateTiaLikeSandbox()
+    private static AppDomain CreateTiaLikeSandbox(string baseDir)
     {
-        var baseDir = Path.GetDirectoryName(typeof(PartialTrustSandboxTests).Assembly.Location)!;
         var setup = new AppDomainSetup { ApplicationBase = baseDir };
 
         var grant = new PermissionSet(PermissionState.None);
-        grant.AddPermission(new SecurityPermission(SecurityPermissionFlag.Execution));
+        grant.AddPermission(new SecurityPermission(
+            SecurityPermissionFlag.Execution | SecurityPermissionFlag.ControlAppDomain));
+        grant.AddPermission(new FileIOPermission(
+            FileIOPermissionAccess.Read | FileIOPermissionAccess.PathDiscovery, baseDir));
 
         return AppDomain.CreateDomain("BlockParam.PartialTrust.Smoke", null, setup, grant);
     }
@@ -119,6 +148,24 @@ public sealed class PartialTrustSandboxTests
 /// </summary>
 public sealed class PartialTrustWorker : MarshalByRefObject
 {
+    /// <summary>
+    /// Registers an <see cref="AppDomain.AssemblyResolve"/> handler that
+    /// loads any requested assembly from <paramref name="probeDir"/> (the
+    /// test output dir). Runs in the sandbox; references nothing from
+    /// BlockParam.dll, so JIT-compiling it does NOT trigger the very load
+    /// it exists to satisfy. Must be called before any probe.
+    /// </summary>
+    public void InstallAssemblyResolver(string probeDir)
+    {
+        AppDomain.CurrentDomain.AssemblyResolve += (_, args) =>
+        {
+            var simpleName = new AssemblyName(args.Name).Name;
+            if (string.IsNullOrEmpty(simpleName)) return null;
+            var candidate = Path.Combine(probeDir, simpleName! + ".dll");
+            return File.Exists(candidate) ? Assembly.LoadFrom(candidate) : null;
+        };
+    }
+
     /// <summary>
     /// Exercises the exact path TIA's loader hit: constructing the service
     /// (empty path → persistence disabled, zero I/O) and reading

--- a/src/BlockParam.Tests/PartialTrustSandboxTests.cs
+++ b/src/BlockParam.Tests/PartialTrustSandboxTests.cs
@@ -37,7 +37,7 @@ public sealed class PartialTrustSandboxTests
     [Fact]
     public void PersistenceEnabled_is_verifiable_under_partial_trust()
     {
-        var baseDir = ProbeDir();
+        var baseDir = StageAssemblies();
         var domain = CreateTiaLikeSandbox(baseDir);
         try
         {
@@ -55,14 +55,15 @@ public sealed class PartialTrustSandboxTests
         }
         finally
         {
-            AppDomain.Unload(domain);
+            try { AppDomain.Unload(domain); }
+            finally { TryDeleteDir(baseDir); }
         }
     }
 
     [Fact]
     public void Sandbox_actually_enforces_IL_verification()
     {
-        var baseDir = ProbeDir();
+        var baseDir = StageAssemblies();
         var domain = CreateTiaLikeSandbox(baseDir);
         try
         {
@@ -82,28 +83,49 @@ public sealed class PartialTrustSandboxTests
         }
         finally
         {
-            AppDomain.Unload(domain);
+            try { AppDomain.Unload(domain); }
+            finally { TryDeleteDir(baseDir); }
         }
     }
 
-    // ApplicationBase for the sandbox: BlockParam.dll's OWN directory.
-    // Anchoring on the production assembly (not the test assembly) is
-    // deliberate — vstest shadow-copies the test assembly, so its
-    // Location points at a host dir with no BlockParam.dll, whereas
-    // typeof(UiZoomService).Assembly.Location is by definition the dir
-    // that contains BlockParam.dll plus the build-output copy of the
-    // test assembly + deps, so the trusted loader resolves everything
-    // from one ApplicationBase with no AssemblyResolve hook.
-    //
-    // Not a storage-layer concern: this only computes an AppDomain
-    // ApplicationBase for the test harness — no production path literal,
-    // no File.*/Directory.* against a BlockParam data location.
-    private static string ProbeDir()
+    private static string AsmDir(Type t)
     {
-        var loc = typeof(UiZoomService).Assembly.Location;
+        var loc = t.Assembly.Location;
         return !string.IsNullOrEmpty(loc)
             ? Path.GetDirectoryName(loc)!
             : AppDomain.CurrentDomain.BaseDirectory;
+    }
+
+    // vstest shadow-copies the test assembly, so BlockParam.dll and
+    // BlockParam.Tests.dll live in different directories at run time and
+    // no single ApplicationBase contains both. Stage the union of both
+    // output dirs into one temp dir so the sandbox's trusted loader
+    // resolves everything (incl. Newtonsoft) from ApplicationBase — no
+    // AssemblyResolve hook (transparent partial-trust code may not
+    // install one) and no grant beyond Execution. Harness infrastructure,
+    // not subject to the storage-layer guardrail.
+    private static string StageAssemblies()
+    {
+        var staging = Path.Combine(
+            Path.GetTempPath(), "BlockParamPT-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(staging);
+        foreach (var src in new[]
+                 {
+                     AsmDir(typeof(UiZoomService)),
+                     AsmDir(typeof(PartialTrustSandboxTests)),
+                 })
+        {
+            foreach (var dll in Directory.GetFiles(src, "*.dll"))
+                File.Copy(dll, Path.Combine(staging, Path.GetFileName(dll)), overwrite: true);
+        }
+        return staging;
+    }
+
+    private static void TryDeleteDir(string dir)
+    {
+        try { Directory.Delete(dir, recursive: true); }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
     }
 
     /// <summary>

--- a/src/BlockParam.Tests/PartialTrustSandboxTests.cs
+++ b/src/BlockParam.Tests/PartialTrustSandboxTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Security;
 using System.Security.Permissions;
 using BlockParam.Services;
@@ -88,33 +90,50 @@ public sealed class PartialTrustSandboxTests
         }
     }
 
-    private static string AsmDir(Type t)
+    // The ORIGINAL deployed directory of an assembly. vstest shadow-copies
+    // assemblies into incomplete per-assembly cache dirs, so Assembly.Location
+    // points at a dir that holds that one DLL but not its dependency closure.
+    // Assembly.CodeBase is preserved as the original build-output path even
+    // under shadow copy (valid on .NET Framework 4.8, the test TFM) — that
+    // directory contains the full copy-local closure.
+    private static string CodeBaseDir(Assembly a)
     {
-        var loc = t.Assembly.Location;
-        return !string.IsNullOrEmpty(loc)
-            ? Path.GetDirectoryName(loc)!
-            : AppDomain.CurrentDomain.BaseDirectory;
+        if (!a.IsDynamic && !string.IsNullOrEmpty(a.CodeBase))
+        {
+            var uri = new Uri(a.CodeBase);
+            if (uri.IsFile)
+                return Path.GetDirectoryName(uri.LocalPath)!;
+        }
+        var loc = a.IsDynamic ? null : a.Location;
+        return string.IsNullOrEmpty(loc)
+            ? AppDomain.CurrentDomain.BaseDirectory
+            : Path.GetDirectoryName(loc)!;
     }
 
-    // vstest shadow-copies the test assembly, so BlockParam.dll and
-    // BlockParam.Tests.dll live in different directories at run time and
-    // no single ApplicationBase contains both. Stage the union of both
-    // output dirs into one temp dir so the sandbox's trusted loader
-    // resolves everything (incl. Newtonsoft) from ApplicationBase — no
-    // AssemblyResolve hook (transparent partial-trust code may not
-    // install one) and no grant beyond Execution. Harness infrastructure,
-    // not subject to the storage-layer guardrail.
+    // No single existing dir contains the whole closure (BlockParam.dll +
+    // BlockParam.Tests.dll + Newtonsoft + deps) because of vstest shadow
+    // copy. Stage the union of the test and production build-output dirs
+    // (resolved via CodeBase, which survives shadow copy) into one temp
+    // dir; the sandbox's trusted loader then resolves everything from
+    // ApplicationBase with no AssemblyResolve hook (transparent
+    // partial-trust code may not install one) and no grant beyond
+    // Execution. Harness infrastructure — not subject to the storage-layer
+    // guardrail.
     private static string StageAssemblies()
     {
+        var dirs = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            CodeBaseDir(typeof(PartialTrustSandboxTests).Assembly),
+            CodeBaseDir(typeof(UiZoomService).Assembly),
+            AppDomain.CurrentDomain.BaseDirectory,
+        };
+
         var staging = Path.Combine(
             Path.GetTempPath(), "BlockParamPT-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(staging);
-        foreach (var src in new[]
-                 {
-                     AsmDir(typeof(UiZoomService)),
-                     AsmDir(typeof(PartialTrustSandboxTests)),
-                 })
+        foreach (var src in dirs)
         {
+            if (!Directory.Exists(src)) continue;
             foreach (var dll in Directory.GetFiles(src, "*.dll"))
                 File.Copy(dll, Path.Combine(staging, Path.GetFileName(dll)), overwrite: true);
         }

--- a/src/BlockParam.Tests/PartialTrustSandboxTests.cs
+++ b/src/BlockParam.Tests/PartialTrustSandboxTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Reflection;
 using System.Security;
 using System.Security.Permissions;
 using BlockParam.Services;
@@ -43,13 +42,6 @@ public sealed class PartialTrustSandboxTests
         try
         {
             var worker = CreateWorker(domain);
-            // vstest resolves BlockParam.dll in the default domain via its
-            // own AssemblyResolver; a bare child-domain ApplicationBase
-            // context does not. Install a resolver in the sandbox BEFORE
-            // ProbeUiZoomService is JIT-compiled (the JIT binds UiZoomService
-            // on method entry, so a missing resolver throws FileNotFound
-            // before the probe's own try/catch can run).
-            worker.InstallAssemblyResolver(baseDir);
             var result = worker.ProbeUiZoomService();
 
             // "A:OK"  -> #131 local-copy discipline present; IL verifies.
@@ -75,7 +67,6 @@ public sealed class PartialTrustSandboxTests
         try
         {
             var worker = CreateWorker(domain);
-            worker.InstallAssemblyResolver(baseDir);
             var result = worker.ProbeCanary();
 
             // "B:REJECTED" is the GOOD outcome: the sandbox verified IL and
@@ -95,13 +86,21 @@ public sealed class PartialTrustSandboxTests
         }
     }
 
-    // Directory holding the built BlockParam.dll + deps (the test output
-    // dir). Not a storage-layer concern: this only computes an AppDomain
+    // ApplicationBase for the sandbox: BlockParam.dll's OWN directory.
+    // Anchoring on the production assembly (not the test assembly) is
+    // deliberate — vstest shadow-copies the test assembly, so its
+    // Location points at a host dir with no BlockParam.dll, whereas
+    // typeof(UiZoomService).Assembly.Location is by definition the dir
+    // that contains BlockParam.dll plus the build-output copy of the
+    // test assembly + deps, so the trusted loader resolves everything
+    // from one ApplicationBase with no AssemblyResolve hook.
+    //
+    // Not a storage-layer concern: this only computes an AppDomain
     // ApplicationBase for the test harness — no production path literal,
     // no File.*/Directory.* against a BlockParam data location.
     private static string ProbeDir()
     {
-        var loc = typeof(PartialTrustSandboxTests).Assembly.Location;
+        var loc = typeof(UiZoomService).Assembly.Location;
         return !string.IsNullOrEmpty(loc)
             ? Path.GetDirectoryName(loc)!
             : AppDomain.CurrentDomain.BaseDirectory;
@@ -109,26 +108,19 @@ public sealed class PartialTrustSandboxTests
 
     /// <summary>
     /// Homogeneous (sandboxed) AppDomain whose grant set mirrors what TIA's
-    /// Add-In Loader gives an Add-In: a restricted partial-trust set — so
-    /// BlockParam.dll receives the partial grant and the CLR runs the IL
-    /// verifier on its methods at JIT, just like inside TIA Portal.
-    ///
-    /// The grant adds Read/PathDiscovery for <paramref name="baseDir"/> and
-    /// ControlAppDomain purely so the in-sandbox <c>AssemblyResolve</c> hook
-    /// can <c>LoadFrom</c> BlockParam.dll + deps (vstest's own resolver does
-    /// not extend into a child domain). Critically this stays *partial*
-    /// trust — IL verification remains active, which the canary fact
-    /// independently re-proves on every run, so it is never a false green.
+    /// Add-In Loader gives an Add-In: execution only, no full-trust assembly
+    /// list — so BlockParam.dll receives the partial grant and the CLR runs
+    /// the IL verifier on its methods at JIT, just like inside TIA Portal.
+    /// No FileIOPermission is needed: the probe uses an empty settings path,
+    /// which disables persistence before any storage call is reached, and
+    /// assemblies load from ApplicationBase via the trusted loader.
     /// </summary>
     private static AppDomain CreateTiaLikeSandbox(string baseDir)
     {
         var setup = new AppDomainSetup { ApplicationBase = baseDir };
 
         var grant = new PermissionSet(PermissionState.None);
-        grant.AddPermission(new SecurityPermission(
-            SecurityPermissionFlag.Execution | SecurityPermissionFlag.ControlAppDomain));
-        grant.AddPermission(new FileIOPermission(
-            FileIOPermissionAccess.Read | FileIOPermissionAccess.PathDiscovery, baseDir));
+        grant.AddPermission(new SecurityPermission(SecurityPermissionFlag.Execution));
 
         return AppDomain.CreateDomain("BlockParam.PartialTrust.Smoke", null, setup, grant);
     }
@@ -148,24 +140,6 @@ public sealed class PartialTrustSandboxTests
 /// </summary>
 public sealed class PartialTrustWorker : MarshalByRefObject
 {
-    /// <summary>
-    /// Registers an <see cref="AppDomain.AssemblyResolve"/> handler that
-    /// loads any requested assembly from <paramref name="probeDir"/> (the
-    /// test output dir). Runs in the sandbox; references nothing from
-    /// BlockParam.dll, so JIT-compiling it does NOT trigger the very load
-    /// it exists to satisfy. Must be called before any probe.
-    /// </summary>
-    public void InstallAssemblyResolver(string probeDir)
-    {
-        AppDomain.CurrentDomain.AssemblyResolve += (_, args) =>
-        {
-            var simpleName = new AssemblyName(args.Name).Name;
-            if (string.IsNullOrEmpty(simpleName)) return null;
-            var candidate = Path.Combine(probeDir, simpleName! + ".dll");
-            return File.Exists(candidate) ? Assembly.LoadFrom(candidate) : null;
-        };
-    }
-
     /// <summary>
     /// Exercises the exact path TIA's loader hit: constructing the service
     /// (empty path → persistence disabled, zero I/O) and reading

--- a/src/BlockParam.Tests/PartialTrustSandboxTests.cs
+++ b/src/BlockParam.Tests/PartialTrustSandboxTests.cs
@@ -1,0 +1,193 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Security;
+using System.Security.Permissions;
+using BlockParam.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Reproduces TIA Portal's Add-In Loader sandbox in-process and asserts that
+/// the partial-trust IL regression fixed in #131 (issue #130) stays fixed.
+///
+/// WHY a whole AppDomain instead of a normal unit test or PEVerify:
+///   - The bug is neither a source defect (Roslyn syntax looks harmless) nor
+///     an IL-verifiability defect — PEVerify/ILVerify both pass `ldflda`+`call`
+///     on a readonly-struct field. It is a .NET Framework 4.8 *partial-trust
+///     CAS runtime policy* that only fires inside a restricted AppDomain.
+///   - No SonarQube / FxCop / analyzer rule covers it (legacy CAS, removed in
+///     .NET Core). The only faithful detector is to re-create the runtime
+///     conditions and JIT the method under the partial grant set TIA uses.
+///
+/// Two facts:
+///   * <see cref="PersistenceEnabled_is_verifiable_under_partial_trust"/> is
+///     the regression gate: with #131 in place it is GREEN; revert the
+///     local-copy discipline in <c>UiZoomService.PersistenceEnabled</c> and it
+///     goes RED with a VerificationException — exactly what TIA's loader threw.
+///   * <see cref="Sandbox_actually_enforces_IL_verification"/> is a self-test:
+///     a method carrying the *pre-#131* unverifiable shape MUST be rejected by
+///     the same sandbox. If it isn't, the toolchain/runner no longer enforces
+///     this policy and the regression gate above is inconclusive — so we fail
+///     loudly rather than report a meaningless green.
+/// </summary>
+public sealed class PartialTrustSandboxTests
+{
+    [Fact]
+    public void PersistenceEnabled_is_verifiable_under_partial_trust()
+    {
+        var domain = CreateTiaLikeSandbox();
+        try
+        {
+            var worker = CreateWorker(domain);
+            var result = worker.ProbeUiZoomService();
+
+            // "A:OK"  -> #131 local-copy discipline present; IL verifies.
+            // "A:VERIFY:..." -> regression: direct `!_settingsPath.IsEmpty`
+            //                   re-emitted `ldflda`+`call`, partial trust
+            //                   rejected it — same crash TIA's loader hit.
+            result.Should().Be(
+                "A:OK",
+                "UiZoomService must JIT cleanly under TIA's partial-trust grant; "
+                + "a VerificationException here means the #131 local-copy fix was lost");
+        }
+        finally
+        {
+            AppDomain.Unload(domain);
+        }
+    }
+
+    [Fact]
+    public void Sandbox_actually_enforces_IL_verification()
+    {
+        var domain = CreateTiaLikeSandbox();
+        try
+        {
+            var worker = CreateWorker(domain);
+            var result = worker.ProbeCanary();
+
+            // "B:REJECTED" is the GOOD outcome: the sandbox verified IL and
+            // threw on the deliberate pre-#131 pattern, proving the gate bites.
+            // "B:NOT-REJECTED" means this runner/toolchain no longer enforces
+            // partial-trust verification for this shape — the regression test
+            // above can no longer catch the #130 bug, so this is a hard fail.
+            result.Should().Be(
+                "B:REJECTED",
+                "the partial-trust sandbox must reject the deliberate "
+                + "readonly-struct `ldflda`+`call` canary; if it doesn't, the "
+                + "#130 regression gate is no longer meaningful on this runner");
+        }
+        finally
+        {
+            AppDomain.Unload(domain);
+        }
+    }
+
+    /// <summary>
+    /// Homogeneous (sandboxed) AppDomain whose grant set mirrors what TIA's
+    /// Add-In Loader gives an Add-In: execution only, no full-trust assembly
+    /// list — so BlockParam.dll receives the partial grant and the CLR runs
+    /// the IL verifier on its methods at JIT, just like inside TIA Portal.
+    /// No FileIOPermission is needed: the probe uses an empty settings path,
+    /// which disables persistence before any storage call is reached.
+    /// </summary>
+    private static AppDomain CreateTiaLikeSandbox()
+    {
+        var baseDir = Path.GetDirectoryName(typeof(PartialTrustSandboxTests).Assembly.Location)!;
+        var setup = new AppDomainSetup { ApplicationBase = baseDir };
+
+        var grant = new PermissionSet(PermissionState.None);
+        grant.AddPermission(new SecurityPermission(SecurityPermissionFlag.Execution));
+
+        return AppDomain.CreateDomain("BlockParam.PartialTrust.Smoke", null, setup, grant);
+    }
+
+    private static PartialTrustWorker CreateWorker(AppDomain domain)
+    {
+        var asm = typeof(PartialTrustWorker).Assembly;
+        return (PartialTrustWorker)domain.CreateInstanceAndUnwrap(
+            asm.FullName!, typeof(PartialTrustWorker).FullName!);
+    }
+}
+
+/// <summary>
+/// Runs inside the partial-trust domain. Everything crossing the AppDomain
+/// boundary is a plain string so no test-framework type is ever loaded into
+/// the sandbox and exceptions are translated rather than marshalled.
+/// </summary>
+public sealed class PartialTrustWorker : MarshalByRefObject
+{
+    /// <summary>
+    /// Exercises the exact path TIA's loader hit: constructing the service
+    /// (empty path → persistence disabled, zero I/O) and reading
+    /// <c>ZoomFactor</c>, which forces <c>EnsureLoaded</c> →
+    /// <c>PersistenceEnabled</c> to JIT under partial trust.
+    /// </summary>
+    public string ProbeUiZoomService()
+    {
+        try
+        {
+            var svc = new UiZoomService("");
+            var zoom = svc.ZoomFactor;
+            if (Math.Abs(zoom - UiZoomService.DefaultZoom) > 0.0001)
+                return "A:UNEXPECTED-ZOOM:" + zoom;
+            return "A:OK";
+        }
+        catch (VerificationException ex)
+        {
+            return "A:VERIFY:" + ex.Message;
+        }
+        catch (Exception ex)
+        {
+            return "A:ERR:" + ex.GetType().FullName + ":" + ex.Message;
+        }
+    }
+
+    /// <summary>
+    /// Invokes the deliberate pre-#131 unverifiable shape. Under a sandbox
+    /// that genuinely enforces verification this throws; that throw is the
+    /// proof the regression gate is live.
+    /// </summary>
+    public string ProbeCanary()
+    {
+        try
+        {
+            var hit = new PartialTrustCanary().TouchLikePreFix();
+            return "B:NOT-REJECTED(" + hit + ")";
+        }
+        catch (VerificationException)
+        {
+            return "B:REJECTED";
+        }
+        catch (Exception ex)
+        {
+            return "B:ERR:" + ex.GetType().FullName + ":" + ex.Message;
+        }
+    }
+}
+
+/// <summary>
+/// Mirrors <c>StoragePath</c> 1:1: a <c>readonly struct</c> exposing an
+/// instance property. Reading it through a <c>readonly</c> field (below)
+/// makes Roslyn emit `ldflda`+`call` with no defensive copy — the precise
+/// pattern .NET Framework 4.8 partial trust rejects. Public + called
+/// directly so the sandbox needs no ReflectionPermission.
+/// </summary>
+public readonly struct PartialTrustCanaryStruct
+{
+    private readonly string? _value;
+    public PartialTrustCanaryStruct(string? value) => _value = value;
+    public bool IsEmpty => string.IsNullOrEmpty(_value);
+}
+
+public sealed class PartialTrustCanary
+{
+    private readonly PartialTrustCanaryStruct _path = new("x");
+
+    // Intentionally written the *broken* (pre-#131) way: a direct instance
+    // call on the readonly-struct field instead of copying to a local first.
+    // This is the canary, not production code — it must stay unverifiable.
+    public bool TouchLikePreFix() => !_path.IsEmpty;
+}

--- a/src/BlockParam/UI/ConfigEditorDialog.xaml.cs
+++ b/src/BlockParam/UI/ConfigEditorDialog.xaml.cs
@@ -298,5 +298,24 @@ public partial class ConfigEditorDialog : Window
         return null;
     }
 
-    private record FileSectionVisuals(RuleFileViewModel File, Grid Root, Border Header);
+    // Plain immutable class, not a positional record: a record's `init`
+    // accessors emit `stfld` to an initonly backing field outside .ctor,
+    // which the .NET Framework 4.8 partial-trust verifier rejects
+    // ("Cannot change initonly field outside its .ctor") and crashes the
+    // Add-In under TIA's CAS sandbox. Get-only auto-properties assigned in
+    // the constructor are verifiable. Reference identity + plain property
+    // reads are all this type is used for (no value-equality / with).
+    private sealed class FileSectionVisuals
+    {
+        public FileSectionVisuals(RuleFileViewModel file, Grid root, Border header)
+        {
+            File = file;
+            Root = root;
+            Header = header;
+        }
+
+        public RuleFileViewModel File { get; }
+        public Grid Root { get; }
+        public Border Header { get; }
+    }
 }


### PR DESCRIPTION
## Summary

Resolves the partial-trust IL defect and stands up a two-layer gate so it
can't regress, plus an unrelated test-infra flake fix found along the way.

- **Fixes the IL defect (#130):** `ConfigEditorDialog.FileSectionVisuals`
  was a positional `record`; its `init` accessors emit `stfld` to an
  `initonly` backing field outside `.ctor`, which the .NET Framework 4.8
  partial-trust verifier rejects (*"Cannot change initonly field outside
  its .ctor"*) and crashes the Add-In under TIA's CAS sandbox. Converted
  to a plain immutable class with get-only properties set in the ctor
  (verifiable IL). This was PEVerify's only error → **PEVerify is now
  green.**
- **Static gate:** splits `PEVerify.exe /IL /UNIQUE` into its own
  `peverify` check-run. It is now a **must-be-green** gate (docs updated;
  no longer "expected red by design").
- **Behavioral gate:** adds `PartialTrustSandboxTests` — an in-process
  Execution-only AppDomain that reproduces TIA's Add-In Loader sandbox and
  JITs the method under the same grant set. Two facts: a regression gate
  (`UiZoomService` must JIT cleanly) and a self-test canary (the sandbox
  must reject the deliberate pre-#131 unverifiable shape, so a green can
  never be a false negative). Assemblies are staged via `Assembly.CodeBase`
  into one ApplicationBase so the closure resolves under vstest shadow
  copy without an AssemblyResolve hook.
- **Test flake fix:** WPF process-wide statics aren't safe across parallel
  STA threads; `[UIFact]` classes raced and intermittently threw
  `ArgumentOutOfRangeException` in a WPF control ctor. Disabled xUnit
  cross-collection parallelization (~7s suite → negligible cost).
- Merged `main`; CI green on the merge commit.

## Why a runtime test and not just PEVerify

PEVerify is the static net but does not flag every variant of this class
(e.g. `ldflda`+`call` on a readonly-struct field passes PEVerify *and*
ILVerify yet crashes under partial-trust CAS). The AppDomain smoke test is
the behavioral net for those. Keeping both is deliberate.

## Test plan

- [x] V20 Build & Test green (incl. both `PartialTrustSandboxTests` facts)
- [x] PEVerify green (`All Classes and Methods in BlockParam.dll Verified.`)
- [x] V21 Build green
- [x] Green on the `main` merge commit (validates against #137's new tests)

Fixes #130

https://claude.ai/code/session_01WWnZ2TMrJazzcFRc25HzuF