### PR TITLE
test(#63): guard HW-typed ConstantName members against false range errors

### DIFF
--- a/src/BlockParam.Tests/MemberValidatorTests.cs
+++ b/src/BlockParam.Tests/MemberValidatorTests.cs
@@ -12,6 +12,9 @@ public class MemberValidatorTests
     private static MemberNode IntMember(string path = "db.moduleId") =>
         new("moduleId", "Int", "0", path, null, Array.Empty<MemberNode>());
 
+    private static MemberNode HwMember(string startValue) =>
+        new("a", "HW_INTERFACE", startValue, "db.a", null, Array.Empty<MemberNode>());
+
     private static TagTableCache CacheWithMod()
     {
         var reader = Substitute.For<ITagTableReader>();
@@ -93,6 +96,21 @@ public class MemberValidatorTests
         var error = v.Validate(IntMember(), "9999");
         error.Should().NotBeNull();
         error.Should().Contain("MOD_*");
+    }
+
+    [Fact]
+    public void HwTypedMember_WithSystemConstantName_ProducesNoIssue()
+    {
+        // #63 latent-regression guard. HW_* datatypes carrying PLC/HW system
+        // constant references (e.g. PROFINET port handles) are NOT in
+        // TiaDataTypeValidator.Validators, so Validate falls through to the
+        // "unknown type → no validation" branch and "Existing Issues" stays
+        // clean. If anyone later adds HW_INTERFACE to the Validators dict to
+        // range-check it as a Word, the v1.0.2 false-positive flood comes
+        // back — this flips red first.
+        var v = new MemberValidator(null, null);
+        v.Validate(HwMember("Local~PROFINET-Schnittstelle_1~Port_1"), "Local~PROFINET-Schnittstelle_1~Port_1")
+            .Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## What

Adds a single regression guard test: `MemberValidatorTests.HwTypedMember_WithSystemConstantName_ProducesNoIssue`.

## Why

#63 (false "value out of range" on symbolic constants) is **already resolved** — the substantive fix shipped in v1.0.2 (commit `3286d04`, recursive tag-table export). The issue has been closed.

The only loose end the maintainer analysis flagged was a *latent regression risk*: `HW_*` datatypes that carry PLC/HW system-constant references (e.g. PROFINET port handles) are not in `TiaDataTypeValidator.Validators`, so `Validate` correctly short-circuits at the "unknown type -> no validation" branch. If anyone later adds an `HW_*` type to that dict (e.g. to range-check it as a `Word`), the ~200-entry false-positive flood returns silently.

This test pins that path so the regression flips a test red before it reaches users. No production code changes.

## Verification

`dotnet test src/BlockParam.Tests -p:UseSiemensStubs=true --filter MemberValidatorTests` — 10/10 pass.

Reference: #63 (closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
