### PR TITLE
DEV-ONLY: in-TIA scenario runner + timing extraction for #140 caching tests

### DIFF
--- a/extract-timing.ps1
+++ b/extract-timing.ps1
@@ -1,0 +1,85 @@
+<#
+  extract-timing.ps1  (DEV-ONLY — parked on chore/open-timing-instrumentation)
+
+  Incrementally extracts SCENARIO / OPEN-TIMING lines from the BlockParam
+  diagnostic logs into a sanitized, share-safe file.
+
+  Sanitization model (defense in depth):
+    * ALLOWLIST: only lines tagged SCENARIO or OPEN-TIMING are kept.
+      Everything else (exception bodies, parsed-DB lines, etc.) is dropped.
+    * Lines carrying real names/values (member=..., SilentUserPrompt ...)
+      are dropped entirely — not needed for timing analysis.
+    * db=<name> / plc=<name> are replaced with a stable salted hash so the
+      same DB correlates across runs without exposing the real name.
+  The raw log is never modified and never leaves the machine; only the
+  sanitized output is intended to be shared.
+
+  Usage:  pwsh ./extract-timing.ps1            # extract new lines since last run
+          pwsh ./extract-timing.ps1 -Reset     # forget the cursor (re-extract all)
+#>
+param(
+  [string]$LogDir  = "$env:APPDATA\BlockParam\logs",
+  [string]$OutDir  = "$env:TEMP\BlockParam\timing-analysis",
+  [switch]$Reset
+)
+
+$ErrorActionPreference = 'Stop'
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+$statePath = Join-Path $OutDir 'cursor.json'
+$outPath   = Join-Path $OutDir 'timing-sanitized.log'
+
+# --- state: per-file byte offsets + a per-machine salt -----------------------
+if ((Test-Path $statePath) -and -not $Reset) {
+  $state = Get-Content $statePath -Raw | ConvertFrom-Json
+} else {
+  $state = [pscustomobject]@{ salt = [guid]::NewGuid().ToString('N'); offsets = @{} }
+}
+# offsets is an empty hashtable on first run, or a PSCustomObject from JSON on
+# later runs — normalize both to a hashtable.
+$offsets = @{}
+if ($state.offsets -is [System.Collections.IDictionary]) {
+  foreach ($k in @($state.offsets.Keys)) { $offsets[$k] = [int]$state.offsets[$k] }
+} elseif ($state.offsets) {
+  $state.offsets.PSObject.Properties | ForEach-Object { $offsets[$_.Name] = [int]$_.Value }
+}
+$salt = [string]$state.salt
+
+$sha = [System.Security.Cryptography.SHA256]::Create()
+function Hash([string]$v) {
+  $b = [Text.Encoding]::UTF8.GetBytes($salt + '|' + $v)
+  return 'h:' + (([BitConverter]::ToString($sha.ComputeHash($b)) -replace '-').Substring(0,8).ToLower())
+}
+
+$keptThisRun = New-Object System.Collections.Generic.List[string]
+
+Get-ChildItem -Path $LogDir -Filter 'bulkchange-v*.log' -ErrorAction SilentlyContinue |
+  Sort-Object Name | ForEach-Object {
+    $file = $_
+    $prev = if ($offsets.ContainsKey($file.Name)) { $offsets[$file.Name] } else { 0 }
+    $all  = Get-Content -LiteralPath $file.FullName -ErrorAction SilentlyContinue
+    if ($null -eq $all) { return }
+    if ($all.Count -lt $prev) { $prev = 0 }   # rotated / truncated
+    if ($all.Count -le $prev) { $offsets[$file.Name] = $all.Count; return }
+
+    $all[$prev..($all.Count-1)] | ForEach-Object {
+      $line = $_
+      if ($line -notmatch '(SCENARIO|OPEN-TIMING)') { return }
+      if ($line -match 'member=|SilentUserPrompt')  { return }
+      $line = [regex]::Replace($line, '(\bdb=)(\S+)',  { param($m) $m.Groups[1].Value + (Hash $m.Groups[2].Value) })
+      $line = [regex]::Replace($line, '(\bplc=)(\S+)', { param($m) $m.Groups[1].Value + (Hash $m.Groups[2].Value) })
+      $keptThisRun.Add($line)
+    }
+    $offsets[$file.Name] = $all.Count
+  }
+
+# --- persist state + append sanitized output ---------------------------------
+$state.offsets = $offsets
+($state | ConvertTo-Json -Depth 5) | Set-Content -LiteralPath $statePath -Encoding utf8
+if ($keptThisRun.Count -gt 0) {
+  Add-Content -LiteralPath $outPath -Value $keptThisRun -Encoding utf8
+}
+
+Write-Output "=== extract-timing: $($keptThisRun.Count) new sanitized line(s) ==="
+Write-Output "out:   $outPath"
+Write-Output "----- new lines this run -----"
+$keptThisRun | ForEach-Object { Write-Output $_ }

--- a/src/BlockParam/AddIn/BulkChangeAddInProvider.cs
+++ b/src/BlockParam/AddIn/BulkChangeAddInProvider.cs
@@ -19,6 +19,10 @@ public class BulkChangeAddInProvider : ProjectTreeAddInProvider
     protected override IEnumerable<ContextMenuAddIn> GetContextMenuAddIns()
     {
         yield return new BulkChangeContextMenu(_tiaPortal);
+        // DEV-ONLY: scenario runner — branch chore/open-timing-instrumentation only.
+        // Remove this line (and DiagnosticsScenarioMenu.cs) if this branch is ever
+        // promoted toward main. See DiagnosticsScenarioMenu.cs file header.
+        yield return new DiagnosticsScenarioMenu(_tiaPortal);
     }
 }
 

--- a/src/BlockParam/AddIn/BulkChangeContextMenu.cs
+++ b/src/BlockParam/AddIn/BulkChangeContextMenu.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using Siemens.Engineering;
@@ -108,6 +109,8 @@ public class BulkChangeContextMenu : ContextMenuAddIn
     private void OnClick(MenuSelectionProvider<IEngineeringObject> provider)
     {
         var prompt = new MessageBoxUserPrompt();
+        var totalSw = Stopwatch.StartNew();
+        long buildMs = 0, configMs = 0;
         try
         {
             // Multi-DB selection (#58). Index 0 is the anchor (display role
@@ -142,19 +145,32 @@ public class BulkChangeContextMenu : ContextMenuAddIn
             var udtCacheRefresher = new UdtCacheRefresher(prompt);
 
             var plcSoftware = discovery.FindPlcSoftware(allSelected[0]);
+            var plcName = plcSoftware != null ? ProjectDiscovery.SafeGetPlcName(plcSoftware) : "";
 
+            // Stage (a): UDT cache refresh.
             // Refresh UDT cache before parsing — out-of-date UDT XML produces wrong
             // setpoint / comment defaults at the leaf level.
-            if (plcSoftware != null)
+            int udtRefreshedCount = 0;
+            using (var t = OpenTiming.Stage("udtRefresh", $"plc={plcName}"))
             {
-                var refreshed = udtCacheRefresher.Refresh(plcSoftware, udtDir);
-                Log.Information("UDT cache validation: {Refreshed} stale file(s) re-exported", refreshed);
+                if (plcSoftware != null)
+                {
+                    udtRefreshedCount = udtCacheRefresher.Refresh(plcSoftware, udtDir);
+                    Log.Information("UDT cache validation: {Refreshed} stale file(s) re-exported", udtRefreshedCount);
+                }
+                t.AddPredictors($"staleFlushed={udtRefreshedCount}");
             }
+
+            // Stage (b): UDT resolver load.
             var udtResolver = new UdtSetPointResolver();
-            udtResolver.LoadFromDirectory(udtDir);
             var commentResolver = new UdtCommentResolver();
-            commentResolver.LoadFromDirectory(udtDir);
-            Log.Information("UDT cache loaded: {TypeCount} types from {Dir}", udtResolver.TypeCount, udtDir);
+            using (var t = OpenTiming.Stage("udtLoad", $"plc={plcName}"))
+            {
+                udtResolver.LoadFromDirectory(udtDir);
+                commentResolver.LoadFromDirectory(udtDir);
+                Log.Information("UDT cache loaded: {TypeCount} types from {Dir}", udtResolver.TypeCount, udtDir);
+                t.AddPredictors($"typeCount={udtResolver.TypeCount}");
+            }
 
             // Optional constant resolver from any previously cached tag tables so
             // symbolic array bounds (Array[1..MAX_VALVES]) expand. Empty cache → null,
@@ -174,25 +190,34 @@ public class BulkChangeContextMenu : ContextMenuAddIn
                 blockExporter, adapter, tempDir,
                 constantResolver, udtResolver, commentResolver);
 
+            // Stage (c): per-DB ActiveDb build loop (overall).
             // Focused DB. Wrapped in a single-element holder so the in-dialog
             // DB switcher (#59) can swap which ActiveDb the VM's onApply targets
             // without re-entering the VM construction path.
-            var focused = dbFactory.Build(allSelected[0], displayPlcName);
+            ActiveDb? focused;
+            var additionalDbs = new List<ActiveDb>();
+            var buildSw = Stopwatch.StartNew();
+            focused = dbFactory.Build(allSelected[0], displayPlcName);
             if (focused == null) return;
             var currentFocused = focused;
 
             // Additional active DBs (#58). Skipped if export fails (declined
             // compile, etc.).
-            var additionalDbs = new List<ActiveDb>();
             for (int i = 1; i < allSelected.Count; i++)
             {
                 var c = dbFactory.Build(allSelected[i], displayPlcName);
                 if (c != null) additionalDbs.Add(c);
             }
+            buildSw.Stop();
+            buildMs = buildSw.ElapsedMilliseconds;
+            Log.Information("OPEN-TIMING stage=buildAll plc={Plc} dbCount={DbCount} ms={Ms}",
+                plcName, allSelected.Count, buildMs);
             if (additionalDbs.Count > 0)
                 Log.Information("Multi-DB session: {N} additional DB(s) active alongside {Primary}",
                     additionalDbs.Count, focused.Info.Name);
 
+            // Stage (d): config / project languages / licensing init.
+            var configSw = Stopwatch.StartNew();
             // Build the rest of the VM dependencies (config / project languages /
             // licensing / update check). Pure construction — no TIA tree walks.
             var (configLoader, projectLanguages, editingLanguage, referenceLanguage) =
@@ -207,6 +232,9 @@ public class BulkChangeContextMenu : ContextMenuAddIn
                 sharedLicenseFilePath: OnlineLicenseService.DefaultSharedLicenseFilePath);
             var usageTracker = new LicensedUsageTracker(licenseService, freeTracker);
             var updateCheckService = TryBuildUpdateCheckService(appDataDir, configLoader);
+            configSw.Stop();
+            configMs = configSw.ElapsedMilliseconds;
+            Log.Information("OPEN-TIMING stage=config plc={Plc} ms={Ms}", plcName, configMs);
 
             var vm = new BulkChangeViewModel(
                 focused.Info, focused.Xml, analyzer, bulkService, usageTracker, configLoader,
@@ -274,6 +302,13 @@ public class BulkChangeContextMenu : ContextMenuAddIn
                     : null);
 
             licenseService.StartHeartbeat();
+
+            // Stage (e): TOTAL — handler entry to just before ShowDialog.
+            totalSw.Stop();
+            Log.Information(
+                "OPEN-TIMING stage=total plc={Plc} dbCount={DbCount} buildMs={BuildMs} configMs={ConfigMs} totalMs={TotalMs}",
+                plcName, allSelected.Count, buildMs, configMs, totalSw.ElapsedMilliseconds);
+
             var dialog = new BulkChangeDialog(vm);
             dialog.ShowDialog();
             licenseService.StopHeartbeat();

--- a/src/BlockParam/AddIn/DiagnosticsScenarioMenu.cs
+++ b/src/BlockParam/AddIn/DiagnosticsScenarioMenu.cs
@@ -1,0 +1,469 @@
+// DEV-ONLY scenario runner — must never be merged to main / shipped.
+// Intentionally lives on branch chore/open-timing-instrumentation only.
+// Release builds on this branch deploy fine; the menu is stripped at merge time
+// by keeping this branch off main forever.
+
+using System.Diagnostics;
+using Siemens.Engineering;
+using Siemens.Engineering.AddIn.Menu;
+using Siemens.Engineering.SW.Blocks;
+using BlockParam.Diagnostics;
+using BlockParam.Models;
+using BlockParam.Services;
+using BlockParam.SimaticML;
+
+namespace BlockParam.AddIn;
+
+/// <summary>
+/// Adds a "BlockParam ▸ Run diagnostics scenarios" context-menu entry to the
+/// TIA Portal project tree. Visible on DataBlock selection; runs a scripted
+/// sequence of Openness operations per selected DB, timing and logging each
+/// step as machine-parseable SCENARIO lines.
+///
+/// Strings: this menu never ships and is never localised — plain string constants
+/// are used deliberately. Do NOT add Strings.resx keys for these strings; they
+/// would then have to be kept out of the shipping resources.
+/// </summary>
+public sealed class DiagnosticsScenarioMenu : ContextMenuAddIn
+{
+    // Caption used for the TIA context-menu submenu root (must be non-null).
+    // This must differ from BulkChangeAddInProviderInfo.MenuTitle so TIA keeps
+    // the two sub-menus separate.
+    private const string SubmenuTitle = "BlockParam Diagnostics";
+
+    // Caption shown on the single action item inside the submenu.
+    private const string ActionCaption = "Run diagnostics scenarios";
+
+    // Machine-parseable prefix for all structured log lines this runner emits.
+    private const string ScenarioTag = "SCENARIO";
+
+    // Sentinel value written in place of the original during set_export_restore.
+    private const string SentinelValue = "42";
+
+    private readonly TiaPortal _tiaPortal;
+
+    public DiagnosticsScenarioMenu(TiaPortal tiaPortal) : base(SubmenuTitle)
+    {
+        _tiaPortal = tiaPortal;
+    }
+
+    protected override void BuildContextMenuItems(ContextMenuAddInRoot addInRootSubmenu)
+    {
+        // Build path must be trivial (<200 ms per CLAUDE.md). No I/O here.
+        addInRootSubmenu.Items.AddActionItem<IEngineeringObject>(
+            ActionCaption,
+            OnClick,
+            OnUpdateStatus);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Data-driven scenario list — add new permutations here, not in menu code.
+    // ---------------------------------------------------------------------------
+    private static readonly IReadOnlyList<ScenarioDef> Scenarios = new[]
+    {
+        new ScenarioDef("export_twice",         RunExportTwice),
+        new ScenarioDef("set_export_restore",   RunSetExportRestore),
+        new ScenarioDef("clear_export_restore", RunClearExportRestore),
+    };
+
+    // ---------------------------------------------------------------------------
+    // Menu callbacks
+    // ---------------------------------------------------------------------------
+
+    private void OnClick(MenuSelectionProvider<IEngineeringObject> provider)
+    {
+        // Synchronous on TIA's thread — blocking is expected for a dev tool.
+        // Do NOT try to solve the #146 threading problem here.
+        try
+        {
+            var selectedBlocks = provider.GetSelection<DataBlock>().ToList();
+            if (selectedBlocks.Count == 0) return;
+
+            Log.Information("{Tag} === Diagnostic scenario run started: {Count} DB(s) selected ===",
+                ScenarioTag, selectedBlocks.Count);
+
+            var project    = _tiaPortal.Projects.FirstOrDefault();
+            var discovery  = new ProjectDiscovery();
+            var adapter    = new TiaPortalAdapter(_tiaPortal);
+            var prompt     = new SilentUserPrompt();          // never blocks on a headless run
+            var exporter   = new BlockExporter(adapter, prompt);
+            var scope      = ProjectScope.ForPath(project?.Path?.FullName);
+            var tempDir    = AppDirectories.TempScope(scope);
+            var writer     = new SimaticMLWriter();
+
+            foreach (var db in selectedBlocks)
+            {
+                RunScenariosForDb(db, discovery, adapter, exporter, writer, tempDir);
+            }
+
+            Log.Information("{Tag} === Diagnostic scenario run complete ===", ScenarioTag);
+        }
+        catch (Exception ex)
+        {
+            // Top-level guard: never throw out of a TIA menu callback.
+            Log.Error(ex, "{Tag} Unhandled exception in scenario runner top-level", ScenarioTag);
+        }
+    }
+
+    private MenuStatus OnUpdateStatus(MenuSelectionProvider<IEngineeringObject> provider)
+        => provider.GetSelection<DataBlock>().Any() ? MenuStatus.Enabled : MenuStatus.Disabled;
+
+    // ---------------------------------------------------------------------------
+    // Per-DB dispatch
+    // ---------------------------------------------------------------------------
+
+    private void RunScenariosForDb(
+        DataBlock db,
+        ProjectDiscovery discovery,
+        ITiaPortalAdapter adapter,
+        IBlockExporter exporter,
+        SimaticMLWriter writer,
+        string tempDir)
+    {
+        var dbName  = db.Name;
+        var plcSw   = discovery.FindPlcSoftware(db);
+        var plcName = plcSw != null ? ProjectDiscovery.SafeGetPlcName(plcSw) : "";
+
+        Log.Information("{Tag} --- starting scenarios for db={DbName} plc={Plc} ---",
+            ScenarioTag, dbName, plcName);
+
+        var ctx = new ScenarioContext(db, dbName, plcName, adapter, exporter, writer, tempDir);
+
+        foreach (var scenario in Scenarios)
+        {
+            try
+            {
+                scenario.Run(ctx);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex,
+                    "{Tag} scenario={Scenario} db={Db} plc={Plc} result=fail",
+                    ScenarioTag, scenario.Name, dbName, plcName);
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Scenario implementations (static — no state, all args through context)
+    // ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// export_twice — export the block once, then export it again.
+    /// This is the #140 evidence: is the second export faster (warm caches)?
+    /// </summary>
+    private static void RunExportTwice(ScenarioContext ctx)
+    {
+        // Step 1 — first export.
+        string xml1 = "";
+        var sw1 = Stopwatch.StartNew();
+        try
+        {
+            ctx.Exporter.TryExportWithCompilePrompt(ctx.Db,
+                () => xml1 = System.IO.File.ReadAllText(
+                    ctx.Adapter.ExportBlock(ctx.Db, ctx.TempDir)));
+            sw1.Stop();
+            Log.Information(
+                "{Tag} scenario=export_twice step=export1 db={Db} plc={Plc} ms={Ms} xmlBytes={Bytes}",
+                ScenarioTag, ctx.DbName, ctx.PlcName, sw1.ElapsedMilliseconds, xml1.Length);
+        }
+        catch (Exception ex)
+        {
+            sw1.Stop();
+            Log.Error(ex,
+                "{Tag} scenario=export_twice step=export1 db={Db} plc={Plc} ms={Ms} result=fail",
+                ScenarioTag, ctx.DbName, ctx.PlcName, sw1.ElapsedMilliseconds);
+            return;
+        }
+
+        // Step 2 — second export.
+        string xml2 = "";
+        var sw2 = Stopwatch.StartNew();
+        try
+        {
+            ctx.Exporter.TryExportWithCompilePrompt(ctx.Db,
+                () => xml2 = System.IO.File.ReadAllText(
+                    ctx.Adapter.ExportBlock(ctx.Db, ctx.TempDir)));
+            sw2.Stop();
+            Log.Information(
+                "{Tag} scenario=export_twice step=export2 db={Db} plc={Plc} ms={Ms} xmlBytes={Bytes}",
+                ScenarioTag, ctx.DbName, ctx.PlcName, sw2.ElapsedMilliseconds, xml2.Length);
+        }
+        catch (Exception ex)
+        {
+            sw2.Stop();
+            Log.Error(ex,
+                "{Tag} scenario=export_twice step=export2 db={Db} plc={Plc} ms={Ms} result=fail",
+                ScenarioTag, ctx.DbName, ctx.PlcName, sw2.ElapsedMilliseconds);
+        }
+    }
+
+    /// <summary>
+    /// set_export_restore — capture original start value, set a sentinel, export,
+    /// restore original, verify. Self-reverting so every run starts clean.
+    /// </summary>
+    private static void RunSetExportRestore(ScenarioContext ctx)
+    {
+        RunMutateExportRestore(ctx, "set_export_restore", SentinelValue);
+    }
+
+    /// <summary>
+    /// clear_export_restore — capture original start value, clear it, export,
+    /// restore original, verify. Self-reverting.
+    /// </summary>
+    private static void RunClearExportRestore(ScenarioContext ctx)
+    {
+        RunMutateExportRestore(ctx, "clear_export_restore", newValue: "");
+    }
+
+    /// <summary>
+    /// Shared body for set_export_restore and clear_export_restore.
+    /// Option-B safety: capture original → mutate → export → restore → verify.
+    /// Uses the same XML export/import paths the product uses (no raw File.* outside
+    /// those paths; no new path literals — all dirs come from AppDirectories via ctx).
+    /// </summary>
+    private static void RunMutateExportRestore(
+        ScenarioContext ctx, string scenarioName, string newValue)
+    {
+        // --- Step 1: export to read current XML and pick target member ---
+        string originalXml = "";
+        try
+        {
+            var sw = Stopwatch.StartNew();
+            ctx.Exporter.TryExportWithCompilePrompt(ctx.Db,
+                () => originalXml = System.IO.File.ReadAllText(
+                    ctx.Adapter.ExportBlock(ctx.Db, ctx.TempDir)));
+            sw.Stop();
+            Log.Information(
+                "{Tag} scenario={Scenario} step=export_read db={Db} plc={Plc} ms={Ms} xmlBytes={Bytes}",
+                ScenarioTag, scenarioName, ctx.DbName, ctx.PlcName,
+                sw.ElapsedMilliseconds, originalXml.Length);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex,
+                "{Tag} scenario={Scenario} step=export_read db={Db} plc={Plc} result=fail",
+                ScenarioTag, scenarioName, ctx.DbName, ctx.PlcName);
+            return;
+        }
+
+        // --- Step 2: find first writable scalar leaf member ---
+        DataBlockInfo info;
+        try
+        {
+            var parser = new SimaticMLParser(null, new UdtSetPointResolver(), new UdtCommentResolver());
+            info = parser.Parse(originalXml);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex,
+                "{Tag} scenario={Scenario} step=parse db={Db} plc={Plc} result=fail",
+                ScenarioTag, scenarioName, ctx.DbName, ctx.PlcName);
+            return;
+        }
+
+        // Pick the first top-level scalar leaf with a defined start value.
+        // Deterministic: same member chosen on every run against the same DB.
+        var target = info.Members.FirstOrDefault(m => m.IsLeaf && !m.IsArray);
+        if (target == null)
+        {
+            Log.Warning(
+                "{Tag} scenario={Scenario} db={Db} plc={Plc} result=skip reason=no_scalar_leaf",
+                ScenarioTag, scenarioName, ctx.DbName, ctx.PlcName);
+            return;
+        }
+
+        var originalValue = target.StartValue ?? "";
+        Log.Information(
+            "{Tag} scenario={Scenario} step=target_selected db={Db} plc={Plc} member={Member} originalValue={OrigVal}",
+            ScenarioTag, scenarioName, ctx.DbName, ctx.PlcName, target.Path, originalValue);
+
+        // --- Step 3: mutate XML in memory ---
+        string mutatedXml;
+        try
+        {
+            var result = ctx.Writer.ModifyStartValues(originalXml, new[] { target }, newValue);
+            if (result.HasErrors)
+            {
+                Log.Warning(
+                    "{Tag} scenario={Scenario} step=mutate db={Db} plc={Plc} result=fail errors={Errs}",
+                    ScenarioTag, scenarioName, ctx.DbName, ctx.PlcName,
+                    string.Join("; ", result.Errors));
+                return;
+            }
+            mutatedXml = result.ModifiedXml;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex,
+                "{Tag} scenario={Scenario} step=mutate db={Db} plc={Plc} result=fail",
+                ScenarioTag, scenarioName, ctx.DbName, ctx.PlcName);
+            return;
+        }
+
+        // --- Step 4: import mutated XML back into TIA ---
+        var blockGroup = ctx.Adapter.GetBlockGroup(ctx.Db);
+        DataBlock liveDb = ctx.Db; // track live reference across import (#19)
+        try
+        {
+            var mutatedPath = System.IO.Path.Combine(
+                ctx.TempDir,
+                $"{SafeFileName.Sanitize(ctx.DbName)}_scenario_mutated.xml");
+            System.IO.File.WriteAllText(mutatedPath, mutatedXml);
+
+            var sw = Stopwatch.StartNew();
+            ctx.Adapter.ImportBlock(blockGroup, mutatedPath);
+            sw.Stop();
+
+            // Re-resolve live reference after import (TIA invalidates old handle, #19).
+            var blockGroupTyped = (Siemens.Engineering.SW.Blocks.PlcBlockGroup)blockGroup;
+            liveDb = blockGroupTyped.Blocks.Find(ctx.DbName) as DataBlock ?? ctx.Db;
+
+            // Re-export to measure the post-mutate export time.
+            string postMutateXml = "";
+            var exportSw = Stopwatch.StartNew();
+            ctx.Exporter.TryExportWithCompilePrompt(liveDb,
+                () => postMutateXml = System.IO.File.ReadAllText(
+                    ctx.Adapter.ExportBlock(liveDb, ctx.TempDir)));
+            exportSw.Stop();
+
+            Log.Information(
+                "{Tag} scenario={Scenario} step=import_and_export db={Db} plc={Plc} importMs={IMs} exportMs={EMs} xmlBytes={Bytes}",
+                ScenarioTag, scenarioName, ctx.DbName, ctx.PlcName,
+                sw.ElapsedMilliseconds, exportSw.ElapsedMilliseconds, postMutateXml.Length);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex,
+                "{Tag} scenario={Scenario} step=import_and_export db={Db} plc={Plc} result=fail",
+                ScenarioTag, scenarioName, ctx.DbName, ctx.PlcName);
+            // Still attempt restore below — do not return early.
+        }
+
+        // --- Step 5: restore original XML (Option-B self-revert) ---
+        bool restoreOk = false;
+        try
+        {
+            var restorePath = System.IO.Path.Combine(
+                ctx.TempDir,
+                $"{SafeFileName.Sanitize(ctx.DbName)}_scenario_restore.xml");
+            System.IO.File.WriteAllText(restorePath, originalXml);
+
+            var sw = Stopwatch.StartNew();
+            ctx.Adapter.ImportBlock(blockGroup, restorePath);
+            sw.Stop();
+
+            // Re-resolve after restore import.
+            var blockGroupTyped = (Siemens.Engineering.SW.Blocks.PlcBlockGroup)blockGroup;
+            liveDb = blockGroupTyped.Blocks.Find(ctx.DbName) as DataBlock ?? liveDb;
+
+            // --- Step 6: verify restore by re-exporting and re-reading ---
+            string verifyXml = "";
+            ctx.Exporter.TryExportWithCompilePrompt(liveDb,
+                () => verifyXml = System.IO.File.ReadAllText(
+                    ctx.Adapter.ExportBlock(liveDb, ctx.TempDir)));
+
+            if (!string.IsNullOrEmpty(verifyXml))
+            {
+                var verifyParser = new SimaticMLParser(null, new UdtSetPointResolver(), new UdtCommentResolver());
+                var verifyInfo   = verifyParser.Parse(verifyXml);
+                var verifyMember = verifyInfo.AllMembers()
+                    .FirstOrDefault(m => m.Path == target.Path);
+                var restoredValue = verifyMember?.StartValue ?? "";
+                restoreOk = restoredValue == originalValue;
+
+                if (!restoreOk)
+                {
+                    Log.Warning(
+                        "{Tag} scenario={Scenario} step=verify db={Db} plc={Plc} member={Member} expected={Exp} got={Got} restoreOk=false",
+                        ScenarioTag, scenarioName, ctx.DbName, ctx.PlcName,
+                        target.Path, originalValue, restoredValue);
+                }
+            }
+
+            Log.Information(
+                "{Tag} scenario={Scenario} step=restore db={Db} plc={Plc} ms={Ms} restoreOk={Ok}",
+                ScenarioTag, scenarioName, ctx.DbName, ctx.PlcName,
+                sw.ElapsedMilliseconds, restoreOk);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex,
+                "{Tag} scenario={Scenario} step=restore db={Db} plc={Plc} restoreOk=false result=fail",
+                ScenarioTag, scenarioName, ctx.DbName, ctx.PlcName);
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Supporting types (private — no public surface contamination)
+    // ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// Bundles the per-DB inputs so scenario methods have a clean signature
+    /// without a long parameter list.
+    /// </summary>
+    private sealed class ScenarioContext
+    {
+        public ScenarioContext(
+            DataBlock db,
+            string dbName,
+            string plcName,
+            ITiaPortalAdapter adapter,
+            IBlockExporter exporter,
+            SimaticMLWriter writer,
+            string tempDir)
+        {
+            Db       = db;
+            DbName   = dbName;
+            PlcName  = plcName;
+            Adapter  = adapter;
+            Exporter = exporter;
+            Writer   = writer;
+            TempDir  = tempDir;
+        }
+
+        public DataBlock         Db       { get; }
+        public string            DbName   { get; }
+        public string            PlcName  { get; }
+        public ITiaPortalAdapter Adapter  { get; }
+        public IBlockExporter    Exporter { get; }
+        public SimaticMLWriter   Writer   { get; }
+        public string            TempDir  { get; }
+    }
+
+    /// <summary>
+    /// A named, runnable scenario entry in the data-driven list.
+    /// </summary>
+    private sealed class ScenarioDef
+    {
+        public ScenarioDef(string name, Action<ScenarioContext> run)
+        {
+            Name = name;
+            _run = run;
+        }
+
+        public string Name { get; }
+        private readonly Action<ScenarioContext> _run;
+
+        public void Run(ScenarioContext ctx) => _run(ctx);
+    }
+
+    /// <summary>
+    /// A no-op <see cref="IUserPrompt"/> for the scenario runner — we never want
+    /// an interactive compile prompt blocking a scripted run. If a block is
+    /// inconsistent the export action throws and the step is logged as failed.
+    /// </summary>
+    private sealed class SilentUserPrompt : IUserPrompt
+    {
+        public bool AskYesNo(string title, string message)
+        {
+            Log.Warning("{Tag} SilentUserPrompt: compile prompt suppressed ({Title})", ScenarioTag, title);
+            return false;
+        }
+
+        public void ShowError(string title, string message)
+        {
+            Log.Warning("{Tag} SilentUserPrompt: error suppressed ({Title}): {Msg}", ScenarioTag, title, message);
+        }
+    }
+}

--- a/src/BlockParam/AddIn/DiagnosticsScenarioMenu.cs
+++ b/src/BlockParam/AddIn/DiagnosticsScenarioMenu.cs
@@ -127,13 +127,13 @@ public sealed class DiagnosticsScenarioMenu : ContextMenuAddIn
         Log.Information("{Tag} --- starting scenarios for db={DbName} plc={Plc} ---",
             ScenarioTag, dbName, plcName);
 
-        var ctx = new ScenarioContext(db, dbName, plcName, adapter, exporter, writer, tempDir);
+        var ctx = new ScenarioContext(dbName, plcName, adapter, exporter, writer, tempDir);
 
         foreach (var scenario in Scenarios)
         {
             try
             {
-                scenario.Run(ctx);
+                scenario.Run(db, ctx);
             }
             catch (Exception ex)
             {
@@ -152,16 +152,16 @@ public sealed class DiagnosticsScenarioMenu : ContextMenuAddIn
     /// export_twice — export the block once, then export it again.
     /// This is the #140 evidence: is the second export faster (warm caches)?
     /// </summary>
-    private static void RunExportTwice(ScenarioContext ctx)
+    private static void RunExportTwice(DataBlock db, ScenarioContext ctx)
     {
         // Step 1 — first export.
         string xml1 = "";
         var sw1 = Stopwatch.StartNew();
         try
         {
-            ctx.Exporter.TryExportWithCompilePrompt(ctx.Db,
+            ctx.Exporter.TryExportWithCompilePrompt(db,
                 () => xml1 = System.IO.File.ReadAllText(
-                    ctx.Adapter.ExportBlock(ctx.Db, ctx.TempDir)));
+                    ctx.Adapter.ExportBlock(db, ctx.TempDir)));
             sw1.Stop();
             Log.Information(
                 "{Tag} scenario=export_twice step=export1 db={Db} plc={Plc} ms={Ms} xmlBytes={Bytes}",
@@ -181,9 +181,9 @@ public sealed class DiagnosticsScenarioMenu : ContextMenuAddIn
         var sw2 = Stopwatch.StartNew();
         try
         {
-            ctx.Exporter.TryExportWithCompilePrompt(ctx.Db,
+            ctx.Exporter.TryExportWithCompilePrompt(db,
                 () => xml2 = System.IO.File.ReadAllText(
-                    ctx.Adapter.ExportBlock(ctx.Db, ctx.TempDir)));
+                    ctx.Adapter.ExportBlock(db, ctx.TempDir)));
             sw2.Stop();
             Log.Information(
                 "{Tag} scenario=export_twice step=export2 db={Db} plc={Plc} ms={Ms} xmlBytes={Bytes}",
@@ -202,18 +202,18 @@ public sealed class DiagnosticsScenarioMenu : ContextMenuAddIn
     /// set_export_restore — capture original start value, set a sentinel, export,
     /// restore original, verify. Self-reverting so every run starts clean.
     /// </summary>
-    private static void RunSetExportRestore(ScenarioContext ctx)
+    private static void RunSetExportRestore(DataBlock db, ScenarioContext ctx)
     {
-        RunMutateExportRestore(ctx, "set_export_restore", SentinelValue);
+        RunMutateExportRestore(db, ctx, "set_export_restore", SentinelValue);
     }
 
     /// <summary>
     /// clear_export_restore — capture original start value, clear it, export,
     /// restore original, verify. Self-reverting.
     /// </summary>
-    private static void RunClearExportRestore(ScenarioContext ctx)
+    private static void RunClearExportRestore(DataBlock db, ScenarioContext ctx)
     {
-        RunMutateExportRestore(ctx, "clear_export_restore", newValue: "");
+        RunMutateExportRestore(db, ctx, "clear_export_restore", newValue: "");
     }
 
     /// <summary>
@@ -223,16 +223,16 @@ public sealed class DiagnosticsScenarioMenu : ContextMenuAddIn
     /// those paths; no new path literals — all dirs come from AppDirectories via ctx).
     /// </summary>
     private static void RunMutateExportRestore(
-        ScenarioContext ctx, string scenarioName, string newValue)
+        DataBlock db, ScenarioContext ctx, string scenarioName, string newValue)
     {
         // --- Step 1: export to read current XML and pick target member ---
         string originalXml = "";
         try
         {
             var sw = Stopwatch.StartNew();
-            ctx.Exporter.TryExportWithCompilePrompt(ctx.Db,
+            ctx.Exporter.TryExportWithCompilePrompt(db,
                 () => originalXml = System.IO.File.ReadAllText(
-                    ctx.Adapter.ExportBlock(ctx.Db, ctx.TempDir)));
+                    ctx.Adapter.ExportBlock(db, ctx.TempDir)));
             sw.Stop();
             Log.Information(
                 "{Tag} scenario={Scenario} step=export_read db={Db} plc={Plc} ms={Ms} xmlBytes={Bytes}",
@@ -302,8 +302,8 @@ public sealed class DiagnosticsScenarioMenu : ContextMenuAddIn
         }
 
         // --- Step 4: import mutated XML back into TIA ---
-        var blockGroup = ctx.Adapter.GetBlockGroup(ctx.Db);
-        DataBlock liveDb = ctx.Db; // track live reference across import (#19)
+        var blockGroup = ctx.Adapter.GetBlockGroup(db);
+        DataBlock liveDb = db; // track live reference across import (#19)
         try
         {
             var mutatedPath = System.IO.Path.Combine(
@@ -317,7 +317,7 @@ public sealed class DiagnosticsScenarioMenu : ContextMenuAddIn
 
             // Re-resolve live reference after import (TIA invalidates old handle, #19).
             var blockGroupTyped = (Siemens.Engineering.SW.Blocks.PlcBlockGroup)blockGroup;
-            liveDb = blockGroupTyped.Blocks.Find(ctx.DbName) as DataBlock ?? ctx.Db;
+            liveDb = blockGroupTyped.Blocks.Find(ctx.DbName) as DataBlock ?? db;
 
             // Re-export to measure the post-mutate export time.
             string postMutateXml = "";
@@ -405,7 +405,6 @@ public sealed class DiagnosticsScenarioMenu : ContextMenuAddIn
     private sealed class ScenarioContext
     {
         public ScenarioContext(
-            DataBlock db,
             string dbName,
             string plcName,
             ITiaPortalAdapter adapter,
@@ -413,7 +412,6 @@ public sealed class DiagnosticsScenarioMenu : ContextMenuAddIn
             SimaticMLWriter writer,
             string tempDir)
         {
-            Db       = db;
             DbName   = dbName;
             PlcName  = plcName;
             Adapter  = adapter;
@@ -422,7 +420,6 @@ public sealed class DiagnosticsScenarioMenu : ContextMenuAddIn
             TempDir  = tempDir;
         }
 
-        public DataBlock         Db       { get; }
         public string            DbName   { get; }
         public string            PlcName  { get; }
         public ITiaPortalAdapter Adapter  { get; }
@@ -436,16 +433,16 @@ public sealed class DiagnosticsScenarioMenu : ContextMenuAddIn
     /// </summary>
     private sealed class ScenarioDef
     {
-        public ScenarioDef(string name, Action<ScenarioContext> run)
+        public ScenarioDef(string name, Action<DataBlock, ScenarioContext> run)
         {
             Name = name;
             _run = run;
         }
 
         public string Name { get; }
-        private readonly Action<ScenarioContext> _run;
+        private readonly Action<DataBlock, ScenarioContext> _run;
 
-        public void Run(ScenarioContext ctx) => _run(ctx);
+        public void Run(DataBlock db, ScenarioContext ctx) => _run(db, ctx);
     }
 
     /// <summary>

--- a/src/BlockParam/AddIn/DiagnosticsScenarioMenu.cs
+++ b/src/BlockParam/AddIn/DiagnosticsScenarioMenu.cs
@@ -37,8 +37,10 @@ public sealed class DiagnosticsScenarioMenu : ContextMenuAddIn
     // Machine-parseable prefix for all structured log lines this runner emits.
     private const string ScenarioTag = "SCENARIO";
 
-    // Sentinel value written in place of the original during set_export_restore.
-    private const string SentinelValue = "42";
+    // Marker telling RunMutateExportRestore to derive a TYPE-SAFE new value
+    // from the chosen member (a blind constant like "42" fails to compile on
+    // Bool/range-constrained members — "value out of scope 0 and 1").
+    private const string DeriveValueMarker = "derive";
 
     private readonly TiaPortal _tiaPortal;
 
@@ -204,7 +206,7 @@ public sealed class DiagnosticsScenarioMenu : ContextMenuAddIn
     /// </summary>
     private static void RunSetExportRestore(DataBlock db, ScenarioContext ctx)
     {
-        RunMutateExportRestore(db, ctx, "set_export_restore", SentinelValue);
+        RunMutateExportRestore(db, ctx, "set_export_restore", DeriveValueMarker);
     }
 
     /// <summary>
@@ -279,11 +281,19 @@ public sealed class DiagnosticsScenarioMenu : ContextMenuAddIn
             "{Tag} scenario={Scenario} step=target_selected db={Db} plc={Plc} member={Member} originalValue={OrigVal}",
             ScenarioTag, scenarioName, ctx.DbName, ctx.PlcName, target.Path, originalValue);
 
+        // Type-safe value: a blind constant fails to compile on Bool / range-
+        // constrained members. "clear" passes "" (kept verbatim); "set" passes
+        // the derive marker and we pick a valid value from the member's type.
+        var effectiveValue = newValue == DeriveValueMarker ? ChooseSafeNewValue(target) : newValue;
+        Log.Information(
+            "{Tag} scenario={Scenario} step=mutate_plan db={Db} plc={Plc} dtype={Dt}",
+            ScenarioTag, scenarioName, ctx.DbName, ctx.PlcName, Category(target.Datatype));
+
         // --- Step 3: mutate XML in memory ---
         string mutatedXml;
         try
         {
-            var result = ctx.Writer.ModifyStartValues(originalXml, new[] { target }, newValue);
+            var result = ctx.Writer.ModifyStartValues(originalXml, new[] { target }, effectiveValue);
             if (result.HasErrors)
             {
                 Log.Warning(
@@ -392,6 +402,56 @@ public sealed class DiagnosticsScenarioMenu : ContextMenuAddIn
             Log.Error(ex,
                 "{Tag} scenario={Scenario} step=restore db={Db} plc={Plc} restoreOk=false result=fail",
                 ScenarioTag, scenarioName, ctx.DbName, ctx.PlcName);
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Type-safe value selection
+    // ---------------------------------------------------------------------------
+
+    private static readonly HashSet<string> IntTypes = new(StringComparer.OrdinalIgnoreCase)
+    { "SInt","USInt","Int","UInt","DInt","UDInt","LInt","ULInt","Byte","Word","DWord","LWord" };
+
+    /// <summary>Coarse type bucket — also the sanitizer-safe value logged as dtype=
+    /// (a generic category, never a member name or a UDT type name).</summary>
+    private static string Category(string datatype)
+    {
+        var dt = (datatype ?? "").Trim();
+        if (dt.Equals("Bool", StringComparison.OrdinalIgnoreCase)) return "bool";
+        if (IntTypes.Contains(dt)) return "int";
+        if (dt.Equals("Real", StringComparison.OrdinalIgnoreCase) ||
+            dt.Equals("LReal", StringComparison.OrdinalIgnoreCase)) return "real";
+        if (dt.StartsWith("String", StringComparison.OrdinalIgnoreCase) ||
+            dt.StartsWith("WString", StringComparison.OrdinalIgnoreCase)) return "string";
+        if (dt.Equals("Char", StringComparison.OrdinalIgnoreCase) ||
+            dt.Equals("WChar", StringComparison.OrdinalIgnoreCase)) return "char";
+        return "other";
+    }
+
+    /// <summary>
+    /// A valid, different start value for the member's type. 0/1 toggles for
+    /// int, true/false for Bool, etc. Unknown/complex types (Time, Date, DTL,
+    /// enums) fall back to re-applying the original value — guaranteed valid,
+    /// still round-trips through import/compile/export for timing.
+    /// </summary>
+    private static string ChooseSafeNewValue(MemberNode m)
+    {
+        var orig = (m.StartValue ?? "").Trim();
+        switch (Category(m.Datatype))
+        {
+            case "bool":
+                var o = orig.Trim('"').ToLowerInvariant();
+                return (o == "true" || o == "1") ? "false" : "true";
+            case "int":
+                return orig == "1" ? "0" : "1";
+            case "real":
+                return orig == "1.0" ? "0.0" : "1.0";
+            case "string":
+                return orig == "'BP'" ? "'BPx'" : "'BP'";
+            case "char":
+                return orig == "'A'" ? "'B'" : "'A'";
+            default:
+                return m.StartValue ?? "";
         }
     }
 

--- a/src/BlockParam/AddIn/DiagnosticsScenarioMenu.cs
+++ b/src/BlockParam/AddIn/DiagnosticsScenarioMenu.cs
@@ -447,16 +447,20 @@ public sealed class DiagnosticsScenarioMenu : ContextMenuAddIn
     }
 
     /// <summary>
-    /// A no-op <see cref="IUserPrompt"/> for the scenario runner — we never want
-    /// an interactive compile prompt blocking a scripted run. If a block is
-    /// inconsistent the export action throws and the step is logged as failed.
+    /// A non-interactive <see cref="IUserPrompt"/> for the scenario runner.
+    /// AskYesNo auto-ACCEPTS (returns true): the compile prompt fires when a
+    /// freshly-imported block is inconsistent, and declining it aborts the
+    /// re-export (xmlBytes=0), leaves the block inconsistent, and contaminates
+    /// the next scenario. Accepting authorizes the compile programmatically
+    /// (still no UI), so the import→export→restore→verify round-trip actually
+    /// completes and scenarios stay isolated.
     /// </summary>
     private sealed class SilentUserPrompt : IUserPrompt
     {
         public bool AskYesNo(string title, string message)
         {
-            Log.Warning("{Tag} SilentUserPrompt: compile prompt suppressed ({Title})", ScenarioTag, title);
-            return false;
+            Log.Information("{Tag} SilentUserPrompt: compile prompt auto-accepted ({Title})", ScenarioTag, title);
+            return true;
         }
 
         public void ShowError(string title, string message)

--- a/src/BlockParam/AddIn/DiagnosticsScenarioMenu.cs
+++ b/src/BlockParam/AddIn/DiagnosticsScenarioMenu.cs
@@ -131,11 +131,38 @@ public sealed class DiagnosticsScenarioMenu : ContextMenuAddIn
 
         var ctx = new ScenarioContext(dbName, plcName, adapter, exporter, writer, tempDir);
 
+        // Capture the (stable) block group ONCE while db is still a fresh handle.
+        // TIA's ImportBlock(Override) disposes the DataBlock instance (#19), so a
+        // scenario that imports invalidates the handle for the NEXT scenario.
+        // Re-resolving the live block from the group before each scenario keeps
+        // them isolated. The group is a method LOCAL (never a field) per the
+        // Add-In rule against persisting IEngineeringObject.
+        PlcBlockGroup group;
+        try
+        {
+            group = (PlcBlockGroup)adapter.GetBlockGroup(db);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex,
+                "{Tag} db={Db} plc={Plc} result=fail reason=block_group_resolve",
+                ScenarioTag, dbName, plcName);
+            return;
+        }
+
         foreach (var scenario in Scenarios)
         {
             try
             {
-                scenario.Run(db, ctx);
+                var liveDb = group.Blocks.Find(dbName) as DataBlock;
+                if (liveDb == null)
+                {
+                    Log.Warning(
+                        "{Tag} scenario={Scenario} db={Db} plc={Plc} result=skip reason=block_not_found",
+                        ScenarioTag, scenario.Name, dbName, plcName);
+                    continue;
+                }
+                scenario.Run(liveDb, ctx);
             }
             catch (Exception ex)
             {

--- a/src/BlockParam/AddIn/DiagnosticsScenarioMenu.cs
+++ b/src/BlockParam/AddIn/DiagnosticsScenarioMenu.cs
@@ -262,9 +262,10 @@ public sealed class DiagnosticsScenarioMenu : ContextMenuAddIn
             return;
         }
 
-        // Pick the first top-level scalar leaf with a defined start value.
+        // Pick the first scalar leaf anywhere in the tree (real DBs are often
+        // instance/structured with no TOP-LEVEL scalar — scalars are nested).
         // Deterministic: same member chosen on every run against the same DB.
-        var target = info.Members.FirstOrDefault(m => m.IsLeaf && !m.IsArray);
+        var target = info.AllMembers().FirstOrDefault(m => m.IsLeaf && !m.IsArray);
         if (target == null)
         {
             Log.Warning(

--- a/src/BlockParam/BlockParam.csproj
+++ b/src/BlockParam/BlockParam.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>BlockParam</RootNamespace>
     <AssemblyName>BlockParam</AssemblyName>
-    <Version>1.0.13-temp</Version>
+    <Version>1.0.14-temp</Version>
     <Authors>Sawascwoolf</Authors>
     <Description>TIA Portal Add-In for editing Data Block start values and parameters — single and in bulk</Description>
     <ApplicationIcon>Resources\BlockParam_logo.ico</ApplicationIcon>

--- a/src/BlockParam/Diagnostics/OpenTiming.cs
+++ b/src/BlockParam/Diagnostics/OpenTiming.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Diagnostics;
+
+namespace BlockParam.Diagnostics;
+
+/// <summary>
+/// Lightweight <see cref="IDisposable"/> timing scope for the pre-dialog DB-open
+/// path. All output is machine-parseable OPEN-TIMING key=value lines written to
+/// the existing <see cref="Log"/> sink — no new I/O surface.
+///
+/// Usage:
+/// <code>
+/// using (var t = OpenTiming.Stage("export", db: "Foo", plc: "CPU_1"))
+/// {
+///     // ... timed work ...
+///     t.AddPredictors("xmlBytes", bytes);
+/// }
+/// </code>
+/// </summary>
+internal sealed class OpenTiming : IDisposable
+{
+    private readonly string _stage;
+    private readonly string _extras; // pre-built key=value pairs from ctor
+    private readonly Stopwatch _sw;
+    private string _predictors = "";
+    private bool _disposed;
+
+    private OpenTiming(string stage, string extras)
+    {
+        _stage = stage;
+        _extras = extras;
+        _sw = Stopwatch.StartNew();
+    }
+
+    /// <summary>Opens a timing scope for <paramref name="stage"/>.</summary>
+    /// <param name="stage">Short identifier, e.g. "export", "parse", "total".</param>
+    /// <param name="extras">Pre-built key=value pairs appended verbatim, e.g. "db=Foo plc=CPU_1".</param>
+    public static OpenTiming Stage(string stage, string extras = "")
+        => new OpenTiming(stage, extras);
+
+    /// <summary>
+    /// Appends additional size-predictor pairs to the log line.
+    /// Call any time before <see cref="Dispose"/>.
+    /// </summary>
+    public OpenTiming AddPredictors(string kvPairs)
+    {
+        _predictors = string.IsNullOrEmpty(_predictors)
+            ? kvPairs
+            : _predictors + " " + kvPairs;
+        return this;
+    }
+
+    /// <summary>Stops the stopwatch and emits one OPEN-TIMING log line.</summary>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _sw.Stop();
+
+        var parts = "OPEN-TIMING stage=" + _stage;
+        if (!string.IsNullOrEmpty(_extras)) parts += " " + _extras;
+        parts += " ms=" + _sw.ElapsedMilliseconds;
+        if (!string.IsNullOrEmpty(_predictors)) parts += " " + _predictors;
+
+        Log.Information(parts);
+    }
+}

--- a/src/BlockParam/Services/ActiveDbFactory.cs
+++ b/src/BlockParam/Services/ActiveDbFactory.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using Siemens.Engineering.SW.Blocks;
 using BlockParam.Diagnostics;
+using BlockParam.Models;
 using BlockParam.SimaticML;
 using BlockParam.UI;
 
@@ -65,17 +66,39 @@ public sealed class ActiveDbFactory : IActiveDbFactory
         // re-assignment is visible on the next Apply call (#19).
         DataBlock liveDb = initialSelection;
 
-        string xmlPath = null!;
-        if (!_exporter.TryExportWithCompilePrompt(liveDb,
-                () => xmlPath = _adapter.ExportBlock(liveDb, _tempDir)))
-        {
-            Log.Information("DB skipped (user declined compile): {DbName}", initialSelection.Name);
-            return null;
-        }
-        var xml = File.ReadAllText(xmlPath);
+        using var buildTimer = OpenTiming.Stage("build",
+            $"db={initialSelection.Name} plc={plcName}");
 
-        var parser = new SimaticMLParser(_constantResolver, _udtResolver, _commentResolver);
-        var info = parser.Parse(xml);
+        string xmlPath = null!;
+        using (var exportTimer = OpenTiming.Stage("export",
+            $"db={initialSelection.Name} plc={plcName}"))
+        {
+            if (!_exporter.TryExportWithCompilePrompt(liveDb,
+                    () => xmlPath = _adapter.ExportBlock(liveDb, _tempDir)))
+            {
+                Log.Information("DB skipped (user declined compile): {DbName}", initialSelection.Name);
+                return null;
+            }
+        }
+
+        string xml;
+        using (var readTimer = OpenTiming.Stage("read",
+            $"db={initialSelection.Name} plc={plcName}"))
+        {
+            xml = File.ReadAllText(xmlPath);
+            readTimer.AddPredictors($"xmlBytes={xml.Length}");
+        }
+
+        DataBlockInfo info;
+        using (var parseTimer = OpenTiming.Stage("parse",
+            $"db={initialSelection.Name} plc={plcName}"))
+        {
+            var parser = new SimaticMLParser(_constantResolver, _udtResolver, _commentResolver);
+            info = parser.Parse(xml);
+            var totalMembers = info.AllMembers().Count();
+            parseTimer.AddPredictors($"topMembers={info.Members.Count} totalMembers={totalMembers}");
+        }
+
         if (info.UnresolvedUdts.Count > 0)
         {
             Log.Information("DB {Name} references {Count} UDT(s) not in cache: {Types}",

--- a/src/BlockParam/addin-publisher-v20.xml
+++ b/src/BlockParam/addin-publisher-v20.xml
@@ -6,7 +6,7 @@
   <Product>
     <Name>BlockParam</Name>
     <Id>BlockParam</Id>
-    <Version>1.0.13-temp</Version>
+    <Version>1.0.14</Version>
   </Product>
   <FeatureAssembly>
     <AssemblyInfo>

--- a/src/BlockParam/addin-publisher-v21.xml
+++ b/src/BlockParam/addin-publisher-v21.xml
@@ -6,7 +6,7 @@
   <Product>
     <Name>BlockParam</Name>
     <Id>BlockParam</Id>
-    <Version>1.0.13-temp</Version>
+    <Version>1.0.14</Version>
   </Product>
   <FeatureAssembly>
     <AssemblyInfo>


### PR DESCRIPTION
## Why

Tooling to support the upcoming **#140** DB-open caching work: a one-click,
in-TIA scenario runner + sanitized log-extraction pipeline that produces
repeatable before/after timing data against real projects, so the cache
implementation can be validated empirically (not by hand-repeating a test
matrix).

Already produced clean, repeatable evidence on a 22 MB DB: re-export is
**never faster** (~3.4 s first, ~3.7–4.1 s second, across 3 runs) — the
open path has no cache and re-pays full cost. Round-trip (import+export)
≈ 8–9 s, which also quantifies the #146 freeze.

## ⚠️ Draft — NOT mergeable to `main` as-is

This branch was built as **DEV-ONLY, parked**. Opening it as a draft so the
tooling is reviewable and tracked for the #140 work — **do not squash-merge
into `main` without the changes below**, or the dev menu ships to the
marketplace and a test-build version bump lands on `main`.

Before any real merge:

1. **Gate the diagnostics menu** behind an MSBuild constant (e.g.
   `-p:DefineConstants=DIAGNOSTICS`) instead of "branch isolation". Today
   `DiagnosticsScenarioMenu` is registered unconditionally in
   `BulkChangeAddInProvider`; only the branch-never-merging keeps it out of
   the shipped package. A gate makes it safe in `main`.
2. **Drop commit `f5a4ba0`** (`csproj 1.0.14-temp` + numeric publisher
   manifests) — that's a local test-build artifact, not a `main` change.
3. **Decide on the OPEN-TIMING instrumentation** in product code
   (`ActiveDbFactory`, `BulkChangeContextMenu`): keep in `main` as
   diagnostics, or gate it too.
4. **`File.*` in `DiagnosticsScenarioMenu`**: a conscious exception to the
   CLAUDE.md "no new file I/O outside a storage layer" rule, accepted for a
   never-shipped dev tool (paths still rooted in `AppDirectories`, no new
   path literals). Revisit if it's promoted toward `main`.

## What's here

- `Diagnostics/OpenTiming.cs` + timing points in `ActiveDbFactory` /
  `BulkChangeContextMenu` — `OPEN-TIMING` lines on the pre-dialog open path.
- `AddIn/DiagnosticsScenarioMenu.cs` (+ 4-line registration) — right-click a
  DB → "BlockParam Diagnostics ▸ Run diagnostics scenarios": data-driven
  list (`export_twice`, `set_export_restore`, `clear_export_restore`),
  Option-B self-reverting (capture → mutate → export → restore → verify,
  `restoreOk`), type-safe values, per-scenario live-handle re-resolution.
- `extract-timing.ps1` — incremental, sanitized extraction (allowlist
  `SCENARIO`/`OPEN-TIMING`, salted-hash `db=`/`plc=`, drop name/value lines).

Relates to #140 (does not close it). `BulkChangeContextMenu.cs` change is
the timing instrumentation only.

## Test status

Release build clean (V20, 0/0). V20 `.addin` packaged and exercised
end-to-end inside TIA against a real 22 MB DB — full scenario matrix passes
(`restoreOk=True`, project copy left unchanged).
