### PR TITLE
refactor(#84): extract selection rules + star-column behavior from code-behind

### DIFF
--- a/src/BlockParam.Tests/SelectionScopeViewModelTests.cs
+++ b/src/BlockParam.Tests/SelectionScopeViewModelTests.cs
@@ -444,6 +444,118 @@ public class SelectionScopeViewModelTests
     }
 
     // ─────────────────────────────────────────────────────────────────────
+    // GetNonLeafItems — extracted from OnListViewSelectionChanged (#84)
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetNonLeafItems_EmptyInput_ReturnsEmpty()
+    {
+        var result = SelectionScopeViewModel.GetNonLeafItems(
+            System.Array.Empty<MemberNodeViewModel>());
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetNonLeafItems_AllLeaves_ReturnsEmpty()
+    {
+        var (_, tree, _) = BuildWithSingleDb();
+        var leaves = tree.RootMembers.Where(r => r.IsLeaf).ToList();
+        leaves.Should().NotBeEmpty("fixture must have at least one leaf");
+
+        var result = SelectionScopeViewModel.GetNonLeafItems(leaves);
+        result.Should().BeEmpty("every input was a leaf — nothing to deselect");
+    }
+
+    [Fact]
+    public void GetNonLeafItems_ParentNodes_AreReturned()
+    {
+        // Build a DB with a nested structure so we have a non-leaf parent.
+        var child = new MemberNode("Speed", "Int", "0", "Motor.Speed", null,
+            System.Array.Empty<MemberNode>());
+        var parent = new MemberNode("Motor", "UDT_Motor", null, "Motor", null,
+            new[] { child });
+        var (_, _, dbs) = Build();
+        var db = new ActiveDb(
+            new DataBlockInfo("DB_Test", 1, "Optimized", "GlobalDB", new[] { parent }),
+            "<Block />");
+        dbs.Add(db);
+
+        var (_, tree, _) = Build();
+        // Rebuild a fresh tree with the nested structure.
+        var dbs2 = new System.Collections.Generic.List<ActiveDb> { db };
+        var tree2 = new MemberTreeViewModel(
+            getActiveDbs: () => dbs2,
+            getCurrentPlcName: () => "",
+            commentLanguagePolicy: new CommentLanguagePolicy(null, null, new[] { "en-GB" }),
+            subscribeToVm: _ => { });
+        tree2.BuildRootMembersFromActiveDbs();
+
+        var parentVm = tree2.RootMembers.First(r => !r.IsLeaf);
+        var childVm = parentVm.Children.First(c => c.IsLeaf);
+
+        // Pass both — only the parent should come back.
+        var result = SelectionScopeViewModel.GetNonLeafItems(
+            new[] { parentVm, childVm });
+
+        result.Should().ContainSingle()
+            .Which.Should().BeSameAs(parentVm,
+                "only the non-leaf parent should be flagged for deselection");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // FilterGhostRemovals — extracted from OnListViewSelectionChanged (#84)
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void FilterGhostRemovals_EmptyRemoved_ReturnsEmpty()
+    {
+        var (_, tree, _) = BuildWithSingleDb();
+        var leaf = tree.RootMembers.First(r => r.IsLeaf);
+        var stillSelected = new HashSet<MemberNodeViewModel> { leaf };
+
+        var result = SelectionScopeViewModel.FilterGhostRemovals(
+            System.Array.Empty<MemberNodeViewModel>(), stillSelected);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FilterGhostRemovals_ItemStillSelected_IsFiltered()
+    {
+        // Simulate WPF ghost-removal: item appears in RemovedItems but is
+        // still in SelectedItems (the singular SelectedItem changed, not the set).
+        var (_, tree, _) = BuildWithSingleDb();
+        var leaf = tree.RootMembers.First(r => r.IsLeaf);
+        var stillSelected = new HashSet<MemberNodeViewModel> { leaf };
+
+        var result = SelectionScopeViewModel.FilterGhostRemovals(
+            new[] { leaf }, stillSelected);
+
+        result.Should().BeEmpty(
+            "item is still in SelectedItems — this is a ghost removal that must " +
+            "be ignored so the manual-selection set is not wrongly shrunk");
+    }
+
+    [Fact]
+    public void FilterGhostRemovals_ItemNotInStillSelected_IsRealRemoval()
+    {
+        var (_, tree, _) = BuildWithSingleDb();
+        var leaves = tree.RootMembers.Where(r => r.IsLeaf).ToList();
+        leaves.Should().HaveCountGreaterOrEqualTo(2,
+            "fixture needs two leaves for this test");
+
+        // leaf[0] was deselected for real; leaf[1] is a ghost removal.
+        var stillSelected = new HashSet<MemberNodeViewModel> { leaves[1] };
+
+        var result = SelectionScopeViewModel.FilterGhostRemovals(
+            new[] { leaves[0], leaves[1] }, stillSelected);
+
+        result.Should().ContainSingle()
+            .Which.Should().BeSameAs(leaves[0],
+                "only the item that is truly absent from SelectedItems is a real deselect");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
     // Fixtures
     // ─────────────────────────────────────────────────────────────────────
 

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -4,6 +4,7 @@
         xmlns:local="clr-namespace:BlockParam.UI"
         xmlns:loc="clr-namespace:BlockParam.Localization"
         xmlns:controls="clr-namespace:BlockParam.UI.Controls.PillMultiSelect"
+        xmlns:behaviors="clr-namespace:BlockParam.UI.Controls"
         Title="{Binding ActiveSet.Title}"
                 Width="1100" Height="700"
         MinWidth="800" MinHeight="500"
@@ -339,6 +340,9 @@
                 </StackPanel>
 
                 <!-- Member Table fills the rest of the column -->
+                <!-- #9 / #84: star-width column via attached behavior.
+                     FixedColumnsWidth = NameColumn(280) + DataTypeColumn(140) + StartValueColumn(120) = 540.
+                     The behavior subscribes to SizeChanged internally so no code-behind handler is needed. -->
                 <ListView
                       x:Name="MemberListView"
                       ItemsSource="{Binding Tree.FlatMembers}"
@@ -351,7 +355,8 @@
                       MouseDoubleClick="OnListViewDoubleClick"
                       ContextMenuOpening="OnListViewContextMenuOpening"
                       SelectionChanged="OnListViewSelectionChanged"
-                      SizeChanged="OnMemberListSizeChanged"
+                      behaviors:GridViewStarColumnBehavior.StarColumn="{x:Reference CommentColumn}"
+                      behaviors:GridViewStarColumnBehavior.FixedColumnsWidth="540"
                       ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                 <ListView.ContextMenu>
                     <ContextMenu/>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml.cs
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml.cs
@@ -143,15 +143,15 @@ public partial class BulkChangeDialog : Window
         var removedList = e.RemovedItems.OfType<MemberNodeViewModel>().ToList();
         bool refreshing = vmCheck?.Tree.IsRefreshing == true;
 
-        // Ignore selection changes that are actually caused by the VM mutating
-        // the FlatMembers ObservableCollection during a refresh — they are ghost
-        // removals/additions, not user input.
+        // Ignore selection changes caused by the VM mutating FlatMembers during a
+        // refresh — they are ghost removals/additions, not user input.
         if (_suppressSelectionEvents || refreshing) return;
         if (DataContext is not BulkChangeViewModel vm) return;
 
         // Deselect any non-leaf items that got included in the multi-select.
-        // Per UX decision: only leaf members are selectable for manual bulk edit.
-        var parentsToDrop = addedList.Where(m => !m.IsLeaf).ToList();
+        // Business rule (testable in SelectionScopeViewModel): only leaf members
+        // are selectable for manual bulk edit (#84).
+        var parentsToDrop = SelectionScopeViewModel.GetNonLeafItems(addedList);
         if (parentsToDrop.Count > 0)
         {
             _suppressSelectionEvents = true;
@@ -168,10 +168,11 @@ public partial class BulkChangeDialog : Window
 
         // WPF fires SelectionChanged with RemovedItems=[X] when the singular
         // SelectedItem property changes, even if X is still in SelectedItems
-        // (multi-select). Filter those ghost removals — a real deselect means
-        // the item is no longer in SelectedItems.
-        var stillSelected = MemberListView.SelectedItems.OfType<MemberNodeViewModel>().ToHashSet();
-        var realRemoved = removedList.Where(m => !stillSelected.Contains(m)).ToList();
+        // (multi-select). Filter those ghost removals — business rule now tested
+        // in SelectionScopeViewModel.FilterGhostRemovals (#84).
+        var stillSelected = MemberListView.SelectedItems.OfType<MemberNodeViewModel>()
+            .ToHashSet();
+        var realRemoved = SelectionScopeViewModel.FilterGhostRemovals(removedList, stillSelected);
 
         var added = addedList.Where(m => m.IsLeaf);
         vm.UpdateManualSelection(added, realRemoved, isFilterRehydration: false);
@@ -228,28 +229,8 @@ public partial class BulkChangeDialog : Window
         }
     }
 
-    /// <summary>
-    /// #9: GridView columns have no native star sizing, so we compute it here.
-    /// Fixed columns keep their widths; the Comment column soaks up whatever
-    /// space is left so long comments stop truncating when the dialog is wide.
-    /// </summary>
-    private void OnMemberListSizeChanged(object sender, SizeChangedEventArgs e)
-    {
-        if (CommentColumn == null || NameColumn == null
-            || DataTypeColumn == null || StartValueColumn == null) return;
-
-        // Chrome + vertical scrollbar + row padding. Slightly conservative so
-        // we never force a horizontal scrollbar when space is tight.
-        const double Chrome = 32;
-        var available = MemberListView.ActualWidth
-                        - NameColumn.Width
-                        - DataTypeColumn.Width
-                        - StartValueColumn.Width
-                        - Chrome;
-
-        const double MinCommentWidth = 160;
-        CommentColumn.Width = System.Math.Max(MinCommentWidth, available);
-    }
+    // OnMemberListSizeChanged removed in #84: star-width column sizing moved to
+    // GridViewStarColumnBehavior attached behavior, set directly on MemberListView in XAML.
 
     private void OnListViewDoubleClick(object sender, MouseButtonEventArgs e)
     {

--- a/src/BlockParam/UI/BulkChangeDialog.xaml.cs
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml.cs
@@ -207,6 +207,10 @@ public partial class BulkChangeDialog : Window
                 // ManualSelectedPaths is keyed by VM reference now (#58),
                 // so a same-path leaf in another active DB is a different
                 // entry — Contains(m) picks the right one without alias.
+                // TODO(#84 follow-up): extract the Contains(m) predicate into
+                // SelectionScopeViewModel.GetItemsToRehydrate(visibleItems, manualSelection)
+                // so the rule becomes unit-testable. The SelectedItems.Add loop must stay
+                // in code-behind (UI-thread WPF operation). See PR #136 description.
                 if (vm.Selection.ManualSelectedPaths.Contains(m))
                 {
                     MemberListView.SelectedItems.Add(m);

--- a/src/BlockParam/UI/Controls/GridViewStarColumnBehavior.cs
+++ b/src/BlockParam/UI/Controls/GridViewStarColumnBehavior.cs
@@ -103,15 +103,43 @@ public static class GridViewStarColumnBehavior
     {
         if (d is not ListView lv) return;
 
-        // Subscribe once; subsequent calls are no-ops because the lambda
-        // captures the ListView by reference and reads its current attached
-        // property values on every SizeChanged event.
-        lv.SizeChanged -= OnListViewSizeChanged;
-        lv.SizeChanged += OnListViewSizeChanged;
+        // When StarColumn transitions null→value, hook the Loaded/Unloaded
+        // lifecycle so SizeChanged is only active while the ListView is in
+        // the visual tree. When it transitions value→null, unhook everything.
+        if (e.Property == StarColumnProperty)
+        {
+            var oldCol = e.OldValue as GridViewColumn;
+            var newCol = e.NewValue as GridViewColumn;
+
+            if (oldCol == null && newCol != null)
+            {
+                // attach
+                lv.Loaded += OnListViewLoaded;
+                lv.Unloaded += OnListViewUnloaded;
+                if (lv.IsLoaded) lv.SizeChanged += OnListViewSizeChanged;
+            }
+            else if (oldCol != null && newCol == null)
+            {
+                // detach
+                lv.Loaded -= OnListViewLoaded;
+                lv.Unloaded -= OnListViewUnloaded;
+                lv.SizeChanged -= OnListViewSizeChanged;
+            }
+        }
 
         // Apply immediately in case the parameter changed while the ListView
         // is already laid out (e.g. during a theme switch or a test harness).
         Apply(lv);
+    }
+
+    private static void OnListViewLoaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is ListView lv) lv.SizeChanged += OnListViewSizeChanged;
+    }
+
+    private static void OnListViewUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is ListView lv) lv.SizeChanged -= OnListViewSizeChanged;
     }
 
     private static void OnListViewSizeChanged(object sender, SizeChangedEventArgs e)

--- a/src/BlockParam/UI/Controls/GridViewStarColumnBehavior.cs
+++ b/src/BlockParam/UI/Controls/GridViewStarColumnBehavior.cs
@@ -1,0 +1,134 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace BlockParam.UI.Controls;
+
+/// <summary>
+/// Attached behavior that gives a <see cref="ListView"/>'s <see cref="GridView"/>
+/// one "star" column that expands to fill whatever horizontal space the fixed
+/// columns leave behind — mirroring the star-sizing that WPF
+/// <see cref="Grid"/> columns support natively but <see cref="GridViewColumn"/>
+/// does not (#9 / #84).
+///
+/// <para>
+/// Usage in XAML:
+/// <code>
+///   &lt;GridViewColumn x:Name="CommentColumn" …/&gt;
+///   …
+///   &lt;ListView local:GridViewStarColumnBehavior.StarColumn="{x:Reference CommentColumn}"
+///              local:GridViewStarColumnBehavior.FixedColumnsWidth="540"
+///              local:GridViewStarColumnBehavior.MinStarWidth="160"
+///              SizeChanged="…" /&gt;
+/// </code>
+/// Or, without a code-behind SizeChanged at all — the behavior subscribes to
+/// the host ListView's <c>SizeChanged</c> internally and resizes whenever the
+/// ListView width changes.
+/// </para>
+///
+/// <para>
+/// <b>Chrome constant:</b> <see cref="ChromeWidth"/> accounts for the
+/// vertical scrollbar track + row padding. Keep it slightly conservative so
+/// a horizontal scrollbar never appears when space is tight. Override via the
+/// <c>ChromeWidth</c> attached property if the ListView uses non-default chrome.
+/// </para>
+/// </summary>
+public static class GridViewStarColumnBehavior
+{
+    // ── Attached properties ──────────────────────────────────────────────────
+
+    /// <summary>The <see cref="GridViewColumn"/> that receives the star width.</summary>
+    public static readonly DependencyProperty StarColumnProperty =
+        DependencyProperty.RegisterAttached(
+            "StarColumn",
+            typeof(GridViewColumn),
+            typeof(GridViewStarColumnBehavior),
+            new PropertyMetadata(null, OnParameterChanged));
+
+    /// <summary>
+    /// Sum of the fixed columns' widths (Name + DataType + StartValue in the
+    /// member ListView). The star column gets:
+    /// <c>Max(MinStarWidth, ListView.ActualWidth - FixedColumnsWidth - ChromeWidth)</c>.
+    /// </summary>
+    public static readonly DependencyProperty FixedColumnsWidthProperty =
+        DependencyProperty.RegisterAttached(
+            "FixedColumnsWidth",
+            typeof(double),
+            typeof(GridViewStarColumnBehavior),
+            new PropertyMetadata(0d, OnParameterChanged));
+
+    /// <summary>Minimum width the star column is allowed to reach (default 160 DIPs).</summary>
+    public static readonly DependencyProperty MinStarWidthProperty =
+        DependencyProperty.RegisterAttached(
+            "MinStarWidth",
+            typeof(double),
+            typeof(GridViewStarColumnBehavior),
+            new PropertyMetadata(160d, OnParameterChanged));
+
+    /// <summary>
+    /// Horizontal chrome to subtract (scrollbar track + row padding).
+    /// Default 32 DIPs — same conservative constant the old code-behind used.
+    /// </summary>
+    public static readonly DependencyProperty ChromeWidthProperty =
+        DependencyProperty.RegisterAttached(
+            "ChromeWidth",
+            typeof(double),
+            typeof(GridViewStarColumnBehavior),
+            new PropertyMetadata(32d, OnParameterChanged));
+
+    // ── Accessors ────────────────────────────────────────────────────────────
+
+    public static GridViewColumn? GetStarColumn(DependencyObject d) =>
+        (GridViewColumn?)d.GetValue(StarColumnProperty);
+    public static void SetStarColumn(DependencyObject d, GridViewColumn? value) =>
+        d.SetValue(StarColumnProperty, value);
+
+    public static double GetFixedColumnsWidth(DependencyObject d) =>
+        (double)d.GetValue(FixedColumnsWidthProperty);
+    public static void SetFixedColumnsWidth(DependencyObject d, double value) =>
+        d.SetValue(FixedColumnsWidthProperty, value);
+
+    public static double GetMinStarWidth(DependencyObject d) =>
+        (double)d.GetValue(MinStarWidthProperty);
+    public static void SetMinStarWidth(DependencyObject d, double value) =>
+        d.SetValue(MinStarWidthProperty, value);
+
+    public static double GetChromeWidth(DependencyObject d) =>
+        (double)d.GetValue(ChromeWidthProperty);
+    public static void SetChromeWidth(DependencyObject d, double value) =>
+        d.SetValue(ChromeWidthProperty, value);
+
+    // ── Change handler ───────────────────────────────────────────────────────
+
+    private static void OnParameterChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not ListView lv) return;
+
+        // Subscribe once; subsequent calls are no-ops because the lambda
+        // captures the ListView by reference and reads its current attached
+        // property values on every SizeChanged event.
+        lv.SizeChanged -= OnListViewSizeChanged;
+        lv.SizeChanged += OnListViewSizeChanged;
+
+        // Apply immediately in case the parameter changed while the ListView
+        // is already laid out (e.g. during a theme switch or a test harness).
+        Apply(lv);
+    }
+
+    private static void OnListViewSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        if (sender is ListView lv) Apply(lv);
+    }
+
+    private static void Apply(ListView lv)
+    {
+        var column = GetStarColumn(lv);
+        if (column == null) return;
+
+        var fixed_ = GetFixedColumnsWidth(lv);
+        var chrome = GetChromeWidth(lv);
+        var min = GetMinStarWidth(lv);
+
+        var available = lv.ActualWidth - fixed_ - chrome;
+        column.Width = System.Math.Max(min, available);
+    }
+}

--- a/src/BlockParam/UI/SelectionScopeViewModel.cs
+++ b/src/BlockParam/UI/SelectionScopeViewModel.cs
@@ -318,6 +318,55 @@ public class SelectionScopeViewModel : ViewModelBase
     }
 
     /// <summary>
+    /// Returns the subset of <paramref name="candidates"/> that must be
+    /// removed from the ListView's <c>SelectedItems</c> before a
+    /// multi-select gesture is processed. Per UX contract: only leaf
+    /// members are eligible for manual bulk-edit selection — parent / group
+    /// rows are structural and carry no editable start-value.
+    ///
+    /// <para>
+    /// This is pure, side-effect-free validation logic that lives here so
+    /// it can be unit-tested independently of the WPF ListView (#84).
+    /// Code-behind calls this method and performs the actual
+    /// <c>SelectedItems.Remove</c> calls itself, because ListView mutation
+    /// requires the UI thread and cannot live in a ViewModel.
+    /// </para>
+    /// </summary>
+    public static IReadOnlyList<MemberNodeViewModel> GetNonLeafItems(
+        IEnumerable<MemberNodeViewModel> candidates)
+    {
+        var result = new System.Collections.Generic.List<MemberNodeViewModel>();
+        foreach (var m in candidates)
+        {
+            if (!m.IsLeaf) result.Add(m);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Filters <paramref name="removed"/> to exclude ghost removals that
+    /// WPF fires when <c>SelectedItem</c> changes in multi-select mode but
+    /// the item is still present in <c>SelectedItems</c>. A real deselect
+    /// only occurs when the item is no longer in <paramref name="stillSelected"/>.
+    ///
+    /// <para>
+    /// Pure, side-effect-free filtering logic extracted from code-behind
+    /// so it can be unit-tested without a live WPF ListView (#84).
+    /// </para>
+    /// </summary>
+    public static IReadOnlyList<MemberNodeViewModel> FilterGhostRemovals(
+        IEnumerable<MemberNodeViewModel> removed,
+        IReadOnlyCollection<MemberNodeViewModel> stillSelected)
+    {
+        var result = new System.Collections.Generic.List<MemberNodeViewModel>();
+        foreach (var m in removed)
+        {
+            if (!stillSelected.Contains(m)) result.Add(m);
+        }
+        return result;
+    }
+
+    /// <summary>
     /// Set of distinct <c>Datatype</c> strings across the currently
     /// manually-selected leaves. Empty when there are no manual
     /// selections. Used by <see cref="ManualSelectionSummary"/> and


### PR DESCRIPTION
## Summary

- **`GetNonLeafItems` / `FilterGhostRemovals`** extracted from `OnListViewSelectionChanged` in code-behind into static methods on `SelectionScopeViewModel`. The business rule (only leaf members are selectable for manual bulk-edit; WPF ghost-removal filtering) now lives in the ViewModel and is fully unit-testable without a live WPF `ListView`.
- **`OnMemberListSizeChanged` removed** from code-behind. Star-width column sizing (#9) moved to a new `GridViewStarColumnBehavior` attached behavior in `src/BlockParam/UI/Controls/GridViewStarColumnBehavior.cs`. Applied to `MemberListView` via XAML attached properties — no code-behind `SizeChanged` handler needed.
- **7 new unit tests** in `SelectionScopeViewModelTests.cs` cover both extracted methods: empty inputs, all-leaves, mixed leaf/parent, ghost-removal filtering, and edge cases.

## What moved where

| Before (code-behind) | After |
|---|---|
| `OnMemberListSizeChanged` (22 LOC) | `GridViewStarColumnBehavior` attached behavior + XAML |
| Non-leaf deselection rule in `OnListViewSelectionChanged` | `SelectionScopeViewModel.GetNonLeafItems` (static, testable) |
| Ghost-removal filter in `OnListViewSelectionChanged` | `SelectionScopeViewModel.FilterGhostRemovals` (static, testable) |

## What stays in code-behind (per CLAUDE.md)

- `RehydrateManualSelection` — `ListView.SelectedItems` mutation requires the UI thread; the business logic (`Contains(m)`) already delegates to `vm.Selection.ManualSelectedPaths`.
- `OnClosing` — `MessageBox` requires a Window owner reference.
- `OnListViewSelectionChanged` itself — WPF event callback + `SelectedItems.Remove` calls (UI tree operations); now delegates to the two extracted methods for the logic parts.
- All overlay positioning, cursor scripting, sticky-header scroll math — pure visual/layout glue.

## Test counts

- Before: 1003 pass (on main)
- After: 1010 pass (net +7 new tests; 2 pre-existing WPF XAML packaging flaky tests in `PillBindableApiTests` remain unchanged — they pass in isolation and fail only when run together with other XAML-loading tests, same behavior as on main)

## TODOs left

- Full `RehydrateManualSelection` decomposition would require making `SelectionScopeViewModel` aware of the filter-visible subset of members, which is a larger refactor touching `SearchFilterViewModel`. Left for a follow-up; a `// TODO` comment is in the code pointing to the planned `SelectionScopeViewModel.GetItemsToRehydrate` extraction.

Closes #84

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>