### PR TITLE
refactor(#121): close out #82 — migrate remaining bare-path lookups

### DIFF
--- a/src/BlockParam.Tests/BulkChangeViewModelDbSwitcherTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelDbSwitcherTests.cs
@@ -321,6 +321,176 @@ public class BulkChangeViewModelDbSwitcherTests
             "Apply on B doesn't touch the stash dictionary");
     }
 
+    // ── Multi-PLC same-name tests (#121) ────────────────────────────────────
+
+    /// <summary>
+    /// Builds two <see cref="DataBlockInfo"/> instances with the <b>same name</b>
+    /// but different PLC names — the real-world failure mode for multi-PLC
+    /// projects where two PLCs each export a DB called "DB_Shared". Used by
+    /// the <c>RestoreStashOntoLive</c> routing tests.
+    /// </summary>
+    private static (DataBlockInfo infoA, DataBlockInfo infoB,
+                    MemberNode speedA, MemberNode speedB)
+        BuildTwoPlcsSameDbName()
+    {
+        // Both DBs have the SAME name and the SAME member paths — the
+        // combination that was the original #82 bug and is now extended
+        // to the PLC dimension by #121.
+        const string sharedDbName = "DB_Shared";
+
+        var speedA = new MemberNode("Speed", "Int", "100", "Speed", null,
+            Array.Empty<MemberNode>());
+        var infoA = new DataBlockInfo(
+            sharedDbName, 1, "Optimized", "GlobalDB", new[] { speedA });
+
+        var speedB = new MemberNode("Speed", "Int", "200", "Speed", null,
+            Array.Empty<MemberNode>());
+        var infoB = new DataBlockInfo(
+            sharedDbName, 1, "Optimized", "GlobalDB", new[] { speedB });
+
+        return (infoA, infoB, speedA, speedB);
+    }
+
+    [Fact]
+    public void RestoreStashOntoLive_SameDbNameDifferentPlcs_RoutesToPlcADb()
+    {
+        // #121 — RestoreStashOntoLive must route edits to the DB whose
+        // (Name, PlcName) pair matches the stash's Summary, not to whichever
+        // DB happens to sit first when two DBs share a name across PLCs.
+        //
+        // Scenario: anchor = DB_Shared@PLC_A, peer = DB_Shared@PLC_B.
+        // Stage an edit on PLC_A, stash PLC_A (Keep), reactivate PLC_A.
+        // The restored edit must land on PLC_A's Speed, NOT PLC_B's.
+        var (infoA, infoB, _, _) = BuildTwoPlcsSameDbName();
+        const string plcA = "PLC_A";
+        const string plcB = "PLC_B";
+
+        var configLoader = new ConfigLoader(null);
+        var bulkService = new BulkChangeService(new ChangeLogger(), configLoader);
+        var usageTracker = Substitute.For<IUsageTracker>();
+        usageTracker.GetStatus().Returns(new UsageStatus(0, 100));
+        usageTracker.RecordUsage(Arg.Any<int>()).Returns(true);
+
+        var mbx = new FakeMessageBox(YesNoCancelResult.No);  // Keep on chip-close
+
+        // PLC_B peer starts alongside the PLC_A anchor.
+        var peerB = new ActiveDb(infoB, "<Block name='DB_Shared' />",
+            onApply: _ => { }, plcName: plcB);
+
+        var vm = new BulkChangeViewModel(
+            infoA, "<Block name='DB_Shared' />",
+            new HierarchyAnalyzer(), bulkService, usageTracker, configLoader,
+            onApply: _ => { },
+            messageBox: mbx,
+            currentPlcName: plcA,
+            additionalActiveDbs: new[] { peerB },
+            buildActiveDbForSummary: s => s.PlcName == plcA
+                ? new ActiveDb(infoA, "<Block name='DB_Shared' />",
+                    onApply: _ => { }, plcName: plcA)
+                : null);
+
+        vm.AllActiveDbs.Should().HaveCount(2);
+
+        // Locate each DB by its PLC name, then find Speed via the DB-scoped
+        // path lookup so we never rely on a bare FlatMembers walk (#82 / #121).
+        var dbA = vm.AllActiveDbs.First(d => d.PlcName == plcA);
+        var dbB = vm.AllActiveDbs.First(d => d.PlcName == plcB);
+
+        // Stage on PLC_A's Speed.
+        var plcASpeed = vm.Tree.FindNodeByPathInDb("Speed", dbA);
+        plcASpeed.Should().NotBeNull("PLC_A must have a Speed member");
+        plcASpeed!.EditableStartValue = "999";
+
+        // Remove PLC_A anchor → Keep (stash it). PLC_B stays active.
+        vm.ActiveSet.RequestRemoveActiveDb(dbA);
+
+        vm.AllActiveDbs.Should().HaveCount(1);
+        vm.ActiveSet.StashedDbs.Should().ContainSingle();
+        vm.ActiveSet.StashedDbs[0].Summary.PlcName.Should().Be(plcA,
+            "stash must carry the PLC name so re-activation targets the right DB");
+
+        // PLC_B's Speed must be untouched — no cross-DB bleed.
+        // After stashing PLC_A the active set is single-DB (PLC_B), so
+        // FindNodeByPathInDb with dbB should resolve cleanly.
+        var plcBSpeed = vm.Tree.FindNodeByPathInDb("Speed", dbB);
+        plcBSpeed.Should().NotBeNull("PLC_B must still be active with its Speed member");
+        plcBSpeed!.PendingValue.Should().BeNull(
+            "PLC_B's Speed must NOT carry PLC_A's stashed edit");
+
+        // Reactivate PLC_A → Replace (mbx returns No → Replace path in
+        // AskAddOrReplace — PLC_B is now the only active DB, so |active|=1
+        // skips the prompt and goes through the Replace branch automatically).
+        var stash = vm.ActiveSet.StashedDbs[0];
+        vm.ActiveSet.SwitchToStashedDbCommand.Execute(stash);
+
+        vm.AllActiveDbs.Should().HaveCount(1, "Replace path soloed to PLC_A DB");
+
+        // The restored VM must carry the edit — PLC_A's Speed, not PLC_B's.
+        var restoredSpeed = vm.Tree.RootMembers
+            .SelectMany(r => new[] { r }.Concat(r.AllDescendants()))
+            .First(n => n.IsLeaf && n.Name == "Speed");
+        restoredSpeed.PendingValue.Should().Be("999",
+            "stash restore must land on PLC_A's Speed; first-match-by-name " +
+            "across PLCs would silently route to the wrong tree");
+    }
+
+    [Fact]
+    public void StashRestore_SameDbNameDifferentPlcs_CrossDbScopeDoesNotBleedAcrossPlcs()
+    {
+        // #121 — After reactivating a stashed DB whose name is shared across
+        // PLCs, a subsequent cross-DB scope selection must not confuse the two
+        // DB identities.  Specifically: after PLC_A's Speed is restored to 999,
+        // selecting PLC_A's Speed must not carry PLC_B's StartValue (200).
+        var (infoA, infoB, _, _) = BuildTwoPlcsSameDbName();
+        const string plcA = "PLC_A";
+        const string plcB = "PLC_B";
+
+        var configLoader = new ConfigLoader(null);
+        var bulkService = new BulkChangeService(new ChangeLogger(), configLoader);
+        var usageTracker = Substitute.For<IUsageTracker>();
+        usageTracker.GetStatus().Returns(new UsageStatus(0, 100));
+        usageTracker.RecordUsage(Arg.Any<int>()).Returns(true);
+
+        var mbx = new FakeMessageBox(YesNoCancelResult.No);
+
+        // Start with both PLCs active.
+        var peerB = new ActiveDb(infoB, "<Block name='DB_Shared' />",
+            onApply: _ => { }, plcName: plcB);
+
+        var vm = new BulkChangeViewModel(
+            infoA, "<Block name='DB_Shared' />",
+            new HierarchyAnalyzer(), bulkService, usageTracker, configLoader,
+            onApply: _ => { },
+            messageBox: mbx,
+            currentPlcName: plcA,
+            additionalActiveDbs: new[] { peerB });
+
+        vm.AllActiveDbs.Should().HaveCount(2);
+
+        // Find both Speed VMs — synthetic roots in multi-DB shape.
+        var dbA = vm.AllActiveDbs.First(d => d.PlcName == plcA);
+        var dbB = vm.AllActiveDbs.First(d => d.PlcName == plcB);
+
+        // Locate Speed in each DB via the DB-scoped lookup (#82).
+        var speedAVm = vm.Tree.FindNodeByPathInDb("Speed", dbA);
+        var speedBVm = vm.Tree.FindNodeByPathInDb("Speed", dbB);
+
+        speedAVm.Should().NotBeNull("PLC_A's Speed must exist in the tree");
+        speedBVm.Should().NotBeNull("PLC_B's Speed must exist in the tree");
+        speedAVm.Should().NotBeSameAs(speedBVm,
+            "two PLCs with the same DB name must produce distinct VM instances");
+
+        // Both share the same path string.
+        speedAVm!.Path.Should().Be(speedBVm!.Path,
+            "both have a member named Speed at the same depth");
+
+        // Each DB's VM must carry its own StartValue — no aliasing.
+        speedAVm.StartValue.Should().Be("100",
+            "PLC_A's StartValue must reflect infoA's value");
+        speedBVm.StartValue.Should().Be("200",
+            "PLC_B's StartValue must reflect infoB's value");
+    }
+
     /// <summary>
     /// Convenience enum shared across DB-switcher tests. Yes/No/Cancel maps
     /// onto the three named outcomes for each typed prompt method.

--- a/src/BlockParam.Tests/PendingEditsViewModelTests.cs
+++ b/src/BlockParam.Tests/PendingEditsViewModelTests.cs
@@ -65,7 +65,7 @@ public class PendingEditsViewModelTests
         pressure.EditableStartValue = "42";
 
         var vm = new PendingEditsViewModel(() => 2);
-        vm.Rebuild(new[] { root }, bulkPaths: null);
+        vm.Rebuild(new[] { root }, bulkNodes: null);
 
         vm.PendingEdits.Should().HaveCount(2);
         vm.HasPendingEdits.Should().BeTrue();
@@ -73,14 +73,17 @@ public class PendingEditsViewModelTests
     }
 
     [Fact]
-    public void Rebuild_MarksOverwrittenByBulkWhenPathInBulkSet()
+    public void Rebuild_MarksOverwrittenByBulkWhenNodeInBulkSet()
     {
+        // The bulk-overwrite flag is keyed by VM reference, not path string,
+        // so two DBs sharing a path never alias (#82 / #121).
         var root = BuildTree();
         var speed = FindLeaf(root, "Speed");
         speed.EditableStartValue = "999";
 
         var vm = new PendingEditsViewModel(() => 1);
-        vm.Rebuild(new[] { root }, bulkPaths: new System.Collections.Generic.HashSet<string> { speed.Path });
+        vm.Rebuild(new[] { root },
+            bulkNodes: new System.Collections.Generic.HashSet<MemberNodeViewModel> { speed });
 
         vm.PendingEdits.Should().ContainSingle()
             .Which.WillBeOverwrittenByBulk.Should().BeTrue();

--- a/src/BlockParam/UI/BulkChangeDialog.xaml.cs
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml.cs
@@ -641,11 +641,14 @@ public partial class BulkChangeDialog : Window
     /// <summary>
     /// Finds the inline-edit TextBox for the given member path. Used to
     /// point the cursor at a cell before any typing has happened.
+    /// Delegates the path→VM resolution to the VM's DB-scoped lookup
+    /// (<see cref="BulkChangeViewModel.FindAnchorVmByPath"/>) so the
+    /// lookup is unambiguous in multi-DB sessions (#82 / #121).
     /// </summary>
     private FrameworkElement? FindInlineCell(string path)
     {
         if (DataContext is not BulkChangeViewModel vm) return null;
-        var node = FindFlatByPath(vm, path);
+        var node = vm.FindAnchorVmByPath(path);
         if (node == null) return null;
         MemberListView.ScrollIntoView(node);
         UpdateLayout();
@@ -653,13 +656,6 @@ public partial class BulkChangeDialog : Window
                    as ListViewItem;
         if (item == null) return null;
         return FindDescendant<TextBox>(item, "InlineStartValue");
-    }
-
-    private static MemberNodeViewModel? FindFlatByPath(BulkChangeViewModel vm, string path)
-    {
-        foreach (var m in vm.Tree.FlatMembers)
-            if (m.Path == path) return m;
-        return null;
     }
 
     /// <summary>

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -1104,6 +1104,17 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         OnPropertyChanged(nameof(NewValue));
     }
 
+    /// <summary>
+    /// Scripted-overlay helper: resolves a member path to a VM within the
+    /// anchor (first active) DB.  The scripted overlay only runs in single-DB
+    /// DevLauncher sessions, so scoping to the anchor is always correct.
+    /// Uses <see cref="FindNodeByPathInDb"/> so the lookup is DB-scoped
+    /// rather than a bare <c>FlatMembers</c> walk that could alias across
+    /// DBs (#82 / #121).
+    /// </summary>
+    internal MemberNodeViewModel? FindAnchorVmByPath(string path) =>
+        FindNodeByPathInDb(path, _active);
+
     public void RefreshFlatList()
     {
         // Pre-PR shape (one combined try/finally on the host) is preserved by
@@ -1111,12 +1122,14 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // Tree.RebuildFlatList's insideRefreshScope callback — both still run
         // while Tree.IsRefreshing is true, so SelectedFlatMember setter +
         // code-behind SelectionChanged stay suppressed during the rebuild.
-        var selectedPath = Selection.SelectedFlatMember?.Path;
+        // Capture the model reference (not the path string) so restore is
+        // unambiguous when two DBs share a path (#82 / #121).
+        var selectedModel = Selection.SelectedFlatMember?.Model;
         Tree.RebuildFlatList(insideRefreshScope: () =>
         {
-            if (selectedPath != null)
+            if (selectedModel != null)
             {
-                var restored = Tree.FlatMembers.FirstOrDefault(m => m.Path == selectedPath);
+                var restored = Tree.FindVmByModel(selectedModel);
                 // Silent setter so we don't re-trigger OnMemberSelected during
                 // the rebuild — the slice raises SelectedFlatMember /
                 // HasSelection / SelectedMemberDisplay PropertyChanged for us.
@@ -1399,10 +1412,15 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// </summary>
     private void RebuildPendingEdits()
     {
-        var bulkPaths = BulkPreview.Count > 0
-            ? new HashSet<string>(BulkPreview.Entries.Select(e => e.Path), StringComparer.Ordinal)
+        // Build the set keyed by VM reference so the "will be overwritten by
+        // bulk" flag in PendingEditsViewModel is unambiguous across DBs.
+        // BulkPreviewEntry.Node is the MemberNodeViewModel that will be
+        // targeted; path string was unreliable when two DBs share a path
+        // (#82 / #121).
+        var bulkNodes = BulkPreview.Count > 0
+            ? new HashSet<MemberNodeViewModel>(BulkPreview.Entries.Select(e => e.Node))
             : null;
-        Pending.Rebuild(RootMembers, bulkPaths);
+        Pending.Rebuild(RootMembers, bulkNodes);
     }
 
     /// <summary>
@@ -2856,10 +2874,18 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         foreach (var root in RootMembers)
             CollectExpandStates(root, expandStates);
 
-        // Preserve selection + scope by stable identity (#8). Index-based lookup
-        // broke because OnMemberSelected adds scopes reversed while RefreshTree
-        // used plain order — indices didn't line up after Apply.
-        var selectedPath = Selection.SelectedFlatMember?.Path;
+        // Preserve selection + scope by stable (ActiveDb, path) identity (#8, #82, #121).
+        // Index-based lookup broke because OnMemberSelected adds scopes reversed
+        // while RefreshTree used plain order — indices didn't line up after Apply.
+        // Capture both path AND owning ActiveDb before the re-parse so the restore
+        // uses FindNodeByPathInDb (DB-scoped) rather than a bare FlatMembers walk.
+        // Model reference is stale after re-parse; path is stable across a
+        // structure-preserving re-parse (the Apply case).
+        var selectedFlatMember = Selection.SelectedFlatMember;
+        var selectedPath = selectedFlatMember?.Path;
+        var selectedOwner = selectedFlatMember != null
+            ? Tree.FindActiveDbForModel(selectedFlatMember.Model)
+            : null;
         var selectedScopeAncestorPath = Selection.SelectedScope?.AncestorPath;
         var selectedScopeDepth = Selection.SelectedScope?.Depth;
 
@@ -2892,10 +2918,17 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         ApplyAllFilters();
         RefreshFlatList();
 
-        // Restore selection and re-trigger scope analysis
+        // Restore selection and re-trigger scope analysis. Use the DB-scoped
+        // path lookup (#82 / #121) so the same path string in two different
+        // DBs always resolves to the right one.  Model references are stale
+        // after re-parse; path is stable across a structure-preserving Apply.
+        // Fall back to _active when the owning DB was not found in the index
+        // (e.g. a node from a DB that was since removed) — FindNodeByPathInDb
+        // will return null if the path doesn't exist in that DB anyway.
         if (selectedPath != null)
         {
-            var restored = Tree.FlatMembers.FirstOrDefault(m => m.Path == selectedPath);
+            var owner = selectedOwner ?? _active;
+            var restored = Tree.FindNodeByPathInDb(selectedPath, owner);
             if (restored != null)
             {
                 // Silent setter — RefreshTree re-populates scopes manually

--- a/src/BlockParam/UI/PendingEditsViewModel.cs
+++ b/src/BlockParam/UI/PendingEditsViewModel.cs
@@ -91,13 +91,16 @@ public class PendingEditsViewModel : ViewModelBase
 
     /// <summary>
     /// Rebuild <see cref="PendingEdits"/> from the current tree state.
-    /// Caller passes the pre-built BulkPreview paths so overwritten flags can
-    /// be set on each entry without the slice scanning the preview itself.
+    /// Caller passes the pre-built BulkPreview VM set so overwritten flags
+    /// can be set on each entry without the slice scanning the preview itself.
+    /// Identity is <see cref="MemberNodeViewModel"/> reference — not path
+    /// string — so two DBs sharing a path never falsely alias (#82 / #121).
     /// </summary>
-    public void Rebuild(IEnumerable<MemberNodeViewModel> roots, HashSet<string>? bulkPaths)
+    public void Rebuild(IEnumerable<MemberNodeViewModel> roots,
+        HashSet<MemberNodeViewModel>? bulkNodes)
     {
         PendingEdits.Clear();
-        CollectPendingEntries(roots, bulkPaths);
+        CollectPendingEntries(roots, bulkNodes);
         OnPropertyChanged(nameof(HasPendingEdits));
         RaiseInvalidPendingChanged();
     }
@@ -140,20 +143,23 @@ public class PendingEditsViewModel : ViewModelBase
     }
 
     private void CollectPendingEntries(IEnumerable<MemberNodeViewModel> nodes,
-        HashSet<string>? bulkPaths)
+        HashSet<MemberNodeViewModel>? bulkNodes)
     {
         foreach (var node in nodes)
         {
             if (node.IsPendingInlineEdit)
             {
-                bool overwritten = bulkPaths != null && bulkPaths.Contains(node.Path);
+                // VM reference equality is unambiguous: two DBs that share a
+                // path string produce two distinct MemberNodeViewModel instances
+                // and will never alias (#82 / #121).
+                bool overwritten = bulkNodes != null && bulkNodes.Contains(node);
                 PendingEdits.Add(new PendingEditEntry(
                     node,
                     node.StartValue ?? "",
                     node.PendingValue ?? "",
                     willBeOverwrittenByBulk: overwritten));
             }
-            CollectPendingEntries(node.Children, bulkPaths);
+            CollectPendingEntries(node.Children, bulkNodes);
         }
     }
 


### PR DESCRIPTION
## Summary

Closes the four bare-path lookup sites flagged in #121 (post-merge review of #119/#82) and adds the missing multi-PLC test fixture requested in the issue.

### Migration sites

| Site | Before | After |
|---|---|---|
| `BulkChangeViewModel.RefreshFlatList` | `FlatMembers.FirstOrDefault(m => m.Path == …)` | `Tree.FindVmByModel(selectedModel)` — model reference stable across non-re-parse rebuilds |
| `BulkChangeViewModel.RefreshTree` | `FlatMembers.FirstOrDefault(m => m.Path == …)` | `Tree.FindNodeByPathInDb(path, owner)` — captures owning `ActiveDb` before re-parse; path is stable across a structure-preserving Apply |
| `BulkChangeDialog.xaml.cs FindFlatByPath` | Bare `FlatMembers` walk in code-behind | Retired; delegated to new `internal BulkChangeViewModel.FindAnchorVmByPath` (routes through `FindNodeByPathInDb`) — no business logic in code-behind |
| `PendingEditsViewModel.Rebuild` | `bulkPaths: HashSet<string>`, `Contains(node.Path)` | `bulkNodes: HashSet<MemberNodeViewModel>`, `Contains(node)` — `BulkPreviewEntry.Node` is already the VM; reference equality is unambiguous |

### New test fixture

`BuildTwoPlcsSameDbName()` in `BulkChangeViewModelDbSwitcherTests` builds two `DataBlockInfo` instances with the **same DB name** on different PLCs — the real-world failure mode `StashRestoration_TwoDbsSharePath_RestoresOntoCorrectDb` does NOT cover (it uses `PlcName=""` for both).

Two new tests:
- `RestoreStashOntoLive_SameDbNameDifferentPlcs_RoutesToPlcADb`: stash PLC_A's DB, verify PLC_B is not contaminated, reactivate PLC_A and assert edit lands on PLC_A's Speed.
- `StashRestore_SameDbNameDifferentPlcs_CrossDbScopeDoesNotBleedAcrossPlcs`: verify each PLC's Speed VM holds its own `StartValue` and the VMs are distinct instances.

## Test plan

- [x] `dotnet build BlockParam.sln -c Debug -p:UseSiemensStubs=true` — 0 warnings, 0 errors
- [x] `dotnet test BlockParam.sln -c Debug --no-build` — 1002/1003 pass (pre-existing timezone failure `FileSystemBlockParamStorageTests.GetLastWriteTime_on_missing_file_returns_FILETIME_epoch` unchanged)
- [x] New tests `RestoreStashOntoLive_SameDbNameDifferentPlcs_RoutesToPlcADb` and `StashRestore_SameDbNameDifferentPlcs_CrossDbScopeDoesNotBleedAcrossPlcs` both green

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)