### PR TITLE
refactor(#87): migrate remaining hand-rolled INPC setters to SetProperty<T>

### DIFF
--- a/src/BlockParam/UI/Controls/PillMultiSelect/PillGroupViewModel.cs
+++ b/src/BlockParam/UI/Controls/PillMultiSelect/PillGroupViewModel.cs
@@ -98,9 +98,7 @@ internal sealed class PillGroupViewModel : PillViewModelBase
         get => _isSelected;
         set
         {
-            if (_isSelected == value) return;
-            _isSelected = value;
-            OnPropertyChanged();
+            if (!SetProperty(ref _isSelected, value)) return;
 
             // User-driven write (header checkbox clicked) — push to children.
             // A null write from the user shouldn't happen (XAML uses

--- a/src/BlockParam/UI/DataBlockListItem.cs
+++ b/src/BlockParam/UI/DataBlockListItem.cs
@@ -64,9 +64,7 @@ public class DataBlockListItem : ViewModelBase
         get => _isActive;
         set
         {
-            if (_isActive == value) return;
-            _isActive = value;
-            OnPropertyChanged();
+            if (!SetProperty(ref _isActive, value)) return;
             if (!_suppressToggle)
                 ToggleRequested?.Invoke(this);
         }

--- a/src/BlockParam/UI/InspectorPanelsViewModel.cs
+++ b/src/BlockParam/UI/InspectorPanelsViewModel.cs
@@ -38,10 +38,8 @@ public class InspectorPanelsViewModel : ViewModelBase
         get => _isInspectorCollapsed;
         set
         {
-            if (_isInspectorCollapsed == value) return;
-            _isInspectorCollapsed = value;
-            OnPropertyChanged(nameof(IsInspectorCollapsed));
-            OnPropertyChanged(nameof(IsInspectorExpanded));
+            if (SetProperty(ref _isInspectorCollapsed, value))
+                OnPropertyChanged(nameof(IsInspectorExpanded));
         }
     }
 

--- a/src/BlockParam/UI/SubscriptionViewModel.cs
+++ b/src/BlockParam/UI/SubscriptionViewModel.cs
@@ -119,9 +119,7 @@ public class SubscriptionViewModel : ViewModelBase, IDisposable
         get => _availableUpdate;
         private set
         {
-            if (ReferenceEquals(_availableUpdate, value)) return;
-            _availableUpdate = value;
-            OnPropertyChanged(nameof(AvailableUpdate));
+            if (!SetProperty(ref _availableUpdate, value)) return;
             OnPropertyChanged(nameof(HasUpdateAvailable));
             OnPropertyChanged(nameof(UpdateBadgeText));
             OnPropertyChanged(nameof(UpdateBadgeTooltip));


### PR DESCRIPTION
## Summary

- `BulkChangeViewModel` was already fully migrated to `SetProperty<T>` during the #80 slice work (each extracted slice got the helper applied as part of the move). No remaining hand-rolled patterns existed there.
- This PR sweeps up the four remaining sites in slice VMs and a control VM that were introduced (or left behind) during the #80 split:

| File | Property | Notes |
|---|---|---|
| `InspectorPanelsViewModel` | `IsInspectorCollapsed` | Raises derived `IsInspectorExpanded`; kept as `if (SetProperty(...)) OnPropertyChanged(...)` |
| `DataBlockListItem` | `IsActive` | Fires `ToggleRequested` event; `if (!SetProperty(...)) return;` preserves the side-effect guard |
| `SubscriptionViewModel` | `AvailableUpdate` | Used `ReferenceEquals`; `UpdateInfo` does not override `Equals` so `EqualityComparer<T>.Default.Equals` is equivalent. Additional notifications preserved |
| `PillGroupViewModel` | `IsSelected` | Nullable bool with child-propagation side effects. `RecomputeFromChildren` intentionally bypasses the setter (to avoid pushing aggregate back to children) — left unchanged |

No behaviour change. The `[CallerMemberName]`-based `SetProperty` always picks up the correct property name in each case.

## Skipped sites

`PillItemSource.DisplayMemberPath`, `AbbreviationMemberPath`, and `GroupKeyMemberPath` use equality guards to avoid redundant rebuilds but raise no `OnPropertyChanged` — they are data-plumbing classes, not VMs. Not migrated (no benefit).

`PillGroupViewModel.RecomputeFromChildren` directly sets `_isSelected` and calls `OnPropertyChanged(nameof(IsSelected))` to bypass the setter's child-propagation logic intentionally. Left unchanged to preserve semantics.

## Note on parallel work

Agent for #84 (`BulkChangeDialog.xaml.cs` business-logic extraction) does not touch `BulkChangeViewModel.cs`. No overlap expected.

## Test plan

- [x] `dotnet build BlockParam.sln -c Debug -p:UseSiemensStubs=true` — 0 errors, 0 warnings
- [x] `dotnet test BlockParam.sln -c Debug --no-build -p:UseSiemensStubs=true` — 1004/1004 pass

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)