### PR TITLE
test: command-level coverage for VM commands (Tier A + B)

### DIFF
--- a/src/BlockParam.Tests/ActiveSetViewModelCommandTests.cs
+++ b/src/BlockParam.Tests/ActiveSetViewModelCommandTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using BlockParam.Models;
+using BlockParam.UI;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Command-level coverage for <see cref="ActiveSetViewModel"/>'s DB-switcher
+/// dropdown commands that the slice-8a / 8b suites don't exercise:
+///
+/// <list type="bullet">
+///   <item><c>CloseDataBlocksDropdownCommand</c> — the open path is heavily
+///       covered elsewhere; this asserts Close toggles
+///       <see cref="ActiveSetViewModel.IsDataBlocksDropdownOpen"/> back to
+///       false after the dropdown is opened.</item>
+///   <item><c>RefreshDataBlocksCommand</c> <c>CanExecute</c> guard — it is
+///       gated on a wired enumerate callback, so the predicate must report
+///       false with no callback and true once one is supplied.</item>
+/// </list>
+///
+/// The builder-style <see cref="Harness"/> mirrors
+/// <c>ActiveSetViewModelMutatorTests</c>'s harness (copied locally — no
+/// shared state across test classes).
+/// </summary>
+public class ActiveSetViewModelCommandTests
+{
+    [Fact]
+    public void CloseDataBlocksDropdownCommand_AfterOpen_TogglesOpenStateBackToFalse()
+    {
+        var available = new[]
+        {
+            new DataBlockSummary("Alpha", ""),
+            new DataBlockSummary("Beta", ""),
+        };
+        var harness = new Harness(Snap(Db("Anchor")))
+            .WithEnumerateDataBlocks(() => available)
+            .WithSwitchToDataBlock(_ => "<Block/>");
+
+        // Reuse the well-covered open path to put the dropdown into the
+        // open state, then assert Close flips it back.
+        harness.Vm.OpenDataBlocksDropdownCommand.Execute(null);
+        harness.Vm.IsDataBlocksDropdownOpen.Should().BeTrue(
+            "the open command is the documented precondition for Close");
+
+        harness.Vm.CloseDataBlocksDropdownCommand.Execute(null);
+
+        harness.Vm.IsDataBlocksDropdownOpen.Should().BeFalse(
+            "Close must toggle the bound open-state back to closed");
+    }
+
+    [Fact]
+    public void CloseDataBlocksDropdownCommand_RaisesPropertyChangedOnOpenState()
+    {
+        var harness = new Harness(Snap(Db("Anchor")));
+        // Force the state open directly so the test is independent of the
+        // open command's own side effects.
+        harness.Vm.IsDataBlocksDropdownOpen = true;
+
+        var raised = new List<string?>();
+        harness.Vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        harness.Vm.CloseDataBlocksDropdownCommand.Execute(null);
+
+        harness.Vm.IsDataBlocksDropdownOpen.Should().BeFalse(
+            "Close sets the open-state to false");
+        raised.Should().Contain(nameof(ActiveSetViewModel.IsDataBlocksDropdownOpen),
+            "the bound open-state must notify so the popup closes in the UI");
+    }
+
+    [Fact]
+    public void RefreshDataBlocksCommand_CanExecute_FalseWithoutEnumerateCallback()
+    {
+        // No enumerate callback wired → the guard's first clause is false.
+        var harness = new Harness(Snap(Db("Anchor")));
+
+        harness.Vm.RefreshDataBlocksCommand.CanExecute(null).Should().BeFalse(
+            "the refresh guard requires a wired enumerate-DataBlocks callback");
+    }
+
+    [Fact]
+    public void RefreshDataBlocksCommand_CanExecute_TrueWhenEnumerateCallbackWired()
+    {
+        // Same VM contract as the false case but with the callback present:
+        // the guard flips to true, demonstrating the false→true transition
+        // is driven solely by the enumerate-callback condition.
+        var harness = new Harness(Snap(Db("Anchor")))
+            .WithEnumerateDataBlocks(() => new[] { new DataBlockSummary("X", "") })
+            .WithSwitchToDataBlock(_ => "<Block/>");
+
+        harness.Vm.RefreshDataBlocksCommand.CanExecute(null).Should().BeTrue(
+            "wiring the enumerate callback satisfies the refresh guard");
+    }
+
+    // ---------- helpers (copied locally; no shared state) ----------
+
+    private static ActiveSetState Snap(params ActiveDb[] dbs)
+        => new ActiveSetState(
+            dbs,
+            new Dictionary<string, StashedDbState>(),
+            "");
+
+    private static ActiveDb Db(string name, string plc = "")
+    {
+        var info = new DataBlockInfo(name, 1, "Optimized", "GlobalDB", Array.Empty<MemberNode>());
+        return new ActiveDb(info, $"<Block name='{name}' />", onApply: null, plcName: plc);
+    }
+
+    /// <summary>
+    /// Builder-style harness so each test only wires the callbacks it needs.
+    /// Mirrors the harness in <c>ActiveSetViewModelMutatorTests</c> — copied
+    /// here intentionally to keep the new class free of shared fixtures.
+    /// </summary>
+    private class Harness
+    {
+        private readonly ActiveSetState _initial;
+        private Func<IReadOnlyList<DataBlockSummary>>? _enumerate;
+        private Func<DataBlockSummary, string>? _switch;
+        private ActiveSetViewModel? _vm;
+
+        public Harness(ActiveSetState initial) { _initial = initial; }
+
+        public ActiveSetViewModel Vm => _vm ??= new ActiveSetViewModel(
+            _initial,
+            messageBox: null,
+            pendingEditStore: null,
+            getModelToDb: null,
+            getStartValueForNode: _ => null,
+            buildActiveDbForSummary: null,
+            enumerateDataBlocks: _enumerate,
+            switchToDataBlock: _switch,
+            tryApplyActiveDbInPlace: null,
+            restoreStashOntoLive: null,
+            setStatus: _ => { },
+            getPendingCount: () => 0,
+            dispatcher: null);
+
+        public Harness WithEnumerateDataBlocks(Func<IReadOnlyList<DataBlockSummary>> enumerate)
+        { _enumerate = enumerate; return this; }
+
+        public Harness WithSwitchToDataBlock(Func<DataBlockSummary, string> sw)
+        { _switch = sw; return this; }
+    }
+}

--- a/src/BlockParam.Tests/BulkChangeViewModelCommandTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelCommandTests.cs
@@ -67,9 +67,12 @@ public class BulkChangeViewModelCommandTests : IDisposable
         var xml = TestFixtures.LoadXml(fixtureName);
         var db = new SimaticMLParser().Parse(xml);
         var analyzer = new HierarchyAnalyzer();
-        var configLoader = ruleJson == null
-            ? new ConfigLoader(null)
-            : CreateConfigLoaderWithRule(ruleJson);
+        // Always back the VM with an isolated temp config (empty ruleset when
+        // no rule is supplied). `new ConfigLoader(null)` would pick up the
+        // developer's ambient %APPDATA%\BlockParam\config.json, making these
+        // tests non-hermetic — see UpdateCommentsCommand_CanExecute_False_
+        // WhenNoCommentConfig for why that bites.
+        var configLoader = CreateConfigLoaderWithRule(ruleJson ?? @"{ ""rules"": [] }");
         var bulkService = new BulkChangeService(new ChangeLogger(), configLoader);
 
         return new BulkChangeViewModel(

--- a/src/BlockParam.Tests/BulkChangeViewModelCommandTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelCommandTests.cs
@@ -1,0 +1,318 @@
+using BlockParam.Config;
+using BlockParam.Licensing;
+using BlockParam.Services;
+using BlockParam.SimaticML;
+using BlockParam.UI;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Command-level coverage for <see cref="BulkChangeViewModel"/> commands that
+/// previously had no command-level tests: ApplyAndCloseCommand,
+/// DiscardPendingCommand (the #21 mis-click regression), UpdateCommentsCommand
+/// + its CanExecute guard, and the ClearManualSelectionCommand CanExecute guard.
+/// Mirrors the harness pattern of <see cref="BulkChangeViewModelTests"/> but
+/// keeps its own temp-dir cleanup so it shares no state with that class.
+/// </summary>
+public class BulkChangeViewModelCommandTests : IDisposable
+{
+    private readonly List<string> _tempDirs = new();
+
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirs)
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Builds a ConfigLoader backed by a real temp config + a single rules
+    /// file containing <paramref name="ruleJson"/>. Copied from the sibling
+    /// test class so this class owns its own cleanup list.
+    /// </summary>
+    private ConfigLoader CreateConfigLoaderWithRule(string ruleJson)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"test_cmd_vm_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        _tempDirs.Add(tempDir);
+
+        var configPath = Path.Combine(tempDir, "config.json");
+        File.WriteAllText(configPath, @"{ ""version"": ""1.0"" }");
+
+        var rulesDir = Path.Combine(tempDir, "rules");
+        Directory.CreateDirectory(rulesDir);
+        File.WriteAllText(Path.Combine(rulesDir, "test-rules.json"), ruleJson);
+
+        return new ConfigLoader(configPath);
+    }
+
+    private static IUsageTracker UsageTracker(int used = 0, int limit = 200)
+    {
+        var tracker = Substitute.For<IUsageTracker>();
+        tracker.GetStatus().Returns(new UsageStatus(used, limit));
+        tracker.RecordUsage(Arg.Any<int>()).Returns(true);
+        return tracker;
+    }
+
+    private BulkChangeViewModel CreateViewModel(
+        string fixtureName = "flat-db.xml",
+        string? ruleJson = null,
+        IUsageTracker? usageTracker = null,
+        IMessageBoxService? messageBox = null)
+    {
+        var xml = TestFixtures.LoadXml(fixtureName);
+        var db = new SimaticMLParser().Parse(xml);
+        var analyzer = new HierarchyAnalyzer();
+        var configLoader = ruleJson == null
+            ? new ConfigLoader(null)
+            : CreateConfigLoaderWithRule(ruleJson);
+        var bulkService = new BulkChangeService(new ChangeLogger(), configLoader);
+
+        return new BulkChangeViewModel(
+            db, xml, analyzer, bulkService,
+            usageTracker ?? UsageTracker(),
+            configLoader,
+            messageBox: messageBox);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // ApplyAndCloseCommand
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// ExecuteApplyAndClose runs ExecuteApply and only fires RequestClose when
+    /// the apply actually succeeded. With a valid staged pending change and
+    /// ample quota, Apply succeeds → the dialog must close.
+    /// </summary>
+    [Fact]
+    public void ApplyAndCloseCommand_RaisesRequestClose_WhenApplySucceeds()
+    {
+        var vm = CreateViewModel();
+        vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+        vm.Pending.PendingInlineEditCount.Should().Be(1, "one valid edit is staged");
+
+        var closed = false;
+        vm.RequestClose += () => closed = true;
+
+        vm.ApplyAndCloseCommand.Execute(null);
+
+        closed.Should().BeTrue(
+            "a successful apply must fire RequestClose so the dialog closes");
+    }
+
+    /// <summary>
+    /// Regression guard: when the pending batch exceeds the remaining daily
+    /// quota, ExecuteApply early-returns before committing and never sets
+    /// _lastApplySucceeded — so RequestClose must NOT fire and the dialog
+    /// stays open for the user to drop edits or upgrade.
+    /// </summary>
+    [Fact]
+    public void ApplyAndCloseCommand_DoesNotClose_WhenOverDailyQuota()
+    {
+        // 200/200 used → RemainingToday == 0, so even one pending edit is over-cap.
+        var vm = CreateViewModel(usageTracker: UsageTracker(used: 200, limit: 200));
+        vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+        vm.Pending.PendingInlineEditCount.Should().Be(1);
+
+        var closed = false;
+        vm.RequestClose += () => closed = true;
+
+        vm.ApplyAndCloseCommand.Execute(null);
+
+        closed.Should().BeFalse(
+            "an over-quota apply must not close the dialog — the edit is not committed");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // DiscardPendingCommand  (#21 mis-click regression)
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// #21: With pending edits staged, confirming the discard prompt
+    /// (AskYesNo → true) clears every staged edit.
+    /// </summary>
+    [Fact]
+    public void DiscardPendingCommand_ConfirmYes_ClearsPendingEdits()
+    {
+        var mb = Substitute.For<IMessageBoxService>();
+        mb.AskYesNo(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        var vm = CreateViewModel(messageBox: mb);
+
+        vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+        vm.Tree.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
+        vm.Pending.PendingInlineEditCount.Should().Be(2, "two edits staged");
+
+        vm.DiscardPendingCommand.Execute(null);
+
+        vm.Pending.PendingInlineEditCount.Should().Be(0,
+            "confirming the discard prompt must clear all staged edits");
+    }
+
+    /// <summary>
+    /// #21 KEY REGRESSION: a mis-click used to silently wipe staged edits.
+    /// When the user declines the confirm prompt (AskYesNo → false), every
+    /// staged edit MUST be preserved untouched.
+    /// </summary>
+    [Fact]
+    public void DiscardPendingCommand_ConfirmNo_PreservesPendingEdits()
+    {
+        var mb = Substitute.For<IMessageBoxService>();
+        mb.AskYesNo(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+        var vm = CreateViewModel(messageBox: mb);
+
+        vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+        vm.Tree.RootMembers.Single(m => m.Name == "Speed").EditableStartValue = "42";
+        vm.Pending.PendingInlineEditCount.Should().Be(2);
+
+        vm.DiscardPendingCommand.Execute(null);
+
+        vm.Pending.PendingInlineEditCount.Should().Be(2,
+            "#21: declining the confirm dialog must NOT wipe staged edits");
+    }
+
+    /// <summary>
+    /// Tier B guard: DiscardPendingCommand is only enabled when there is at
+    /// least one pending inline edit to discard.
+    /// </summary>
+    [Fact]
+    public void DiscardPendingCommand_CanExecute_TracksPendingCount()
+    {
+        var vm = CreateViewModel();
+
+        vm.DiscardPendingCommand.CanExecute(null).Should().BeFalse(
+            "nothing staged → nothing to discard");
+
+        vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+
+        vm.DiscardPendingCommand.CanExecute(null).Should().BeTrue(
+            "one staged edit → discard becomes available");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // UpdateCommentsCommand + CanExecuteUpdateComments
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// CanExecuteUpdateComments == (Selection.HasScope &amp;&amp; HasCommentConfig).
+    /// False with no scope / no comment config; true only once a scope is
+    /// selected AND a rule with a non-empty CommentTemplate is loaded.
+    /// </summary>
+    [Fact]
+    public void UpdateCommentsCommand_CanExecute_RequiresScopeAndCommentConfig()
+    {
+        // udt-instances-db.xml: ModuleId leaves live under Msg_CommError UDT
+        // instances; GenerateForScope walks up to the parent, so the rule
+        // targets the parent path "Msg_CommError" (mirrors the sibling suite).
+        var rule = @"{ ""rules"": [{ ""pathPattern"": ""Msg_CommError"",
+            ""commentTemplate"": ""{db}"" }] }";
+        var vm = CreateViewModel("udt-instances-db.xml", ruleJson: rule);
+
+        vm.HasCommentConfig.Should().BeTrue("the loaded rule has a commentTemplate");
+        vm.UpdateCommentsCommand.CanExecute(null).Should().BeFalse(
+            "no scope selected yet → command must stay disabled");
+
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
+        vm.RefreshFlatList();
+        var leaf = vm.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
+        vm.Selection.SelectedFlatMember = leaf;
+        vm.Selection.SelectedScope =
+            vm.Selection.AvailableScopes.OrderByDescending(s => s.MatchCount).First();
+
+        vm.UpdateCommentsCommand.CanExecute(null).Should().BeTrue(
+            "scope selected AND a commentTemplate rule loaded → command enabled");
+    }
+
+    /// <summary>
+    /// CanExecuteUpdateComments must stay false when a scope is selected but
+    /// the config has no commentTemplate rule (the HasCommentConfig half of
+    /// the guard).
+    /// </summary>
+    [Fact]
+    public void UpdateCommentsCommand_CanExecute_False_WhenNoCommentConfig()
+    {
+        // Explicit empty ruleset via an isolated temp config — `new ConfigLoader(null)`
+        // would pick up the developer's ambient %APPDATA% config, which may carry a
+        // commentTemplate rule and make HasCommentConfig spuriously true.
+        var vm = CreateViewModel("udt-instances-db.xml", ruleJson: @"{ ""rules"": [] }");
+
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
+        vm.RefreshFlatList();
+        var leaf = vm.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
+        vm.Selection.SelectedFlatMember = leaf;
+        vm.Selection.SelectedScope =
+            vm.Selection.AvailableScopes.OrderByDescending(s => s.MatchCount).First();
+
+        vm.Selection.HasScope.Should().BeTrue("a scope is selected");
+        vm.HasCommentConfig.Should().BeFalse("no commentTemplate rule is configured");
+        vm.UpdateCommentsCommand.CanExecute(null).Should().BeFalse(
+            "scope alone is not enough — the comment-config half of the guard fails");
+    }
+
+    /// <summary>
+    /// Executing UpdateCommentsCommand with a valid commentTemplate rule and a
+    /// selected scope stages comment changes: HasPendingChanges flips true and
+    /// StatusText moves off its initial value. Asserts state/flags, not the
+    /// localized string (which comes from Res.Format).
+    /// </summary>
+    [Fact]
+    public void UpdateCommentsCommand_Execute_SetsPendingAndUpdatesStatus()
+    {
+        var rule = @"{ ""rules"": [{ ""pathPattern"": ""Msg_CommError"",
+            ""commentTemplate"": ""{db}"" }] }";
+        var vm = CreateViewModel("udt-instances-db.xml", ruleJson: rule,
+            messageBox: Substitute.For<IMessageBoxService>());
+
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
+        vm.RefreshFlatList();
+        var leaf = vm.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
+        vm.Selection.SelectedFlatMember = leaf;
+        vm.Selection.SelectedScope =
+            vm.Selection.AvailableScopes.OrderByDescending(s => s.MatchCount).First();
+
+        var initialStatus = vm.StatusText;
+        vm.UpdateCommentsCommand.CanExecute(null).Should().BeTrue();
+
+        vm.UpdateCommentsCommand.Execute(null);
+
+        vm.HasPendingChanges.Should().BeTrue(
+            "writing comment previews into the DB must mark the dialog dirty");
+        vm.StatusText.Should().NotBe(initialStatus,
+            "the command must report progress via StatusText (Comments_Updated)");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // ClearManualSelectionCommand  (Tier B guard only)
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Tier B guard: ClearManualSelectionCommand.CanExecute ==
+    /// (Selection.ManualSelectionCount &gt; 0). False with nothing manually
+    /// selected; true once a Ctrl+Click multi-selection exists.
+    /// </summary>
+    [Fact]
+    public void ClearManualSelectionCommand_CanExecute_TracksManualSelectionCount()
+    {
+        var vm = CreateViewModel("udt-instances-db.xml");
+
+        vm.ClearManualSelectionCommand.CanExecute(null).Should().BeFalse(
+            "no manual selection yet");
+
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
+        vm.RefreshFlatList();
+        var leaves = vm.Tree.FlatMembers.Where(m => m.IsLeaf).Take(2).ToList();
+        leaves.Should().HaveCount(2, "fixture must expose at least 2 leaves");
+
+        vm.UpdateManualSelection(
+            added: leaves,
+            removed: Array.Empty<MemberNodeViewModel>(),
+            isFilterRehydration: false);
+
+        vm.Selection.ManualSelectionCount.Should().Be(2);
+        vm.ClearManualSelectionCommand.CanExecute(null).Should().BeTrue(
+            "a manual multi-selection exists → clearing it becomes available");
+    }
+}

--- a/src/BlockParam.Tests/ConfigEditorViewModelCommandTests.cs
+++ b/src/BlockParam.Tests/ConfigEditorViewModelCommandTests.cs
@@ -1,0 +1,264 @@
+using FluentAssertions;
+using BlockParam.Config;
+using BlockParam.UI;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Command-level coverage for <see cref="ConfigEditorViewModel"/> commands that
+/// the sibling <c>ConfigEditorViewModelTests</c> does not exercise:
+/// <c>DuplicateSelectedCommand</c>, <c>DeleteFileCommand</c>,
+/// <c>ResetToBaseCommand</c> and <c>SaveAndCloseCommand</c>. Construction /
+/// temp-dir / ConfigLoader plumbing mirrors the sibling test harness; helpers
+/// are copied (not shared) so the two classes stay independent.
+/// </summary>
+public class ConfigEditorViewModelCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _rulesDir;
+    private readonly string _projectDir;
+    private readonly string _projectRulesDir;
+
+    public ConfigEditorViewModelCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"BlockParamConfigCmdTest_{Guid.NewGuid():N}");
+        _rulesDir = Path.Combine(_tempDir, "rules");
+        // AppDirectories.ProjectRulesDir => {projectDir}\UserFiles\BlockParam
+        _projectDir = Path.Combine(_tempDir, "tiaProject");
+        _projectRulesDir = Path.Combine(_projectDir, "UserFiles", "BlockParam");
+        Directory.CreateDirectory(_rulesDir);
+        Directory.CreateDirectory(_projectRulesDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private string ConfigPath => Path.Combine(_tempDir, "config.json");
+
+    private ConfigLoader CreateLoader() => new ConfigLoader(ConfigPath);
+
+    private void WriteRuleFile(string fileName, string json) =>
+        File.WriteAllText(Path.Combine(_rulesDir, fileName), json);
+
+    private void WriteProjectRuleFile(string fileName, string json) =>
+        File.WriteAllText(Path.Combine(_projectRulesDir, fileName), json);
+
+    // ---- DuplicateSelectedCommand ------------------------------------------
+
+    /// <summary>
+    /// DuplicateSelectedCommand.CanExecute is false when no rule is selected
+    /// and true once a rule is selected (predicate is <c>SelectedRule != null</c>).
+    /// </summary>
+    [Fact]
+    public void DuplicateSelected_CanExecute_TracksSelectedRule()
+    {
+        WriteRuleFile("dup.json",
+            @"{ ""version"": ""1.0"", ""rules"": [{ ""pathPattern"": "".*\\.a$"" }] }");
+        var vm = new ConfigEditorViewModel(CreateLoader());
+
+        vm.DuplicateSelectedCommand.CanExecute(null).Should()
+            .BeFalse("no rule is selected yet");
+
+        vm.SelectedRule = vm.RuleFiles[0].Rules[0];
+        vm.DuplicateSelectedCommand.CanExecute(null).Should()
+            .BeTrue("a rule is now selected");
+    }
+
+    /// <summary>
+    /// Executing DuplicateSelectedCommand inserts a copy of the selected rule
+    /// into the same file directly after the source, copies the field values,
+    /// flags the copy as new, and selects the copy.
+    /// </summary>
+    [Fact]
+    public void DuplicateSelected_AddsCopyAfterSourceInSameFile()
+    {
+        WriteRuleFile("dup.json", @"{
+            ""version"": ""1.0"",
+            ""rules"": [{
+                ""pathPattern"": "".*\\.speed$"", ""datatype"": ""Int"",
+                ""tagTableReference"": { ""tableName"": ""Const_Speed"" }
+            }]
+        }");
+        var vm = new ConfigEditorViewModel(CreateLoader());
+        var file = vm.RuleFiles[0];
+        var source = file.Rules[0];
+        vm.SelectedRule = source;
+
+        vm.DuplicateSelectedCommand.Execute(null);
+
+        vm.RuleFiles.Should().HaveCount(1, "duplication stays within the same file");
+        file.Rules.Should().HaveCount(2, "a duplicate rule was added");
+        var copy = file.Rules[1];
+        copy.Should().NotBeSameAs(source, "the duplicate is a distinct instance");
+        copy.PathPattern.Should().Be(source.PathPattern, "field values are copied");
+        copy.Datatype.Should().Be("Int", "field values are copied");
+        copy.TagTableName.Should().Be("Const_Speed", "field values are copied");
+        copy.IsNew.Should().BeTrue("the duplicate is an unsaved new rule");
+        vm.SelectedRule.Should().BeSameAs(copy, "the new copy becomes the selection");
+    }
+
+    // ---- DeleteFileCommand -------------------------------------------------
+
+    /// <summary>
+    /// DeleteFileCommand.CanExecute requires the parameter to be a
+    /// <see cref="RuleFileViewModel"/>; null and other types return false.
+    /// </summary>
+    [Fact]
+    public void DeleteFile_CanExecute_RequiresRuleFileParameter()
+    {
+        WriteRuleFile("f.json",
+            @"{ ""version"": ""1.0"", ""rules"": [{ ""pathPattern"": "".*\\.a$"" }] }");
+        var vm = new ConfigEditorViewModel(CreateLoader());
+
+        vm.DeleteFileCommand.CanExecute(null).Should()
+            .BeFalse("null is not a RuleFileViewModel");
+        vm.DeleteFileCommand.CanExecute("not-a-file").Should()
+            .BeFalse("a string is not a RuleFileViewModel");
+        vm.DeleteFileCommand.CanExecute(vm.RuleFiles[0]).Should()
+            .BeTrue("a RuleFileViewModel parameter is accepted");
+    }
+
+    /// <summary>
+    /// Executing DeleteFileCommand with a RuleFileViewModel removes that file
+    /// from the editor's <c>RuleFiles</c> collection and deletes it from disk.
+    /// No message-box / confirm seam exists on the VM, so the command is
+    /// directly testable.
+    /// </summary>
+    [Fact]
+    public void DeleteFile_RemovesFileFromCollectionAndDisk()
+    {
+        WriteRuleFile("keep.json",
+            @"{ ""version"": ""1.0"", ""rules"": [{ ""pathPattern"": "".*\\.keep$"" }] }");
+        WriteRuleFile("remove.json",
+            @"{ ""version"": ""1.0"", ""rules"": [{ ""pathPattern"": "".*\\.gone$"" }] }");
+        var vm = new ConfigEditorViewModel(CreateLoader());
+
+        var target = vm.RuleFiles.Single(f => f.FileName == "remove.json");
+        vm.DeleteFileCommand.Execute(target);
+
+        vm.RuleFiles.Should().ContainSingle()
+            .Which.FileName.Should().Be("keep.json", "only the targeted file was removed");
+        File.Exists(Path.Combine(_rulesDir, "remove.json")).Should()
+            .BeFalse("the deleted file is removed from disk");
+        File.Exists(Path.Combine(_rulesDir, "keep.json")).Should()
+            .BeTrue("the untouched file stays on disk");
+    }
+
+    // ---- ResetToBaseCommand ------------------------------------------------
+
+    /// <summary>
+    /// ResetToBaseCommand.CanExecute is false for a file with no lower-priority
+    /// versions and true for a file that overrides another source's same-named
+    /// file (predicate is <c>SelectedFile?.HasOverrides == true</c>).
+    /// </summary>
+    [Fact]
+    public void ResetToBase_CanExecute_TracksHasOverrides()
+    {
+        // Same filename in Local and TiaProject -> the project copy wins and
+        // carries the local copy as an OverriddenVersion (HasOverrides == true).
+        const string body = @"{ ""version"": ""1.0"", ""rules"": [{ ""pathPattern"": "".*\\.x$"" }] }";
+        WriteRuleFile("shared-name.json", body);
+        WriteProjectRuleFile("shared-name.json", body);
+        WriteRuleFile("plain.json", body);
+
+        var loader = CreateLoader();
+        loader.SetTiaProjectPath(_projectDir);
+        var vm = new ConfigEditorViewModel(loader);
+
+        var plain = vm.RuleFiles.Single(f => f.FileName == "plain.json");
+        vm.SelectedFile = plain;
+        vm.ResetToBaseCommand.CanExecute(null).Should()
+            .BeFalse("the plain file has no overridden versions");
+
+        var overriding = vm.RuleFiles.Single(f => f.FileName == "shared-name.json");
+        overriding.HasOverrides.Should().BeTrue("same name exists in two sources");
+        vm.SelectedFile = overriding;
+        vm.ResetToBaseCommand.CanExecute(null).Should()
+            .BeTrue("the selected file overrides a lower-priority version");
+    }
+
+    /// <summary>
+    /// Executing ResetToBaseCommand deletes the higher-priority override file
+    /// from disk while leaving the base (lower-priority) version intact, so a
+    /// subsequent reload no longer reports the file as an override.
+    /// </summary>
+    [Fact]
+    public void ResetToBase_DeletesOverrideFile_KeepsBase()
+    {
+        const string body = @"{ ""version"": ""1.0"", ""rules"": [{ ""pathPattern"": "".*\\.x$"" }] }";
+        WriteRuleFile("shared-name.json", body);          // Local  = base
+        WriteProjectRuleFile("shared-name.json", body);    // Project = override (wins)
+
+        var loader = CreateLoader();
+        loader.SetTiaProjectPath(_projectDir);
+        var vm = new ConfigEditorViewModel(loader);
+
+        var overriding = vm.RuleFiles.Single(f => f.FileName == "shared-name.json");
+        overriding.HasOverrides.Should().BeTrue("precondition: the file is an override");
+        vm.SelectedFile = overriding;
+
+        vm.ResetToBaseCommand.Execute(null);
+
+        File.Exists(Path.Combine(_projectRulesDir, "shared-name.json")).Should()
+            .BeFalse("the override copy is deleted by reset-to-base");
+        File.Exists(Path.Combine(_rulesDir, "shared-name.json")).Should()
+            .BeTrue("the lower-priority base copy is preserved");
+
+        // Reload from scratch: with the override gone the surviving file is no
+        // longer reported as overriding anything.
+        var freshLoader = CreateLoader();
+        freshLoader.SetTiaProjectPath(_projectDir);
+        var vm2 = new ConfigEditorViewModel(freshLoader);
+        vm2.RuleFiles.Single(f => f.FileName == "shared-name.json")
+            .HasOverrides.Should().BeFalse("the override was removed, only the base remains");
+    }
+
+    // ---- SaveAndCloseCommand -----------------------------------------------
+
+    /// <summary>
+    /// SaveAndCloseCommand persists the same observable effect as SaveCommand
+    /// (the new file is written to disk with the auto-derived name) AND raises
+    /// the <c>RequestClose</c> event so the dialog can close.
+    /// </summary>
+    [Fact]
+    public void SaveAndClose_SavesAndRaisesRequestClose()
+    {
+        var vm = new ConfigEditorViewModel(CreateLoader());
+        var closeRaised = false;
+        vm.RequestClose += () => closeRaised = true;
+
+        vm.NewFileCommand.Execute(null);
+        vm.SelectedRule!.PathPattern = @".*\.elementId$";
+
+        vm.SaveAndCloseCommand.Execute(null);
+
+        File.Exists(Path.Combine(_rulesDir, "_any_.elementId.json")).Should()
+            .BeTrue("save-and-close persists the file just like Save");
+        closeRaised.Should().BeTrue("RequestClose fires once the save succeeds");
+    }
+
+    /// <summary>
+    /// When the save half of SaveAndCloseCommand fails validation (a new file
+    /// with no path pattern), the close signal is NOT raised — the dialog must
+    /// stay open so the user can fix the error.
+    /// </summary>
+    [Fact]
+    public void SaveAndClose_DoesNotCloseWhenSaveFailsValidation()
+    {
+        var vm = new ConfigEditorViewModel(CreateLoader());
+        var closeRaised = false;
+        vm.RequestClose += () => closeRaised = true;
+
+        vm.NewFileCommand.Execute(null); // rule has no PathPattern -> invalid
+
+        vm.SaveAndCloseCommand.Execute(null);
+
+        closeRaised.Should().BeFalse("a failed save must keep the dialog open");
+        vm.ValidationMessage.Should().NotBeNullOrEmpty(
+            "validation surfaces a message instead of closing");
+    }
+}

--- a/src/BlockParam.Tests/DiffPreviewViewModelTests.cs
+++ b/src/BlockParam.Tests/DiffPreviewViewModelTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using BlockParam.Models;
+using BlockParam.UI;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Command-level coverage for <see cref="DiffPreviewViewModel"/>'s
+/// <c>ApplyCommand</c> / <c>CancelCommand</c>. <c>DiffPreviewServiceTests</c>
+/// covers the diff computation service — NOT these VM commands.
+///
+/// <para>
+/// The dialog signals close via the <see cref="DiffPreviewViewModel.RequestClose"/>
+/// event and records the user's intent in
+/// <see cref="DiffPreviewViewModel.Confirmed"/> (true = Apply, false =
+/// Cancel). Tests subscribe to <c>RequestClose</c> to observe the close
+/// signal without a real <c>Window</c>.
+/// </para>
+///
+/// Contracts under test:
+/// <list type="bullet">
+///   <item><c>ApplyCommand</c> sets <c>Confirmed = true</c> and raises
+///       <c>RequestClose</c>; its <c>CanExecute</c> is gated on
+///       <c>ChangedCount &gt; 0</c>.</item>
+///   <item><c>CancelCommand</c> sets <c>Confirmed = false</c> and raises
+///       <c>RequestClose</c> unconditionally.</item>
+/// </list>
+/// </summary>
+public class DiffPreviewViewModelTests
+{
+    [Fact]
+    public void ApplyCommand_SetsConfirmedTrueAndSignalsClose()
+    {
+        var vm = MakeVm(changed: 2, total: 3);
+        int closeSignals = 0;
+        vm.RequestClose += () => closeSignals++;
+
+        vm.ApplyCommand.Execute(null);
+
+        vm.Confirmed.Should().BeTrue(
+            "Apply records the user's intent to commit the staged changes");
+        closeSignals.Should().Be(1,
+            "Apply must signal the host to close the preview dialog");
+    }
+
+    [Fact]
+    public void ApplyCommand_CanExecute_FalseWhenNoChanges_TrueWhenChanges()
+    {
+        var noChanges = MakeVm(changed: 0, total: 3);
+        noChanges.ApplyCommand.CanExecute(null).Should().BeFalse(
+            "applying with zero changed values is a no-op, so the guard blocks it");
+
+        var withChanges = MakeVm(changed: 1, total: 3);
+        withChanges.ApplyCommand.CanExecute(null).Should().BeTrue(
+            "at least one changed value makes Apply meaningful");
+    }
+
+    [Fact]
+    public void CancelCommand_SetsConfirmedFalseAndSignalsClose()
+    {
+        var vm = MakeVm(changed: 2, total: 3);
+        int closeSignals = 0;
+        vm.RequestClose += () => closeSignals++;
+
+        vm.CancelCommand.Execute(null);
+
+        vm.Confirmed.Should().BeFalse(
+            "Cancel records that the user declined the staged changes");
+        closeSignals.Should().Be(1,
+            "Cancel must signal the host to close the preview dialog");
+    }
+
+    [Fact]
+    public void CancelCommand_CanExecute_AlwaysTrueEvenWithZeroChanges()
+    {
+        // Unlike Apply, Cancel has no guard — the user must always be able
+        // to back out of the preview regardless of the change count.
+        var vm = MakeVm(changed: 0, total: 0);
+
+        vm.CancelCommand.CanExecute(null).Should().BeTrue(
+            "Cancel is unconditionally available so the dialog is escapable");
+    }
+
+    [Fact]
+    public void ApplyThenCancel_LastInvocationWins_ConfirmedReflectsCancel()
+    {
+        // Defensive: if both commands fire (e.g. double interaction before
+        // the dialog tears down), Confirmed must reflect the last gesture.
+        var vm = MakeVm(changed: 2, total: 3);
+        int closeSignals = 0;
+        vm.RequestClose += () => closeSignals++;
+
+        vm.ApplyCommand.Execute(null);
+        vm.CancelCommand.Execute(null);
+
+        vm.Confirmed.Should().BeFalse(
+            "Cancel ran last so it overrides the earlier Apply confirmation");
+        closeSignals.Should().Be(2,
+            "each command independently signals close");
+    }
+
+    // ---------- helpers (copied locally; no shared state) ----------
+
+    private static DiffPreviewViewModel MakeVm(int changed, int total)
+    {
+        var entries = new List<DiffEntry>();
+        // First `changed` entries differ (old != new); the rest are equal
+        // so DiffEntry.IsChanged is false → ChangedCount == changed.
+        for (int i = 0; i < changed; i++)
+            entries.Add(new DiffEntry($"M{i}", "Int", oldValue: "0", newValue: "1"));
+        for (int i = changed; i < total; i++)
+            entries.Add(new DiffEntry($"M{i}", "Int", oldValue: "7", newValue: "7"));
+
+        return new DiffPreviewViewModel(
+            dbName: "DB_Test",
+            memberName: "Speed",
+            newValue: "1",
+            entries: entries);
+    }
+}

--- a/src/BlockParam.Tests/PlcPillViewModelTests.cs
+++ b/src/BlockParam.Tests/PlcPillViewModelTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BlockParam.Models;
+using BlockParam.UI;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Command-level coverage for <see cref="PlcPillViewModel.LoadCommand"/>,
+/// the lazy DB-list fetch wired as
+/// <c>new RelayCommand(_ =&gt; OnIsOpenFlippedToTrue(), _ =&gt; !_isLoaded)</c>.
+///
+/// <para>
+/// The load handler is <c>async void</c> but awaits the host-supplied
+/// <c>loadDbs</c> delegate. The harness returns an already-completed
+/// <see cref="Task"/> (<see cref="Task.FromResult{TResult}"/>), so the
+/// awaiter reports completed and the continuation runs synchronously
+/// before <c>Execute</c> returns — no dispatcher pumping needed, plain
+/// <c>[Fact]</c> is sufficient.
+/// </para>
+///
+/// Contracts under test:
+/// <list type="bullet">
+///   <item>First <c>Execute</c> performs the load — observable via
+///       <see cref="PlcPillViewModel.IsLoaded"/> flipping true and
+///       <see cref="PlcPillViewModel.AvailableDbs"/> being replaced with
+///       the fetched list.</item>
+///   <item><c>CanExecute</c> is true before load (<c>!_isLoaded</c>) and
+///       false after.</item>
+///   <item>A second <c>Execute</c> is a safe no-op (the loader is not
+///       invoked again).</item>
+/// </list>
+/// </summary>
+public class PlcPillViewModelTests
+{
+    [Fact]
+    public void LoadCommand_FirstExecute_PerformsLoadAndPopulatesAvailableDbs()
+    {
+        var fetched = new List<DataBlockListItem>
+        {
+            Item("DB_One", "PLC_1"),
+            Item("DB_Two", "PLC_1"),
+        };
+        int loadCalls = 0;
+        var vm = new PlcPillViewModel(
+            plcName: "PLC_1",
+            isAnchor: true,
+            initialActiveItems: Array.Empty<DataBlockListItem>(),
+            loadDbs: _ =>
+            {
+                loadCalls++;
+                return Task.FromResult<IReadOnlyList<DataBlockListItem>>(fetched);
+            });
+
+        vm.LoadCommand.Execute(null);
+
+        loadCalls.Should().Be(1, "the first Execute drives the lazy DB-list fetch");
+        vm.IsLoaded.Should().BeTrue(
+            "OnIsOpenFlippedToTrue sets IsLoaded once the fetch completes");
+        vm.AvailableDbs.Should().HaveCount(2,
+            "AvailableDbs is replaced with the fetched PLC list");
+        vm.AvailableDbs.Should().BeEquivalentTo(fetched);
+    }
+
+    [Fact]
+    public void LoadCommand_CanExecute_TrueBeforeLoad_FalseAfterLoad()
+    {
+        var vm = new PlcPillViewModel(
+            plcName: "PLC_1",
+            isAnchor: false,
+            initialActiveItems: Array.Empty<DataBlockListItem>(),
+            loadDbs: _ => Task.FromResult<IReadOnlyList<DataBlockListItem>>(
+                Array.Empty<DataBlockListItem>()));
+
+        vm.LoadCommand.CanExecute(null).Should().BeTrue(
+            "the guard is !_isLoaded and nothing has loaded yet");
+
+        vm.LoadCommand.Execute(null);
+
+        vm.LoadCommand.CanExecute(null).Should().BeFalse(
+            "after a successful load _isLoaded is true so the guard flips");
+    }
+
+    [Fact]
+    public void LoadCommand_SecondExecute_IsSafeNoOp()
+    {
+        int loadCalls = 0;
+        var vm = new PlcPillViewModel(
+            plcName: "PLC_1",
+            isAnchor: false,
+            initialActiveItems: Array.Empty<DataBlockListItem>(),
+            loadDbs: _ =>
+            {
+                loadCalls++;
+                return Task.FromResult<IReadOnlyList<DataBlockListItem>>(
+                    new List<DataBlockListItem> { Item("DB_One", "PLC_1") });
+            });
+
+        vm.LoadCommand.Execute(null);
+        // Execute again directly (bypassing CanExecute, as a misbehaving
+        // binding could) — OnIsOpenFlippedToTrue must short-circuit on the
+        // _isLoaded guard rather than re-fetching.
+        vm.LoadCommand.Execute(null);
+
+        loadCalls.Should().Be(1,
+            "a second Execute is a safe no-op once the pill is loaded");
+        vm.IsLoaded.Should().BeTrue();
+        vm.AvailableDbs.Should().ContainSingle(
+            "the list is not re-fetched / duplicated on the second Execute");
+    }
+
+    // ---------- helpers (copied locally; no shared state) ----------
+
+    private static DataBlockListItem Item(string name, string plc) =>
+        new DataBlockListItem(
+            new DataBlockSummary(name, "", plcName: plc, number: 1),
+            isActive: false,
+            isAnchor: false);
+}

--- a/src/BlockParam.Tests/SubscriptionViewModelCommandTests.cs
+++ b/src/BlockParam.Tests/SubscriptionViewModelCommandTests.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Threading;
+using BlockParam.Config;
+using BlockParam.Licensing;
+using BlockParam.UI;
+using BlockParam.Updates;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Command-guard coverage for <see cref="SubscriptionViewModel"/>.
+///
+/// <para>
+/// Only the <c>ShowUpdateDetailsCommand</c> <c>CanExecute</c> guard is
+/// exercised here — its predicate is <c>() =&gt; HasUpdateAvailable</c>.
+/// The update-check setup mirrors
+/// <c>SubscriptionViewModelTests.InitializeUpdateCheck_WithCachedRelease_PopulatesBadge</c>
+/// (a stub update service exposing a cached <see cref="UpdateInfo"/>) so
+/// the guard can be driven both false (no cached release) and true.
+/// </para>
+///
+/// <para>
+/// The command bodies are deliberately NOT executed:
+/// <c>ExecuteShowUpdateDetails</c> opens an <c>UpdateAvailableDialog</c>,
+/// <c>ExecuteEnterLicenseKey</c> opens a <c>LicenseKeyDialog</c>, and
+/// <c>ExecuteUpgradeToPro</c> shells out to a browser. They need a dialog
+/// seam (a Tier-B boundary) before their execution can be unit-tested
+/// without spawning real windows — see the GAP notes below.
+/// </para>
+/// </summary>
+public class SubscriptionViewModelCommandTests
+{
+    [Fact]
+    public void ShowUpdateDetailsCommand_CanExecute_FalseWhenNoUpdateAvailable()
+    {
+        // Stub service with no cached release → AvailableUpdate stays null →
+        // HasUpdateAvailable false → guard false.
+        var vm = CreateVm(updateService: new StubUpdateService(cached: null));
+
+        vm.InitializeUpdateCheck(forceRefresh: false);
+
+        vm.HasUpdateAvailable.Should().BeFalse(
+            "no cached release means there is nothing to show details for");
+        vm.ShowUpdateDetailsCommand.CanExecute(null).Should().BeFalse(
+            "the guard is () => HasUpdateAvailable, which is false here");
+    }
+
+    [Fact]
+    public void ShowUpdateDetailsCommand_CanExecute_TrueWhenCachedReleasePresent()
+    {
+        // Same setup shape as the false case but with a cached release, so
+        // the false→true transition is driven purely by HasUpdateAvailable.
+        var info = new UpdateInfo { TagName = "v9.9.9", Name = "Great release" };
+        var vm = CreateVm(updateService: new StubUpdateService(cached: info));
+
+        vm.InitializeUpdateCheck(forceRefresh: false);
+
+        vm.HasUpdateAvailable.Should().BeTrue(
+            "a cached release populates AvailableUpdate");
+        vm.ShowUpdateDetailsCommand.CanExecute(null).Should().BeTrue(
+            "the guard follows HasUpdateAvailable, which is now true");
+    }
+
+    [Fact]
+    public void ShowUpdateDetailsCommand_CanExecute_NoUpdateService_StaysFalse()
+    {
+        // Defensive: with no update service at all the badge never appears,
+        // so the guard must remain false (and not throw).
+        var vm = CreateVm(updateService: null);
+
+        vm.InitializeUpdateCheck(forceRefresh: false);
+
+        vm.HasUpdateAvailable.Should().BeFalse();
+        vm.ShowUpdateDetailsCommand.CanExecute(null).Should().BeFalse(
+            "without an update service there is never an update to detail");
+    }
+
+    // GAP: ExecuteShowUpdateDetails / ExecuteEnterLicenseKey open real WPF
+    // dialogs (UpdateAvailableDialog / LicenseKeyDialog) and
+    // ExecuteUpgradeToPro shells out to a browser. Their execution can't be
+    // command-tested without a production dialog seam (Tier-B boundary).
+    // Not adding one here (no production changes); only the guard is tested.
+
+    // ---------- fixtures (copied locally; no shared state) ----------
+
+    private static SubscriptionViewModel CreateVm(
+        IUpdateCheckService? updateService,
+        bool isPro = false)
+    {
+        var tracker = new StubUsageTracker(used: 0, limit: 200);
+        var license = new StubLicenseService(isPro);
+        var msg = new SpyMessageBox();
+        return new SubscriptionViewModel(
+            tracker, license, updateService,
+            new ConfigLoader(null), msg, Dispatcher.CurrentDispatcher);
+    }
+
+    private sealed class StubLicenseService : ILicenseService
+    {
+        public StubLicenseService(bool isPro) { IsProActive = isPro; }
+        public LicenseInfo GetLicenseInfo() => new LicenseInfo { Tier = LicenseTier.Free };
+        public LicenseTier CurrentTier => IsProActive ? LicenseTier.Pro : LicenseTier.Free;
+        public bool IsProActive { get; }
+        public Task<LicenseActivationResult> ActivateKeyAsync(string licenseKey)
+            => Task.FromResult(LicenseActivationResult.InvalidKey("stub"));
+        public void DeactivateKey() { }
+        public void StartHeartbeat() { }
+        public void StopHeartbeat() { }
+        // Manual add/remove avoids CS0067 ("event never used").
+        public event EventHandler? LicenseStateChanged { add { } remove { } }
+        public void Dispose() { }
+    }
+
+    private sealed class StubUsageTracker : IUsageTracker
+    {
+        private int _used;
+        public StubUsageTracker(int used, int limit)
+        {
+            _used = used;
+            DailyLimit = limit;
+        }
+        public int DailyLimit { get; }
+        public UsageStatus GetStatus() => new UsageStatus(_used, DailyLimit);
+        public bool RecordUsage(int count)
+        {
+            if (_used + count > DailyLimit) return false;
+            _used += count;
+            return true;
+        }
+    }
+
+    private sealed class StubUpdateService : IUpdateCheckService
+    {
+        private readonly UpdateInfo? _cached;
+        public StubUpdateService(UpdateInfo? cached) { _cached = cached; }
+        public UpdateInfo? GetCached() => _cached;
+        public Task<UpdateInfo?> CheckAsync(CancellationToken ct = default)
+            => Task.FromResult<UpdateInfo?>(_cached);
+    }
+
+    private sealed class SpyMessageBox : IMessageBoxService
+    {
+        public bool AskYesNo(string message, string title) => false;
+        public void ShowError(string message, string title) { }
+        public void ShowInfo(string message, string title) { }
+        public ApplyStashCancelResult AskApplyStashCancel(string message, string title)
+            => ApplyStashCancelResult.Cancel;
+        public AddOrReplaceResult AskAddOrReplace(string message, string title)
+            => AddOrReplaceResult.Cancel;
+        public CloseWithStashResult AskCloseWithStash(string message, string title)
+            => CloseWithStashResult.Cancel;
+    }
+}


### PR DESCRIPTION
## Summary

Closes the **zero-coverage gaps** for `ICommand` surfaces that were testable at the command/workflow level with **no UI thread and no production refactor** — the "Tier 1" / "Tier A + B" slice from the test-gap analysis.

**32 new tests across 6 new files. No production code changed.** Full suite: 1042 passing / 0 failing / 0 skipped.

| File | Coverage |
|---|---|
| `BulkChangeViewModelCommandTests` (9) | ApplyAndClose (closes on success / stays open over quota), DiscardPending (**#21 regression: confirm-No preserves staged edits**), UpdateComments + CanExecute guard, ClearManualSelection guard |
| `ConfigEditorViewModelCommandTests` (8) | DuplicateSelected, DeleteFile, ResetToBase, SaveAndClose (+ CanExecute guards) |
| `ActiveSetViewModelCommandTests` (4) | CloseDataBlocksDropdown, RefreshDataBlocks CanExecute guard |
| `PlcPillViewModelTests` (3) | LoadCommand lazy-load + CanExecute flip + no-op-twice |
| `DiffPreviewViewModelTests` (5) | Apply/Cancel result + close signal + guards |
| `SubscriptionViewModelCommandTests` (3) | ShowUpdateDetails CanExecute guard |

## Notes

- **Test-harness pitfall fixed in the new tests:** `new ConfigLoader(null)` picks up the developer's ambient `%APPDATA%\BlockParam\config.json`, which made `HasCommentConfig` spuriously true. Comment-config tests now use isolated temp configs.
- **Documented Tier-B boundary (not worked around):** `SubscriptionViewModel.{EnterLicenseKey,UpgradeToPro,ShowUpdateDetails}` and `BulkChangeViewModel.ExecuteEditConfig` open real dialogs/browser — only their CanExecute guards are testable until a dialog seam is introduced. Left as a documented `// GAP:` for a follow-up.
- Additive only — no existing test or `.csproj` modified (SDK-style default compile items pick up the new files).

## Test plan

`dotnet test src/BlockParam.Tests/BlockParam.Tests.csproj -c Debug -p:UseSiemensStubs=true` → 1042 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)