### PR TITLE
fix(#143/#144/#148): patterned bulk-scope label single source of truth + stale Set-caption + selected-cell outline

### DIFF
--- a/src/BlockParam.Tests/BulkChangeServiceTests.cs
+++ b/src/BlockParam.Tests/BulkChangeServiceTests.cs
@@ -269,4 +269,44 @@ public class BulkChangeServiceTests : IDisposable
         _logger.Entries.Should().OnlyContain(e => !e.Scope.Contains("(all selected DBs)"),
             "the cross-DB qualifier must not appear on single-DB log entries");
     }
+
+    /// <summary>
+    /// #152 review: the "All selected DBs" mega-scope already self-describes
+    /// via its AncestorName, so the change-log Scope column must stay the clean
+    /// "All selected DBs" — never the doubled "All selected DBs (all selected
+    /// DBs)" stutter. Drives the REAL <c>BuildAllSelectedDbsScope</c> through
+    /// <c>AnalyzeMulti</c> (not a hand-faked ScopeLevel) so the
+    /// <see cref="ScopeLevel.IsAllSelectedDbsScope"/> flag is exercised end to
+    /// end. Without the flag this test reproduces the stutter and fails.
+    /// </summary>
+    [Fact]
+    public void LogChanges_AllSelectedDbsMegaScope_NoDoubledQualifier()
+    {
+        var xml = TestFixtures.LoadXml("flat-db.xml");
+        var db1 = _parser.Parse(xml);
+        var db2 = _parser.Parse(TestFixtures.LoadXml("flat-db.xml"));
+        var analyzer = new HierarchyAnalyzer();
+        var speed = db1.AllMembers().First(m => m.Name == "Speed");
+
+        // The real mega-scope from the analyzer — not a constructed stand-in.
+        var megaScope = analyzer.AnalyzeMulti(new[] { db1, db2 }, db1, speed)
+            .Scopes.Single(s => s.IsAllSelectedDbsScope);
+        megaScope.IsCrossDb.Should().BeTrue("the mega-scope spans every selected DB");
+        megaScope.AncestorName.Should().Be("All selected DBs",
+            "the mega-scope's AncestorName already self-describes the cross-DB span");
+
+        _logger.Clear();
+        var service = CreateService();
+        var changeSet = new ChangeSet("FlatDB", "Speed", "Int", megaScope, "100");
+
+        service.ApplyViaXml(xml, changeSet);
+
+        _logger.Entries.Should().NotBeEmpty();
+        _logger.Entries.Should().OnlyContain(
+            e => e.Scope == "All selected DBs",
+            "the self-describing mega-scope must log its bare AncestorName");
+        _logger.Entries.Should().OnlyContain(
+            e => !e.Scope.Contains("(all selected DBs)"),
+            "the redundant cross-DB qualifier must be suppressed for the mega-scope (#152)");
+    }
 }

--- a/src/BlockParam.Tests/BulkChangeServiceTests.cs
+++ b/src/BlockParam.Tests/BulkChangeServiceTests.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Threading;
 using FluentAssertions;
 using NSubstitute;
 using BlockParam.Config;
@@ -13,6 +15,14 @@ public class BulkChangeServiceTests : IDisposable
     private readonly SimaticMLParser _parser = new();
     private readonly ChangeLogger _logger = new();
     private readonly List<string> _tempDirs = new();
+
+    public BulkChangeServiceTests()
+    {
+        // Scope qualifier text comes from Strings.resx — pin culture so en-US
+        // assertions are stable regardless of the runner's OS language.
+        Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
+        Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+    }
 
     public void Dispose()
     {
@@ -192,5 +202,71 @@ public class BulkChangeServiceTests : IDisposable
         result.IsSuccess.Should().BeTrue();
         var newDb = _parser.Parse(result.ModifiedXml);
         newDb.Members.First(m => m.Name == "Speed").StartValue.Should().Be("2000");
+    }
+
+    /// <summary>
+    /// #143 / #152: when the scope spans more than one selected DB (IsCrossDb = true),
+    /// the change-log Scope column must carry the cross-DB qualifier appended to the
+    /// concrete AncestorName so an auditor can distinguish a cross-DB bulk apply.
+    /// </summary>
+    [Fact]
+    public void LogChanges_CrossDbScope_ScopeEntryCarriesCrossDbQualifier()
+    {
+        var xml = TestFixtures.LoadXml("udt-instances-db.xml");
+        var db = _parser.Parse(xml);
+        var analyzer = new HierarchyAnalyzer();
+        var moduleId = db.AllMembers().First(m => m.Name == "ModuleId");
+        var withinDbScope = analyzer.Analyze(db, moduleId).Scopes.Last();
+
+        // Promote the within-DB scope to a cross-DB scope (IsCrossDb = true).
+        // Concrete AncestorName is preserved; IsCrossDb is the only change.
+        var crossDbScope = new ScopeLevel(
+            withinDbScope.AncestorName,
+            withinDbScope.AncestorPath,
+            withinDbScope.Depth,
+            withinDbScope.MatchingMembers,
+            withinDbScope.LeafName,
+            isCrossDb: true);
+
+        _logger.Clear();
+        var service = CreateService();
+        var changeSet = new ChangeSet("UdtInstancesDB", "ModuleId", "Int", crossDbScope, "55");
+
+        service.ApplyViaXml(xml, changeSet);
+
+        _logger.Entries.Should().NotBeEmpty();
+        _logger.Entries.Should().OnlyContain(
+            e => e.Scope == withinDbScope.AncestorName + " (all selected DBs)",
+            "cross-DB applies must carry the qualifier so auditors can distinguish them");
+        _logger.Entries.Should().OnlyContain(e => !e.Scope.Contains("*"),
+            "the audit log must record the concrete AncestorName, not the UI wildcard pattern");
+    }
+
+    /// <summary>
+    /// #152: a single-DB scope (IsCrossDb = false) must NOT carry the cross-DB qualifier
+    /// — the Scope column must equal the bare AncestorName, unchanged.
+    /// </summary>
+    [Fact]
+    public void LogChanges_SingleDbScope_ScopeEntryIsBarAncestorName()
+    {
+        var xml = TestFixtures.LoadXml("udt-instances-db.xml");
+        var db = _parser.Parse(xml);
+        var analyzer = new HierarchyAnalyzer();
+        var moduleId = db.AllMembers().First(m => m.Name == "ModuleId");
+        var scope = analyzer.Analyze(db, moduleId).Scopes.Last();
+        scope.IsCrossDb.Should().BeFalse("baseline: within-DB scope must not be flagged cross-DB");
+
+        _logger.Clear();
+        var service = CreateService();
+        var changeSet = new ChangeSet("UdtInstancesDB", "ModuleId", "Int", scope, "42");
+
+        service.ApplyViaXml(xml, changeSet);
+
+        _logger.Entries.Should().NotBeEmpty();
+        _logger.Entries.Should().OnlyContain(
+            e => e.Scope == scope.AncestorName,
+            "single-DB applies must log the bare AncestorName without any qualifier");
+        _logger.Entries.Should().OnlyContain(e => !e.Scope.Contains("(all selected DBs)"),
+            "the cross-DB qualifier must not appear on single-DB log entries");
     }
 }

--- a/src/BlockParam.Tests/BulkChangeViewModelTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelTests.cs
@@ -128,7 +128,12 @@ public class BulkChangeViewModelTests : IDisposable
             "AcceptSuggestion must re-raise the composed Set-button caption");
         raised.Should().Contain(nameof(BulkChangeViewModel.SetButtonTooltip),
             "AcceptSuggestion must re-raise the composed Set-button tooltip");
-        vm.SetButtonText.Should().Be("Set 4 in 'UdtInstancesDB'",
+        // #143: label is now the patterned form (wildcard + leaf), routed
+        // through the localized MenuTitle_SetAll template (assert via Res so
+        // the test is culture-independent — the runner OS may be de). The
+        // #144 fix here is the count moving off 0 + the notification firing.
+        vm.SetButtonText.Should().Be(
+            BlockParam.Localization.Res.Format("MenuTitle_SetAll", 4, "*.ModuleId"),
             "the caption must reflect the accepted suggestion's count, not stay frozen at 0");
     }
 
@@ -212,13 +217,18 @@ public class BulkChangeViewModelTests : IDisposable
         vm.Selection.SelectedScope = dbScope;
 
         vm.NewValue = "42"; // matches every selected member — 0 would change
-        vm.SetButtonText.Should().Be("Set 0 in 'UdtInstancesDB'",
+        // #143: patterned label (wildcard + leaf) via the localized
+        // MenuTitle_SetAll template — assert through Res so the test is
+        // culture-independent (matches the manual-mode test below).
+        vm.SetButtonText.Should().Be(
+            BlockParam.Localization.Res.Format("MenuTitle_SetAll", 0, "*.ModuleId"),
             "all 4 already hold '42' so the button must advertise 0, not 4");
         vm.SetPendingCommand.CanExecute(null).Should().BeFalse(
             "enable state and label come from the same predicate");
 
         vm.NewValue = "99"; // different — all 4 would change
-        vm.SetButtonText.Should().Be("Set 4 in 'UdtInstancesDB'");
+        vm.SetButtonText.Should().Be(
+            BlockParam.Localization.Res.Format("MenuTitle_SetAll", 4, "*.ModuleId"));
         vm.SetPendingCommand.CanExecute(null).Should().BeTrue();
     }
 

--- a/src/BlockParam.Tests/BulkChangeViewModelTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelTests.cs
@@ -94,6 +94,45 @@ public class BulkChangeViewModelTests : IDisposable
     }
 
     /// <summary>
+    /// #144: AcceptSuggestion cancels the NewValue debounce (verified above),
+    /// which is the only re-raise site for SetButtonText/SetButtonTooltip on
+    /// the typed path. Without an explicit re-raise the Set-button caption
+    /// stays frozen at the pre-selection count ("Set 0 in 'X'") even though
+    /// the preview and enable state move on. The fix re-raises both notifications
+    /// inside AcceptSuggestion after UpdateHighlighting().
+    /// </summary>
+    [Fact]
+    public void AcceptSuggestion_updates_SetButtonText_and_raises_notification()
+    {
+        var vm = CreateViewModelWithRule("udt-instances-db.xml", @"{ ""rules"": [] }");
+
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
+        vm.RefreshFlatList();
+
+        var moduleId = vm.Tree.FlatMembers.First(m => m.Name == "ModuleId" && m.IsLeaf);
+        vm.Selection.SelectedFlatMember = moduleId;
+        var dbScope = vm.Selection.AvailableScopes.First(s => s.MatchCount == 4);
+        vm.Selection.SelectedScope = dbScope;
+
+        // Pre-condition: empty value → 0 would change → caption advertises 0.
+        vm.SetButtonText.Should().Contain("0",
+            "with no value typed, nothing would change yet");
+
+        var raised = new List<string?>();
+        ((INotifyPropertyChanged)vm).PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        // Accept a value that differs from the existing "42" — all 4 would change.
+        vm.AcceptSuggestion("99");
+
+        raised.Should().Contain(nameof(BulkChangeViewModel.SetButtonText),
+            "AcceptSuggestion must re-raise the composed Set-button caption");
+        raised.Should().Contain(nameof(BulkChangeViewModel.SetButtonTooltip),
+            "AcceptSuggestion must re-raise the composed Set-button tooltip");
+        vm.SetButtonText.Should().Be("Set 4 in 'UdtInstancesDB'",
+            "the caption must reflect the accepted suggestion's count, not stay frozen at 0");
+    }
+
+    /// <summary>
     /// #26: Pre-existing values that violate a configured rule should be surfaced
     /// in <see cref="BulkChangeViewModel.ExistingIssues"/> on dialog load —
     /// without the user needing to edit them first.

--- a/src/BlockParam.Tests/HierarchyAnalyzerMultiDbTests.cs
+++ b/src/BlockParam.Tests/HierarchyAnalyzerMultiDbTests.cs
@@ -99,14 +99,14 @@ public class HierarchyAnalyzerMultiDbTests
 
         // No cross-DB scope should have a match count larger than the
         // db1-only counts: db2 contributes nothing.
+        // (#143: cross-DB classification moved from a magic AncestorName
+        // substring to the explicit ScopeLevel.IsCrossDb flag.)
         var withinDbMax = result.Scopes
-            .Where(s => s.AncestorName != "All selected DBs"
-                        && !s.AncestorName.Contains("across all selected DBs"))
+            .Where(s => !s.IsCrossDb)
             .Max(s => s.MatchCount);
 
         var crossDbMax = result.Scopes
-            .Where(s => s.AncestorName.Contains("across all selected DBs")
-                        || s.AncestorName == "All selected DBs")
+            .Where(s => s.IsCrossDb)
             .DefaultIfEmpty()
             .Max(s => s?.MatchCount ?? 0);
 
@@ -149,15 +149,15 @@ public class HierarchyAnalyzerMultiDbTests
 
         // For each within-DB scope, there must NOT be a cross-DB sibling
         // with the same MatchCount — that would be a noop sibling.
+        // (#143: classify via ScopeLevel.IsCrossDb, not an AncestorName substring.)
         var withinDbScopes = result.Scopes
-            .Where(s => !s.AncestorName.Contains("across all selected DBs")
-                        && s.AncestorName != "All selected DBs")
+            .Where(s => !s.IsCrossDb)
             .ToList();
 
         foreach (var w in withinDbScopes)
         {
             result.Scopes
-                .Where(s => s.AncestorName.Contains("across all selected DBs"))
+                .Where(s => s.IsCrossDb)
                 .Should().NotContain(s => s.MatchCount == w.MatchCount
                                           && s.AncestorPath == w.AncestorPath,
                     "noop cross-DB sibling must be suppressed when the lift adds no matches");

--- a/src/BlockParam.Tests/ScopeLabelFormatterTests.cs
+++ b/src/BlockParam.Tests/ScopeLabelFormatterTests.cs
@@ -1,0 +1,140 @@
+using System.Globalization;
+using System.Threading;
+using BlockParam.Models;
+using BlockParam.Services;
+using BlockParam.SimaticML;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// #143: the bulk-scope label must state the <em>pattern</em> the scope
+/// matches (with a <c>*</c> wildcard for the varying instance/DB segment)
+/// and name the leaf field being written — not a single concrete
+/// DB-qualified example path. <see cref="ScopeLabelFormatter"/> is the
+/// single source of truth every render site routes through.
+/// </summary>
+public class ScopeLabelFormatterTests
+{
+    private readonly SimaticMLParser _parser = new();
+    private readonly HierarchyAnalyzer _analyzer = new();
+
+    public ScopeLabelFormatterTests()
+    {
+        // Labels go through Strings.resx — pin culture so en assertions are
+        // stable regardless of the runner's OS language.
+        Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
+        Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+    }
+
+    private static ScopeLevel Scope(
+        string ancestorName, string ancestorPath, string leafName,
+        int matchCount = 4, bool isCrossDb = false)
+    {
+        var members = Enumerable.Range(0, matchCount)
+            .Select(i => new MemberNode(
+                leafName, "Bool", null, $"x{i}.{leafName}", null, Array.Empty<MemberNode>()))
+            .ToList();
+        return new ScopeLevel(ancestorName, ancestorPath, 0, members, leafName, isCrossDb);
+    }
+
+    [Fact]
+    public void Pattern_WithinDb_WildcardsLeadingSegment_AndAppendsLeaf()
+    {
+        // Concrete AncestorName "DB21.resetButton" → pattern "*.resetButton.elementId".
+        var scope = Scope("DB21.resetButton", "resetButton", "elementId");
+
+        ScopeLabelFormatter.Pattern(scope).Should().Be("*.resetButton.elementId");
+        scope.Label.Should().Be("Set all 4 in *.resetButton.elementId");
+    }
+
+    [Fact]
+    public void Pattern_DbRoot_NoAncestorPath_StillNamesLeaf()
+    {
+        // DB-root scope has an empty ancestor path: pattern collapses to "*.leaf".
+        var scope = Scope("DB21", "", "elementId");
+
+        ScopeLabelFormatter.Pattern(scope).Should().Be("*.elementId");
+        scope.Label.Should().Be("Set all 4 in *.elementId");
+    }
+
+    [Fact]
+    public void CrossDb_FoldsSuffixIntoLeadingWildcard_NoStringAppend()
+    {
+        // Pre-#143 this rendered "Set all 8 in 'DB21.resetButton — across all
+        // selected DBs'". The "— across all selected DBs" append is gone; the
+        // leading "*" already says the DB varies.
+        var scope = Scope("DB21.resetButton", "resetButton", "elementId",
+            matchCount: 8, isCrossDb: true);
+
+        scope.Label.Should().Be("Set all 8 in *.resetButton.elementId");
+        scope.Label.Should().NotContain("across all selected DBs");
+        scope.Label.Should().NotContain("'");
+    }
+
+    [Fact]
+    public void MegaScope_EmptyAncestorPath_RendersWildcardLeaf()
+    {
+        var scope = Scope("All selected DBs", "", "elementId",
+            matchCount: 12, isCrossDb: true);
+
+        scope.Label.Should().Be("Set all 12 in *.elementId");
+    }
+
+    [Fact]
+    public void NoLeaf_ArrayElementScope_PatternIsJustWildcardedPath()
+    {
+        // Array-element scopes target the elements themselves — no separate
+        // leaf field. Pattern is the wildcarded array path, no trailing dot.
+        var scope = Scope("DB21.Motors", "Motors", leafName: "", matchCount: 5);
+
+        ScopeLabelFormatter.Pattern(scope).Should().Be("*.Motors");
+        scope.Label.Should().Be("Set all 5 in *.Motors");
+    }
+
+    [Fact]
+    public void ToString_RoutesThroughTheSameFormatter()
+    {
+        var scope = Scope("DB21.resetButton", "resetButton", "elementId");
+        scope.ToString().Should().Be(scope.Label);
+    }
+
+    [Fact]
+    public void Analyzer_WithinDbScope_LabelNamesWildcardAndLeaf()
+    {
+        // Integration: a real analysis must thread the leaf name through so
+        // the label states the field being written.
+        var db = _parser.Parse(TestFixtures.LoadXml("udt-instances-db.xml"));
+        var moduleId = db.Members[0].Children[0].Children[0];
+        moduleId.Name.Should().Be("ModuleId");
+
+        var result = _analyzer.Analyze(db, moduleId);
+
+        var dbScope = result.Scopes.First(s => s.AncestorName == "UdtInstancesDB");
+        dbScope.LeafName.Should().Be("ModuleId");
+        dbScope.Label.Should().Be($"Set all {dbScope.MatchCount} in *.ModuleId");
+        dbScope.Label.Should().NotContain("UdtInstancesDB",
+            "the label states the pattern, not the concrete DB name");
+    }
+
+    [Fact]
+    public void Analyzer_CrossDbLift_IsCrossDbFlaggedAndLabelHasNoSuffix()
+    {
+        var db1 = _parser.Parse(TestFixtures.LoadXml("udt-instances-db.xml"));
+        var db2 = _parser.Parse(TestFixtures.LoadXml("udt-instances-db.xml"));
+        var moduleId = db1.Members[0].Children[0].Children[0];
+
+        var result = _analyzer.AnalyzeMulti(new[] { db1, db2 }, db1, moduleId);
+
+        var crossDb = result.Scopes.Where(s => s.IsCrossDb).ToList();
+        crossDb.Should().NotBeEmpty("two identical DBs must produce cross-DB lifts");
+        crossDb.Should().AllSatisfy(s =>
+        {
+            s.Label.Should().StartWith("Set all ");
+            s.Label.Should().Contain("*.");
+            s.Label.Should().NotContain("across all selected DBs");
+            s.Label.Should().NotContain("'");
+        });
+    }
+}

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -133,6 +133,7 @@ Nein = Aktuelles (möglicherweise unvollständiges) Ergebnis behalten</value></d
   <data name="Column_Name" xml:space="preserve"><value>Name</value></data>
   <data name="Column_DataType" xml:space="preserve"><value>Datentyp</value></data>
   <data name="Column_StartValue" xml:space="preserve"><value>Startwert</value></data>
+  <data name="Legend_Selected" xml:space="preserve"><value>Ausgewählt</value></data>
   <!-- BulkChangeDialog -->
   <data name="Dialog_BulkEdit" xml:space="preserve"><value>Massenänderung</value></data>
   <data name="Dialog_Set" xml:space="preserve"><value>Setzen</value></data>

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -58,6 +58,7 @@
   <data name="Error_NotADataBlock" xml:space="preserve"><value>Das ausgewählte Element ist kein Datenbaustein.</value></data>
   <data name="Error_ProtectedBlock" xml:space="preserve"><value>Dieser Datenbaustein ist schreib- oder Know-how-geschützt.</value></data>
   <!-- Logging -->
+  <data name="Scope_CrossDbQualifier" xml:space="preserve"><value> (alle ausgewählten DBs)</value></data>
   <data name="Log_ValueChanged" xml:space="preserve"><value>'{0}' geändert von '{1}' auf '{2}'</value></data>
   <data name="Log_BulkOperationComplete" xml:space="preserve"><value>Massenoperation abgeschlossen: {0} Werte geändert in '{1}'</value></data>
   <!-- Bereinigung -->

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -33,7 +33,7 @@
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <!-- Kontextmenü -->
   <data name="MenuTitle_BulkChange" xml:space="preserve"><value>BlockParam...</value></data>
-  <data name="MenuTitle_SetAll" xml:space="preserve"><value>Alle {0} in '{1}' setzen</value></data>
+  <data name="MenuTitle_SetAll" xml:space="preserve"><value>Alle {0} in {1} setzen</value></data>
   <data name="MenuTitle_EditStartValues" xml:space="preserve"><value>Startwerte bearbeiten...</value></data>
   <!-- Dialog -->
   <data name="Dialog_Title" xml:space="preserve"><value>BlockParam: {0}</value></data>
@@ -144,9 +144,9 @@ Dies kann nicht rückgängig gemacht werden.</value></data>
   <data name="Dialog_Constants" xml:space="preserve"><value>Konstanten</value></data>
   <data name="Dialog_RefreshConstants" xml:space="preserve"><value>Konstanten aktualisieren</value></data>
   <data name="Dialog_SetTooltip" xml:space="preserve"><value>Bulk-Werte als ausstehend markieren (gelb)</value></data>
-  <data name="Dialog_SetTooltip_ScopeIdle" xml:space="preserve"><value>{0} Element(e) in '{1}'</value></data>
+  <data name="Dialog_SetTooltip_ScopeIdle" xml:space="preserve"><value>{0} Element(e) in {1}</value></data>
   <data name="Dialog_SetTooltip_ManualIdle" xml:space="preserve"><value>{0} Element(e) ausgewählt</value></data>
-  <data name="Dialog_SetTooltip_ScopeBreakdown" xml:space="preserve"><value>{0} von {1} in '{2}' werden gesetzt · {3} bereits auf diesem Wert</value></data>
+  <data name="Dialog_SetTooltip_ScopeBreakdown" xml:space="preserve"><value>{0} von {1} in {2} werden gesetzt · {3} bereits auf diesem Wert</value></data>
   <data name="Dialog_SetTooltip_ManualBreakdown" xml:space="preserve"><value>{0} von {1} ausgewählten werden gesetzt · {2} bereits auf diesem Wert</value></data>
   <data name="Dialog_LimitReachedOverlay_Title" xml:space="preserve"><value>Tägliches Gratis-Limit erreicht</value></data>
   <data name="Dialog_LimitReachedOverlay_Text" xml:space="preserve"><value>Upgrade auf Pro für unbegrenzte Massenänderungen, oder bis morgen warten.</value></data>

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -91,6 +91,14 @@
     <value>This Data Block is write-protected or know-how protected.</value>
   </data>
   <!-- Logging -->
+  <!-- Appended to AncestorName in the change-log Scope column when the bulk
+       operation was applied across more than one selected DB (IsCrossDb = true).
+       Kept as a plain parenthetical so auditors reading the log can distinguish
+       a cross-DB bulk apply from a single-DB one.  (#143 / #152) -->
+  <data name="Scope_CrossDbQualifier" xml:space="preserve">
+    <value> (all selected DBs)</value>
+    <comment>Parenthetical appended to the concrete AncestorName in the audit-log Scope column when IsCrossDb is true. The leading space is intentional so it reads "TP307.drive1 (all selected DBs)" without extra glue code in the caller.</comment>
+  </data>
   <data name="Log_ValueChanged" xml:space="preserve">
     <value>Changed '{0}' from '{1}' to '{2}'</value>
     <comment>{0} = member path, {1} = old value, {2} = new value</comment>

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -44,8 +44,8 @@
     <value>BlockParam...</value>
   </data>
   <data name="MenuTitle_SetAll" xml:space="preserve">
-    <value>Set all {0} in '{1}'</value>
-    <comment>{0} = count, {1} = scope name</comment>
+    <value>Set all {0} in {1}</value>
+    <comment>{0} = match count, {1} = scope match pattern (e.g. *.resetButton.elementId). Single source of truth for the bulk-scope label; rendered by ScopeLabelFormatter and reused by the dropdown, Set button, tooltip, ToString and context menu (#143).</comment>
   </data>
   <!-- Context menu action item label (#50). The submenu root is MenuTitle_BulkChange ("BlockParam..."); this is the leaf the user clicks. -->
   <data name="MenuTitle_EditStartValues" xml:space="preserve">
@@ -358,16 +358,16 @@ This cannot be undone.</value>
     <value>Stage bulk values as pending (yellow)</value>
   </data>
   <data name="Dialog_SetTooltip_ScopeIdle" xml:space="preserve">
-    <value>{0} member(s) in '{1}'</value>
-    <comment>{0} = total scope size, {1} = ancestor name. Shown when no value is typed.</comment>
+    <value>{0} member(s) in {1}</value>
+    <comment>{0} = total scope size, {1} = scope match pattern. Shown when no value is typed.</comment>
   </data>
   <data name="Dialog_SetTooltip_ManualIdle" xml:space="preserve">
     <value>{0} member(s) selected</value>
     <comment>{0} = total manual selection. Shown when no value is typed.</comment>
   </data>
   <data name="Dialog_SetTooltip_ScopeBreakdown" xml:space="preserve">
-    <value>{0} of {1} in '{2}' will be staged · {3} already at this value</value>
-    <comment>{0} = will-stage count, {1} = total scope, {2} = ancestor name, {3} = already-match count</comment>
+    <value>{0} of {1} in {2} will be staged · {3} already at this value</value>
+    <comment>{0} = will-stage count, {1} = total scope, {2} = scope match pattern, {3} = already-match count</comment>
   </data>
   <data name="Dialog_SetTooltip_ManualBreakdown" xml:space="preserve">
     <value>{0} of {1} selected will be staged · {2} already at this value</value>

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -310,6 +310,10 @@ No = Keep the current (possibly partial) result</value>
   <data name="Column_StartValue" xml:space="preserve">
     <value>Start value</value>
   </data>
+  <!-- Member-table legend: selected/targeted Value cell (#148). -->
+  <data name="Legend_Selected" xml:space="preserve">
+    <value>Selected</value>
+  </data>
   <!-- Cleanup Dialog -->
   <data name="Cleanup_Title" xml:space="preserve">
     <value>Struct Cleanup</value>

--- a/src/BlockParam/Services/BulkChangeService.cs
+++ b/src/BlockParam/Services/BulkChangeService.cs
@@ -132,12 +132,14 @@ public class BulkChangeService
     private void LogChanges(ChangeSet changeSet, IEnumerable<ValueChange> changes)
     {
         // Retain the concrete AncestorName for audit traceability (never log the
-        // "*" UI pattern here). When the scope spans more than one selected DB
-        // (IsCrossDb = true), append the cross-DB qualifier so an auditor reading
-        // the log can distinguish a cross-DB bulk apply from a single-DB one.
-        // The qualifier text is sourced from Strings.resx (Scope_CrossDbQualifier)
-        // to satisfy the no-inline-user-visible-strings guardrail. (#143 / #152)
-        var auditScope = changeSet.Scope.IsCrossDb
+        // "*" UI pattern here). For a cross-DB *lift* scope (IsCrossDb, concrete
+        // within-DB AncestorName) append the cross-DB qualifier so an auditor can
+        // distinguish it from a single-DB apply. The "All selected DBs" mega-scope
+        // already self-describes (IsAllSelectedDbsScope) — skip the qualifier
+        // there to avoid the "All selected DBs (all selected DBs)" stutter. The
+        // qualifier text is sourced from Strings.resx (Scope_CrossDbQualifier) to
+        // satisfy the no-inline-user-visible-strings guardrail. (#143 / #152)
+        var auditScope = changeSet.Scope.IsCrossDb && !changeSet.Scope.IsAllSelectedDbsScope
             ? changeSet.Scope.AncestorName + Res.Get("Scope_CrossDbQualifier")
             : changeSet.Scope.AncestorName;
 

--- a/src/BlockParam/Services/BulkChangeService.cs
+++ b/src/BlockParam/Services/BulkChangeService.cs
@@ -1,4 +1,5 @@
 using BlockParam.Config;
+using BlockParam.Localization;
 using BlockParam.Models;
 using BlockParam.SimaticML;
 
@@ -130,6 +131,16 @@ public class BulkChangeService
 
     private void LogChanges(ChangeSet changeSet, IEnumerable<ValueChange> changes)
     {
+        // Retain the concrete AncestorName for audit traceability (never log the
+        // "*" UI pattern here). When the scope spans more than one selected DB
+        // (IsCrossDb = true), append the cross-DB qualifier so an auditor reading
+        // the log can distinguish a cross-DB bulk apply from a single-DB one.
+        // The qualifier text is sourced from Strings.resx (Scope_CrossDbQualifier)
+        // to satisfy the no-inline-user-visible-strings guardrail. (#143 / #152)
+        var auditScope = changeSet.Scope.IsCrossDb
+            ? changeSet.Scope.AncestorName + Res.Get("Scope_CrossDbQualifier")
+            : changeSet.Scope.AncestorName;
+
         foreach (var change in changes)
         {
             _logger.Log(new ChangeLogEntry(
@@ -139,7 +150,7 @@ public class BulkChangeService
                 change.Datatype,
                 change.OldValue,
                 change.NewValue,
-                changeSet.Scope.AncestorName));
+                auditScope));
         }
     }
 }

--- a/src/BlockParam/Services/HierarchyAnalyzer.cs
+++ b/src/BlockParam/Services/HierarchyAnalyzer.cs
@@ -276,7 +276,8 @@ public class HierarchyAnalyzer
             depth: -2000, // Sorts last (broadest).
             matchingMembers: matches,
             leafName: name,
-            isCrossDb: true);
+            isCrossDb: true,
+            isAllSelectedDbsScope: true);
     }
 
     /// <summary>
@@ -545,7 +546,8 @@ public class ScopeLevel
         int depth,
         IReadOnlyList<MemberNode> matchingMembers,
         string leafName = "",
-        bool isCrossDb = false)
+        bool isCrossDb = false,
+        bool isAllSelectedDbsScope = false)
     {
         AncestorName = ancestorName;
         AncestorPath = ancestorPath;
@@ -553,6 +555,7 @@ public class ScopeLevel
         MatchingMembers = matchingMembers;
         LeafName = leafName;
         IsCrossDb = isCrossDb;
+        IsAllSelectedDbsScope = isAllSelectedDbsScope;
     }
 
     /// <summary>
@@ -586,6 +589,16 @@ public class ScopeLevel
     /// suffix into the label template (#143) removed that substring.
     /// </summary>
     public bool IsCrossDb { get; }
+
+    /// <summary>
+    /// True only for the "All selected DBs" mega-scope, whose
+    /// <see cref="AncestorName"/> ("All selected DBs") already self-describes
+    /// the cross-DB span. Lets the audit log skip the redundant cross-DB
+    /// qualifier here (it is still appended for cross-DB <em>lift</em> scopes,
+    /// whose AncestorName is a concrete within-DB ancestor). Explicit flag
+    /// rather than substring-matching AncestorName (#152 review).
+    /// </summary>
+    public bool IsAllSelectedDbsScope { get; }
 
     /// <summary>Number of members that would be affected by this bulk operation</summary>
     public int MatchCount => MatchingMembers.Count;

--- a/src/BlockParam/Services/HierarchyAnalyzer.cs
+++ b/src/BlockParam/Services/HierarchyAnalyzer.cs
@@ -124,10 +124,12 @@ public class HierarchyAnalyzer
         if (matches.Count < 2) return null;
 
         return new ScopeLevel(
-            ancestorName: $"all selected DBs.{ancestorPath}",
+            ancestorName: ancestorPath,
             ancestorPath: ancestorPath,
             depth: -1000 + ancestor.Depth,
-            matchingMembers: matches);
+            matchingMembers: matches,
+            leafName: name,
+            isCrossDb: true);
     }
 
     private static List<ScopeLevel> DeduplicateByMatchCount(List<ScopeLevel> scopes)
@@ -232,11 +234,17 @@ public class HierarchyAnalyzer
 
         if (lifted.Count == 0) return null;
 
+        // The " — across all selected DBs" suffix used to be string-appended
+        // onto AncestorName here; #143 folded it into the patterned label
+        // (the leading "*" already says "varies across DBs"). AncestorName
+        // stays the concrete within-DB name for audit/classification.
         return new ScopeLevel(
-            ancestorName: $"{withinDbScope.AncestorName} — across all selected DBs",
+            ancestorName: withinDbScope.AncestorName,
             ancestorPath: withinDbScope.AncestorPath,
             depth: -1000 + withinDbScope.Depth, // Cross-DB scopes sort after their within-DB sibling.
-            matchingMembers: lifted);
+            matchingMembers: lifted,
+            leafName: selectedMember.Name,
+            isCrossDb: true);
     }
 
     /// <summary>
@@ -266,7 +274,9 @@ public class HierarchyAnalyzer
             ancestorName: "All selected DBs",
             ancestorPath: "",
             depth: -2000, // Sorts last (broadest).
-            matchingMembers: matches);
+            matchingMembers: matches,
+            leafName: name,
+            isCrossDb: true);
     }
 
     /// <summary>
@@ -369,11 +379,19 @@ public class HierarchyAnalyzer
                 labelParts[d] = (mask & (1 << d)) != 0 ? selectedIndices[d].ToString() : "*";
             var prefixLabel = $"[{string.Join(",", labelParts)}]";
 
+            // Leaf is meaningful only for array-of-UDT (nested field selected);
+            // when the element itself is the target the index segment already
+            // identifies it.
+            var partialLeaf = ReferenceEquals(arrayElement, selectedMember)
+                ? ""
+                : selectedMember.Name;
+
             result.Add(new ScopeLevel(
                 ancestorName: $"{db.Name}.{arrayParent.Path}{prefixLabel}",
                 ancestorPath: $"{arrayParent.Path}{prefixLabel}",
                 depth: arrayParent.Depth + 1,
-                matchingMembers: members));
+                matchingMembers: members,
+                leafName: partialLeaf));
         }
 
         return result;
@@ -420,7 +438,8 @@ public class HierarchyAnalyzer
                     ancestorName: $"{db.Name}.{ancestor.Path}",
                     ancestorPath: ancestor.Path,
                     depth: ancestor.Depth,
-                    matchingMembers: matchesInScope));
+                    matchingMembers: matchesInScope,
+                    leafName: selectedMember.Name));
             }
         }
 
@@ -431,7 +450,8 @@ public class HierarchyAnalyzer
                 ancestorName: db.Name,
                 ancestorPath: "",
                 depth: -1, // Root level
-                matchingMembers: allMatches));
+                matchingMembers: allMatches,
+                leafName: selectedMember.Name));
         }
 
         // Remove duplicate scopes (where match count is the same as a broader scope)
@@ -523,15 +543,24 @@ public class ScopeLevel
         string ancestorName,
         string ancestorPath,
         int depth,
-        IReadOnlyList<MemberNode> matchingMembers)
+        IReadOnlyList<MemberNode> matchingMembers,
+        string leafName = "",
+        bool isCrossDb = false)
     {
         AncestorName = ancestorName;
         AncestorPath = ancestorPath;
         Depth = depth;
         MatchingMembers = matchingMembers;
+        LeafName = leafName;
+        IsCrossDb = isCrossDb;
     }
 
-    /// <summary>Display name of the ancestor (e.g. "TP307.drive1" or "TP307")</summary>
+    /// <summary>
+    /// Concrete DB-qualified ancestor name (e.g. "TP307.drive1" or "TP307").
+    /// Kept concrete on purpose: used for scope classification and as the
+    /// audit-log scope column. The user-facing label is <see cref="Label"/>,
+    /// which renders the <em>pattern</em> via <see cref="ScopeLabelFormatter"/>.
+    /// </summary>
     public string AncestorName { get; }
 
     /// <summary>Full path of the ancestor (empty for DB root)</summary>
@@ -543,8 +572,31 @@ public class ScopeLevel
     /// <summary>All members matching the target name within this scope</summary>
     public IReadOnlyList<MemberNode> MatchingMembers { get; }
 
+    /// <summary>
+    /// Name of the leaf member being written (e.g. "elementId"). Threaded in
+    /// at construction so the patterned <see cref="Label"/> can name the
+    /// field the bulk op actually changes (#143).
+    /// </summary>
+    public string LeafName { get; }
+
+    /// <summary>
+    /// True when this scope spans more than one selected DB (cross-DB lift /
+    /// "all selected DBs" mega-scope). Replaces the old "contains a magic
+    /// substring in AncestorName" classification — folding the cross-DB
+    /// suffix into the label template (#143) removed that substring.
+    /// </summary>
+    public bool IsCrossDb { get; }
+
     /// <summary>Number of members that would be affected by this bulk operation</summary>
     public int MatchCount => MatchingMembers.Count;
 
-    public override string ToString() => $"Set all {MatchCount} in '{AncestorName}'";
+    /// <summary>
+    /// The single user-facing label, e.g. <c>Set all 4 in *.resetButton.elementId</c>.
+    /// All render sites (both XAML ItemTemplates, the Set button, its tooltip,
+    /// <see cref="ToString"/>, the context menu) bind/route through this so
+    /// they cannot drift (#143).
+    /// </summary>
+    public string Label => ScopeLabelFormatter.Format(this);
+
+    public override string ToString() => Label;
 }

--- a/src/BlockParam/Services/ScopeLabelFormatter.cs
+++ b/src/BlockParam/Services/ScopeLabelFormatter.cs
@@ -1,0 +1,70 @@
+using System.Text;
+using BlockParam.Localization;
+
+namespace BlockParam.Services;
+
+/// <summary>
+/// Single source of truth for the user-facing "Set all N in …" bulk-scope
+/// label (#143).
+///
+/// <para>
+/// Before this class there were 5+ independent renderings of the same
+/// concept — two XAML <c>ItemTemplate</c>s, <see cref="ScopeLevel.ToString"/>,
+/// the Set-button caption, and the Set-button tooltip — each composing the
+/// concrete, DB-qualified <see cref="ScopeLevel.AncestorName"/> by hand.
+/// They drifted, advertised one concrete example path instead of the
+/// pattern the scope matches, and never named the leaf field being written.
+/// </para>
+///
+/// <para>
+/// This formatter emits the <em>pattern</em>, not an example. The varying
+/// instance / DB segment becomes a <c>*</c> wildcard (the same convention
+/// already used for unfixed array dimensions, e.g. <c>Motors[2,*]</c>), and
+/// the leaf member actually being set is appended. Cross-DB scopes use the
+/// same leading <c>*</c> (the DB is the thing that varies), so the awkward
+/// "<c> -- across all selected DBs</c>" string append disappears — the
+/// pattern already states it.
+/// </para>
+///
+/// <para>
+/// Every caller routes through <see cref="Pattern"/> /
+/// <see cref="Format(ScopeLevel)"/> so the renderings cannot drift again.
+/// The single resx template is <c>MenuTitle_SetAll</c> ("Set all {0} in
+/// {1}"), reused across <c>en</c>/<c>de</c>.
+/// </para>
+/// </summary>
+public static class ScopeLabelFormatter
+{
+    private const string Wildcard = "*";
+
+    /// <summary>
+    /// The scope-match pattern, e.g. <c>*.resetButton.elementId</c>.
+    /// Leading <c>*</c> = the varying instance/DB segment; the middle is the
+    /// scope's ancestor path (empty for a DB-root or all-DBs scope); the
+    /// trailing segment is the leaf member being written.
+    /// </summary>
+    public static string Pattern(ScopeLevel scope)
+    {
+        var sb = new StringBuilder(Wildcard);
+        if (!string.IsNullOrEmpty(scope.AncestorPath))
+        {
+            sb.Append('.');
+            sb.Append(scope.AncestorPath);
+        }
+        if (!string.IsNullOrEmpty(scope.LeafName))
+        {
+            sb.Append('.');
+            sb.Append(scope.LeafName);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// The full user-facing label, e.g. <c>Set all 4 in *.resetButton.elementId</c>.
+    /// Routed through the single <c>MenuTitle_SetAll</c> resx template so the
+    /// dropdown, Set button, tooltip, ToString and context menu render
+    /// identically and localize together.
+    /// </summary>
+    public static string Format(ScopeLevel scope) =>
+        Res.Format("MenuTitle_SetAll", scope.MatchCount, Pattern(scope));
+}

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -23,6 +23,14 @@
             <local:StringNotEmptyToVisibilityConverter x:Key="StringToVis"/>
             <local:InvertBoolConverter x:Key="InvertBool"/>
 
+            <!-- #148: selected/targeted Value-cell outline. A 2px indigo
+                 border (NOT a fill) so the orthogonal state fill
+                 (green / blue / amber / red) stays visible underneath.
+                 Deliberately distinct from the green #D5F0D5 / #4CAF50
+                 "Already matching" affordance. Single token — no scattered
+                 inline hex. -->
+            <SolidColorBrush x:Key="SelectedCellOutline" Color="#5B21B6"/>
+
         <!-- Trigger-summary overflow rules for the pill row. Mirrors the
              defaults baked into PillOverflowOptions.DataBlockDefault(): keep
              showing full DB names until the joined text passes ~30 chars or
@@ -336,7 +344,15 @@
                     <Border Background="#CCE5FF" Width="12" Height="12" BorderBrush="#2196F3" BorderThickness="3,0,0,0" Margin="0,0,3,0"/>
                     <TextBlock Text="Bulk set" Foreground="#888" FontSize="10" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <Border Background="#FFCDD2" Width="12" Height="12" BorderBrush="#D32F2F" BorderThickness="3,0,0,0" Margin="0,0,3,0"/>
-                    <TextBlock Text="Invalid" Foreground="#888" FontSize="10" VerticalAlignment="Center"/>
+                    <TextBlock Text="Invalid" Foreground="#888" FontSize="10" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                    <!-- #148: selected/targeted Value cell — a 2px indigo
+                         outline with transparent fill (the state fill shows
+                         through), not another colored fill. Same brush token
+                         as the cell trigger so they can't drift. -->
+                    <Border Background="Transparent" Width="12" Height="12"
+                            BorderBrush="{StaticResource SelectedCellOutline}"
+                            BorderThickness="2" Margin="0,0,3,0"/>
+                    <TextBlock Text="{loc:Loc Legend_Selected}" Foreground="#888" FontSize="10" VerticalAlignment="Center"/>
                 </StackPanel>
 
                 <!-- Member Table fills the rest of the column -->
@@ -517,6 +533,16 @@
                                                     </DataTrigger>
                                                     <DataTrigger Binding="{Binding HasInlineError}" Value="True">
                                                         <Setter Property="Background" Value="#FFCDD2"/>
+                                                    </DataTrigger>
+                                                    <!-- #148: selected/targeted row. Highest priority
+                                                         (declared last) but only touches BorderBrush /
+                                                         BorderThickness — the state fill above keeps its
+                                                         Background and shows through the transparent
+                                                         interior, so a row that is both selected AND
+                                                         "Already matching" is no longer indistinguishable. -->
+                                                    <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                                        <Setter Property="BorderBrush" Value="{StaticResource SelectedCellOutline}"/>
+                                                        <Setter Property="BorderThickness" Value="2"/>
                                                     </DataTrigger>
                                                 </Style.Triggers>
                                             </Style>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -23,13 +23,13 @@
             <local:StringNotEmptyToVisibilityConverter x:Key="StringToVis"/>
             <local:InvertBoolConverter x:Key="InvertBool"/>
 
-            <!-- #148: selected/targeted Value-cell outline. A 2px indigo
-                 border (NOT a fill) so the orthogonal state fill
-                 (green / blue / amber / red) stays visible underneath.
-                 Deliberately distinct from the green #D5F0D5 / #4CAF50
-                 "Already matching" affordance. Single token — no scattered
-                 inline hex. -->
-            <SolidColorBrush x:Key="SelectedCellOutline" Color="#5B21B6"/>
+        <!-- #148: selected/targeted Value-cell outline. A 2px indigo
+             border (NOT a fill) so the orthogonal state fill
+             (green / blue / amber / red) stays visible underneath.
+             Deliberately distinct from the green #D5F0D5 / #4CAF50
+             "Already matching" affordance. Single token — no scattered
+             inline hex. -->
+        <SolidColorBrush x:Key="SelectedCellOutline" Color="#5B21B6"/>
 
         <!-- Trigger-summary overflow rules for the pill row. Mirrors the
              defaults baked into PillOverflowOptions.DataBlockDefault(): keep

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -792,13 +792,11 @@
                                                           HorizontalAlignment="Stretch">
                                                     <ComboBox.ItemTemplate>
                                                         <DataTemplate>
-                                                            <TextBlock>
-                                                                <Run Text="Set all "/>
-                                                                <Run Text="{Binding MatchCount, Mode=OneWay}" FontWeight="SemiBold"/>
-                                                                <Run Text=" in '"/>
-                                                                <Run Text="{Binding AncestorName, Mode=OneWay}"/>
-                                                                <Run Text="'"/>
-                                                            </TextBlock>
+                                                            <!-- #143: single source of truth — ScopeLevel.Label
+                                                                 (ScopeLabelFormatter + MenuTitle_SetAll resx).
+                                                                 Kept identical-by-construction with the
+                                                                 ScopeOverlayList template below. -->
+                                                            <TextBlock Text="{Binding Label, Mode=OneWay}"/>
                                                         </DataTemplate>
                                                     </ComboBox.ItemTemplate>
                                                 </ComboBox>
@@ -1734,13 +1732,11 @@
                  ScrollViewer.HorizontalScrollBarVisibility="Disabled">
             <ListBox.ItemTemplate>
                 <DataTemplate>
-                    <TextBlock Padding="8,4" FontSize="11">
-                        <Run Text="Set all "/>
-                        <Run Text="{Binding MatchCount, Mode=OneWay}" FontWeight="SemiBold"/>
-                        <Run Text=" in '"/>
-                        <Run Text="{Binding AncestorName, Mode=OneWay}"/>
-                        <Run Text="'"/>
-                    </TextBlock>
+                    <!-- #143: same single source of truth as ScopeCombo
+                         above — bound to ScopeLevel.Label so the capture
+                         overlay can't drift from the live dropdown. -->
+                    <TextBlock Padding="8,4" FontSize="11"
+                               Text="{Binding Label, Mode=OneWay}"/>
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -548,8 +548,14 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         {
             if (Selection.IsManualMode)
                 return Res.Format("Dialog_SetManualCount", CountWouldChangeMembers());
+            // #143: single source of truth — the patterned scope label.
+            // CountWouldChangeMembers() (not MatchCount) is the staged count;
+            // route it through the same MenuTitle_SetAll template the dropdown
+            // / ToString use so the wording can't drift.
             return Selection.SelectedScope != null
-                ? $"Set {CountWouldChangeMembers()} in '{Selection.SelectedScope.AncestorName}'"
+                ? Res.Format("MenuTitle_SetAll",
+                    CountWouldChangeMembers(),
+                    ScopeLabelFormatter.Pattern(Selection.SelectedScope))
                 : "Set";
         }
     }
@@ -575,18 +581,27 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             {
                 breakdown = Selection.IsManualMode
                     ? Res.Format("Dialog_SetTooltip_ManualIdle", total)
-                    : Res.Format("Dialog_SetTooltip_ScopeIdle", total, Selection.SelectedScope?.AncestorName ?? "");
+                    : Res.Format("Dialog_SetTooltip_ScopeIdle", total,
+                        ScopePattern(Selection.SelectedScope));
             }
             else
             {
                 breakdown = Selection.IsManualMode
                     ? Res.Format("Dialog_SetTooltip_ManualBreakdown", willChange, total, alreadyMatch)
                     : Res.Format("Dialog_SetTooltip_ScopeBreakdown",
-                        willChange, total, Selection.SelectedScope?.AncestorName ?? "", alreadyMatch);
+                        willChange, total, ScopePattern(Selection.SelectedScope), alreadyMatch);
             }
             return action + "\n" + breakdown;
         }
     }
+
+    /// <summary>
+    /// Null-safe wrapper over <see cref="ScopeLabelFormatter.Pattern"/> so the
+    /// Set-button tooltip shows the same patterned segment the dropdown /
+    /// caption use (#143). Single seam — not count/label logic.
+    /// </summary>
+    private static string ScopePattern(ScopeLevel? scope) =>
+        scope == null ? "" : ScopeLabelFormatter.Pattern(scope);
 
     // IsManualMode / ManualSelectionCount / ManualSelectedPaths / CanEdit /
     // ManualSelectionSummary / IsSelectionTypeHomogeneous / SelectedMemberDisplay

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -1048,6 +1048,12 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         ValidateValue();
         Autocomplete.ClearFiltered();
         UpdateHighlighting();
+        // Suggestion-accept bypasses the NewValue debounce (cancelled above),
+        // so re-raise the composed Set-button caption/tooltip here — same pair
+        // raised on the typed path (:506-507) and scope/manual seams
+        // (:1169-1170, :1182-1183). #144.
+        OnPropertyChanged(nameof(SetButtonText));
+        OnPropertyChanged(nameof(SetButtonTooltip));
     }
 
     /// <summary>Show suggestions filtered by current text (always opens).</summary>


### PR DESCRIPTION
Three overlapping issues, fixed together because #143 and #144 share `BulkChangeViewModel.cs:545-555` (the `SetButtonText` composition). #148 is an isolated rider.

## Closing keywords

Closes #143
Closes #144
Closes #148

## #144 — Set-button caption frozen at "Set 0…" after accepting a suggestion (commit 1)

`AcceptSuggestion` cancels the `NewValue` debounce — and that debounce callback (`:506-507`) is the *only* re-raise site for `SetButtonText` / `SetButtonTooltip` on the typed path. The suggestion-accept path rebuilt the preview and re-enabled the button through separate mechanisms but never re-raised the composed caption, so it stayed frozen at the pre-selection count.

Fix: the same `OnPropertyChanged(nameof(SetButtonText))` / `nameof(SetButtonTooltip))` pair raised at `:506-507` / `:1169-1170` / `:1182-1183`, added after `UpdateHighlighting()` in `AcceptSuggestion`. No count logic duplicated, no new method on the #80 hotspot. Two lines + a regression test.

## #143 — scope label shows a concrete example path, omits the leaf (commit 2, the refactor)

### Single source of truth

`ScopeLevel.AncestorName` (a concrete, DB-qualified string like `DB21.resetButton`, plus a `— across all selected DBs` string-append for the cross-DB lift) was rendered independently in 5+ places — both XAML `ItemTemplate`s, `ScopeLevel.ToString`, the Set-button caption (an inline interpolated string — a CLAUDE.md violation), and the Set-button tooltip — which drifted, advertised one example instead of the rule, and never named the leaf field.

The seam introduced is **`BlockParam.Services.ScopeLabelFormatter`** (a small static sibling of `HierarchyAnalyzer`), exposing:

- `Pattern(ScopeLevel)` → `*.resetButton.elementId` (leading `*` = the varying instance/DB segment, reusing the existing `Motors[2,*]` array-dim wildcard convention; then the scope's ancestor path; then the leaf member being written).
- `Format(ScopeLevel)` → the full label via the single reshaped **`MenuTitle_SetAll`** resx template (`Set all {0} in {1}`, en/de — no near-duplicate key added).

`ScopeLevel` gained `LeafName` + `IsCrossDb` (threaded at construction; the leaf is `selectedMember.Name` everywhere) and a computed `Label` that delegates to the formatter. **Final label format: `Set all {N} in *.{ancestorPath}.{leafName}`** (segments dropped when empty — DB-root → `Set all 4 in *.elementId`; array-element scope → `Set all 5 in *.Motors`).

### Why #143 + #144 share `BulkChangeViewModel.cs:545-555`

`SetButtonText` is the one property both issues touch: #144 needed it re-raised after `AcceptSuggestion`; #143 needed its inline `$"Set {…} in '{AncestorName}'"` interpolation replaced with a `Res.Format("MenuTitle_SetAll", …, ScopeLabelFormatter.Pattern(…))` call. Done as two commits so the trivial notification fix anchors the shared file before the refactor reshapes it.

### Routed through the one seam

Both XAML `ItemTemplate`s (`ScopeCombo` + the DevLauncher `ScopeOverlayList`) now bind a single `{Binding Label}` so they are identical by construction. `SetButtonText` + the Set-button tooltip route through the same template / `Pattern()`. `ToString` returns `Label`. The `— across all selected DBs` append is gone (the leading `*` already states the DB varies); `AncestorName` stays concrete for the audit log + classification, and cross-DB classification moved from a magic substring to the explicit `ScopeLevel.IsCrossDb` flag.

### Tests

`HierarchyAnalyzerMultiDbTests` classification predicates moved off the removed substring onto `IsCrossDb`. New `ScopeLabelFormatterTests` covers within-DB / DB-root / cross-DB / mega / array forms (unit + analyzer integration). The two `BulkChangeViewModel` `SetButtonText` assertions now compare via `Res.Format` (culture-independent — the caption is *correctly* localized now that it no longer bypasses resx; that's why the old literal-English assertions had to change).

## #148 — selected cell indistinguishable from "Already matching" green (commit 3, isolated rider)

New `SelectedCellOutline` indigo `#5B21B6` brush token in the existing `Window.Resources`; a higher-priority `DataTrigger` (declared last) on the Value-cell `Border` bound to the existing `MemberNodeViewModel.IsSelected` sets a 2px `BorderBrush` + `BorderThickness` only — the orthogonal state fill keeps its `Background` and shows through, so selected + already-matching is unambiguous. Legend gains a "Selected" swatch (same token) after "Invalid", labelled via the new `Legend_Selected` resx key (en/de). No code-behind, no #80 VM growth. Kept as a separate commit so it drops cleanly if it ever complicates #143/#144.

## Verification

`dotnet test src/BlockParam.Tests -p:UseSiemensStubs=true` → **1058 passed, 0 failed, 0 skipped**. Debug + Release builds clean (0 warnings). No new readonly-struct field-access patterns, so the `peverify` job is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)