### PR TITLE
fix(#142): clear start value reverts to default instead of empty <StartValue>

### DIFF
--- a/src/BlockParam.Tests/BulkChangeServiceTests.cs
+++ b/src/BlockParam.Tests/BulkChangeServiceTests.cs
@@ -242,6 +242,25 @@ public class BulkChangeServiceTests : IDisposable
             "the audit log must record the concrete AncestorName, not the UI wildcard pattern");
     }
 
+    [Fact]
+    public void RecommendStrategy_ClearValue_ForcesXmlStrategy()
+    {
+        var xml = TestFixtures.LoadXml("udt-instances-db.xml");
+        var db = _parser.Parse(xml);
+        var analyzer = new HierarchyAnalyzer();
+        var moduleId = db.AllMembers().First(m => m.Path == "Drive1.Msg_CommError.ModuleId");
+        var scope = analyzer.Analyze(db, moduleId).Scopes.First(); // narrowest scope
+
+        var service = CreateService();
+        var clearSet = new ChangeSet("UdtInstancesDB", "ModuleId", "Int", scope, "");
+        var setSet = new ChangeSet("UdtInstancesDB", "ModuleId", "Int", scope, "7");
+
+        // Sanity: a non-clear narrow scope would normally use the Direct API.
+        service.RecommendStrategy(setSet).Should().Be(BulkStrategy.DirectApi);
+        // A clear must override that and take the XML path.
+        service.RecommendStrategy(clearSet).Should().Be(BulkStrategy.XmlExportImport);
+    }
+
     /// <summary>
     /// #152: a single-DB scope (IsCrossDb = false) must NOT carry the cross-DB qualifier
     /// — the Scope column must equal the bare AncestorName, unchanged.

--- a/src/BlockParam.Tests/BulkChangeViewModelTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelTests.cs
@@ -320,6 +320,92 @@ public class BulkChangeViewModelTests : IDisposable
     }
 
     /// <summary>
+    /// #142: clearing a member that HAS a start value is a genuine
+    /// revert-to-default pending edit — not a "discard my edit" gesture.
+    /// Regression: the cleared row appeared in the Pending Edits list (built
+    /// from tree nodes) while the store-backed counter stayed 0, so Apply
+    /// was disabled and the staged clear could never be applied.
+    /// </summary>
+    [Fact]
+    public void ClearingStartValue_StagesPendingEdit_CounterAndApplyAgree()
+    {
+        var vm = CreateViewModel();
+        var speed = vm.Tree.RootMembers.Single(m => m.Name == "Speed");
+        speed.StartValue.Should().Be("1500", "fixture precondition");
+
+        // User deletes the cell text → empty value.
+        speed.EditableStartValue = "";
+
+        speed.IsPendingInlineEdit.Should().BeTrue(
+            "clearing a member that had a value is a genuine revert-to-default edit");
+        vm.Pending.PendingEdits.Should().Contain(e => e.Node == speed,
+            "the cleared row must appear in the Pending Edits list");
+        vm.Pending.PendingInlineEditCount.Should().Be(1,
+            "the store-backed counter must agree with the list (#142 regression: was 0)");
+        vm.ApplyCommand.CanExecute(null).Should().BeTrue(
+            "Apply must be enabled for a staged clear (#142 regression: was disabled)");
+    }
+
+    /// <summary>
+    /// #142 guard: clearing then typing the original value back is still a
+    /// revert (no net change) — store, counter and list all return to empty.
+    /// Protects against over-correcting the clear fix into "clears never
+    /// revert".
+    /// </summary>
+    [Fact]
+    public void ClearingThenRestoringOriginal_IsRevert_NoPending()
+    {
+        var vm = CreateViewModel();
+        var speed = vm.Tree.RootMembers.Single(m => m.Name == "Speed");
+
+        speed.EditableStartValue = "";          // clear → genuine pending edit
+        vm.Pending.PendingInlineEditCount.Should().Be(1);
+
+        speed.EditableStartValue = "1500";      // back to original → revert
+        speed.IsPendingInlineEdit.Should().BeFalse();
+        vm.Pending.PendingEdits.Should().NotContain(e => e.Node == speed);
+        vm.Pending.PendingInlineEditCount.Should().Be(0,
+            "restoring the original value is a no-net-change revert");
+    }
+
+    /// <summary>
+    /// #142 review follow-up: clearing a member that NEVER had a start value
+    /// (UDT-instance leaf whose value isn't materialized → StartValue == null)
+    /// is a no-op, not a stageable edit. Regression guard: the clear fix must
+    /// not stage/charge a phantom pending edit, and the tree-derived list must
+    /// stay in sync with the store-backed counter (no divergence).
+    /// </summary>
+    [Fact]
+    public void ClearingMemberThatNeverHadStartValue_IsNoOp_NotStaged()
+    {
+        var xml = TestFixtures.LoadXml("v20-real-export-db.xml");
+        var parser = new SimaticMLParser();
+        var db = parser.Parse(xml);
+        var analyzer = new HierarchyAnalyzer();
+        var configLoader = new ConfigLoader(null);
+        var bulkService = new BulkChangeService(new ChangeLogger(), configLoader);
+        var usageTracker = Substitute.For<IUsageTracker>();
+        usageTracker.GetStatus().Returns(new UsageStatus(0, 200)); // ample quota — isolate pending logic
+        usageTracker.RecordUsage(Arg.Any<int>()).Returns(true);
+        var vm = new BulkChangeViewModel(db, xml, analyzer, bulkService, usageTracker, configLoader);
+
+        FlatTreeManager.ExpandAll(vm.Tree.RootMembers);
+        vm.RefreshFlatList();
+        var bmkId = vm.Tree.FlatMembers.First(m => m.Name == "bmkId" && m.IsLeaf);
+        bmkId.StartValue.Should().BeNull("fixture: bmkId has no <StartValue> element");
+
+        // User clicks into the empty cell and "clears" it — no actual change.
+        bmkId.EditableStartValue = "";
+
+        bmkId.IsPendingInlineEdit.Should().BeFalse(
+            "clearing a member that never had a value is a no-op, not a pending edit");
+        vm.Pending.PendingEdits.Should().NotContain(e => e.Node == bmkId,
+            "a no-op clear must not appear in the Pending Edits list");
+        vm.Pending.PendingInlineEditCount.Should().Be(0,
+            "store-backed counter must not count a no-op clear (would charge quota for nothing)");
+    }
+
+    /// <summary>
     /// Builds a VM with a configurable usage status and optional license service —
     /// the ApplyTooltip tests vary remaining quota and Pro state, so the standard
     /// helper isn't flexible enough.

--- a/src/BlockParam.Tests/SimaticMLWriterTests.cs
+++ b/src/BlockParam.Tests/SimaticMLWriterTests.cs
@@ -357,4 +357,97 @@ public class SimaticMLWriterTests
         SimaticMLWriter.TokenizePath("Plain.Name")
             .Should().Equal("Plain", "Name");
     }
+
+    [Fact]
+    public void Write_ClearDirectMember_RemovesStartValueElement()
+    {
+        var xml = TestFixtures.LoadXml("flat-db.xml");
+        var db = _parser.Parse(xml);
+        var speed = db.Members.First(m => m.Name == "Speed");
+
+        var result = _writer.ModifyStartValues(xml, new[] { speed }, "");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Changes.Should().HaveCount(1);
+        result.Changes[0].OldValue.Should().Be("1500");
+        result.Changes[0].NewValue.Should().Be("");
+
+        // No empty <StartValue> emitted anywhere.
+        result.ModifiedXml.Should().NotContain("<StartValue></StartValue>");
+        result.ModifiedXml.Should().NotContain("<StartValue />");
+
+        var modified = _parser.Parse(result.ModifiedXml);
+        modified.Members.First(m => m.Name == "Speed").StartValue.Should().BeNull();
+        // Siblings untouched.
+        modified.Members.First(m => m.Name == "Temperature").StartValue.Should().Be("25.5");
+        modified.Members.First(m => m.Name == "Enable").StartValue.Should().Be("true");
+    }
+
+    [Fact]
+    public void Write_ClearUdtInstanceMember_RemovesStartValue_SiblingsUntouched()
+    {
+        var xml = TestFixtures.LoadXml("udt-instances-db.xml");
+        var db = _parser.Parse(xml);
+        var moduleId = db.AllMembers()
+            .First(m => m.Path == "Drive1.Msg_CommError.ModuleId");
+
+        var result = _writer.ModifyStartValues(xml, new[] { moduleId }, "");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Changes[0].OldValue.Should().Be("42");
+        result.ModifiedXml.Should().NotContain("<StartValue></StartValue>");
+        result.ModifiedXml.Should().NotContain("<StartValue />");
+
+        var modified = _parser.Parse(result.ModifiedXml);
+        modified.AllMembers().First(m => m.Path == "Drive1.Msg_CommError.ModuleId")
+            .StartValue.Should().BeNull();
+        // A different UDT-instance's ModuleId is unaffected.
+        modified.AllMembers().First(m => m.Path == "Sensor1.Msg_CommError.ModuleId")
+            .StartValue.Should().Be("42");
+    }
+
+    [Fact]
+    public void Write_ClearArrayElement_PrunesSubelement_SiblingsUntouched()
+    {
+        var xml = TestFixtures.LoadXml("mixed-types-db.xml");
+        var db = _parser.Parse(xml);
+        var elem3 = db.Members.First(m => m.Name == "MyArray").Children[3]; // [3]
+
+        var result = _writer.ModifyStartValues(xml, new[] { elem3 }, "");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Changes[0].OldValue.Should().Be("400");
+        result.ModifiedXml.Should().NotContain("<StartValue></StartValue>");
+        result.ModifiedXml.Should().NotContain("<StartValue />");
+
+        var modified = _parser.Parse(result.ModifiedXml);
+        modified.Members.First(m => m.Name == "MyArray").Children[3].StartValue.Should().BeNull();
+        // Sibling indices keep their values.
+        modified.Members.First(m => m.Name == "MyArray").Children[0].StartValue.Should().Be("100");
+        modified.Members.First(m => m.Name == "MyArray").Children[4].StartValue.Should().Be("500");
+    }
+
+    [Fact]
+    public void Write_ClearWhenNoStartValuePresent_IsIdempotentNoEmptyElement()
+    {
+        // Clear the same direct member twice; the second clear has nothing
+        // to remove and must not create an empty element or error.
+        var xml = TestFixtures.LoadXml("flat-db.xml");
+        var db = _parser.Parse(xml);
+        var speed = db.Members.First(m => m.Name == "Speed");
+
+        var first = _writer.ModifyStartValues(xml, new[] { speed }, "");
+        first.IsSuccess.Should().BeTrue();
+
+        var db2 = _parser.Parse(first.ModifiedXml);
+        var speed2 = db2.Members.First(m => m.Name == "Speed");
+        var second = _writer.ModifyStartValues(first.ModifiedXml, new[] { speed2 }, "");
+
+        second.IsSuccess.Should().BeTrue();
+        second.Changes.Should().BeEmpty(
+            "a clear with no <StartValue> to remove is a genuine no-op — recording a "
+            + "phantom change would charge quota and audit-log a write that changed nothing");
+        second.ModifiedXml.Should().NotContain("<StartValue></StartValue>");
+        second.ModifiedXml.Should().NotContain("<StartValue />");
+    }
 }

--- a/src/BlockParam/BlockParam.csproj
+++ b/src/BlockParam/BlockParam.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>BlockParam</RootNamespace>
     <AssemblyName>BlockParam</AssemblyName>
-    <Version>1.0.13-temp</Version>
+    <Version>1.0.14</Version>
     <Authors>Sawascwoolf</Authors>
     <Description>TIA Portal Add-In for editing Data Block start values and parameters — single and in bulk</Description>
     <ApplicationIcon>Resources\BlockParam_logo.ico</ApplicationIcon>

--- a/src/BlockParam/Services/BulkChangeService.cs
+++ b/src/BlockParam/Services/BulkChangeService.cs
@@ -37,6 +37,13 @@ public class BulkChangeService
     /// </summary>
     public BulkStrategy RecommendStrategy(ChangeSet changeSet)
     {
+        // A "clear" (revert-to-default) can only be expressed by REMOVING the
+        // <StartValue> element via the XML path. The Openness Direct API's
+        // SetAttribute("StartValue", "") cannot revert to default (issue #142),
+        // so clears always take the XML strategy regardless of scope size.
+        if (string.IsNullOrWhiteSpace(changeSet.NewValue))
+            return BulkStrategy.XmlExportImport;
+
         return changeSet.Scope.MatchCount <= DirectApiThreshold
             ? BulkStrategy.DirectApi
             : BulkStrategy.XmlExportImport;
@@ -78,6 +85,13 @@ public class BulkChangeService
         if (validationError != null)
         {
             return new DirectApiResult(new[] { validationError }, Array.Empty<ValueChange>());
+        }
+
+        if (string.IsNullOrWhiteSpace(changeSet.NewValue))
+        {
+            return new DirectApiResult(
+                new[] { "Clearing a start value requires the XML strategy (cannot revert to default via the Direct API)." },
+                Array.Empty<ValueChange>());
         }
 
         var changes = new List<ValueChange>();

--- a/src/BlockParam/Services/TiaPortalAdapter.cs
+++ b/src/BlockParam/Services/TiaPortalAdapter.cs
@@ -87,6 +87,12 @@ public class TiaPortalAdapter : ITiaPortalAdapter
         return _tiaPortal.ExclusiveAccess(description);
     }
 
+    /// <summary>
+    /// Sets a member's StartValue via the Openness Direct API. Callers must
+    /// NOT pass an empty/whitespace value: SetAttribute("StartValue", "")
+    /// does not revert to default. Clears are routed to the XML strategy by
+    /// BulkChangeService.RecommendStrategy (issue #142).
+    /// </summary>
     public void SetStartValueDirect(object member, string value)
     {
         var engineeringObject = (IEngineeringObject)member;

--- a/src/BlockParam/SimaticML/SimaticMLWriter.cs
+++ b/src/BlockParam/SimaticML/SimaticMLWriter.cs
@@ -33,6 +33,20 @@ public class SimaticMLWriter
                 continue;
             }
 
+            if (string.IsNullOrWhiteSpace(newValue))
+            {
+                var oldCleared = location.ClearStartValue(ns);
+                // ClearStartValue returns null only when there was no
+                // <StartValue> element to remove → a genuine no-op. Don't
+                // record a phantom ValueChange: it would be counted toward
+                // the daily quota and written to the audit log for a write
+                // that changed nothing (bulk-clear over a scope where some
+                // members have no explicit start value hits this).
+                if (oldCleared != null)
+                    changes.Add(new ValueChange(target.Path, target.Datatype, oldCleared, ""));
+                continue;
+            }
+
             var startValueElement = location.GetOrCreateStartValue(ns);
 
             // Read old value (from ConstantName attribute or text)
@@ -292,6 +306,47 @@ public class SimaticMLWriter
                 sub.Add(inner);
             }
             return inner;
+        }
+
+        /// <summary>
+        /// Clears a member's start value by REMOVING the &lt;StartValue&gt; element
+        /// (the SimaticML representation of "no explicit start value → revert to
+        /// default"). Emitting an empty &lt;StartValue&gt;&lt;/StartValue&gt; is
+        /// invalid for re-import (issue #142). For a directly-declared DB member
+        /// TIA then falls back to the type default; for a member inside a UDT
+        /// instance it falls back to the UDT-defined default — both are expressed
+        /// by the same "element absent" XML, so no per-member-kind branching is
+        /// needed here. When the value lived under a &lt;Subelement&gt; (array /
+        /// per-instance override) the now-childless &lt;Subelement&gt; is pruned
+        /// too. Returns the prior value, or null if there was nothing to clear.
+        /// </summary>
+        public string? ClearStartValue(XNamespace ns)
+        {
+            XElement? sv;
+            XElement? owningSubelement = null;
+
+            if (SubelementPath == null)
+            {
+                sv = Member.Element(ns + SE.StartValue);
+            }
+            else
+            {
+                owningSubelement = LocalElements(Member, SE.Subelement)
+                    .FirstOrDefault(e => e.Attribute(SE.Path)?.Value == SubelementPath);
+                sv = owningSubelement == null ? null : LocalElement(owningSubelement, SE.StartValue);
+            }
+
+            if (sv == null) return null;
+
+            var prior = sv.Attribute(SE.ConstantName)?.Value?.Trim('"') ?? sv.Value;
+            sv.Remove();
+
+            // Prune a Subelement that only existed to carry this StartValue. Keep
+            // it if it still holds other content (e.g. a per-instance <Comment>).
+            if (owningSubelement != null && !owningSubelement.Elements().Any())
+                owningSubelement.Remove();
+
+            return prior;
         }
     }
 

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -2779,20 +2779,31 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         Log.Information(
             "[gesture] Inline edit on {Path}: '{Old}' → '{New}' | {State}",
             memberVm.Path, memberVm.StartValue ?? "", newValue, BuildSnapshotForLog());
-        if (string.IsNullOrEmpty(newValue))
+        // #142: an empty cell is NOT unconditionally "discard my edit".
+        // Clearing a member that HAD a start value is a genuine
+        // revert-to-default change that must be staged and applied (the
+        // writer removes the <StartValue> element). The only true revert is
+        // when there is no net change versus the member's original value —
+        // which MemberNodeViewModel.EditableStartValue already encodes by
+        // calling ClearPending() (→ IsPendingInlineEdit == false) only when
+        // the cell equals the original. Branch on that single source of
+        // truth so the store, the counter and the tree-derived Pending list
+        // can never disagree (the bug: list showed the cleared row, counter
+        // stayed 0, Apply disabled).
+        if (!memberVm.IsPendingInlineEdit)
         {
-            // Inline revert / cleared field: drop any stale validation error
-            // from the prior value, then refresh the aggregated pending queue
-            // / preview — otherwise the row lingers red and a stale message
-            // stays in StatusText. StartsWith matches the exact producer
-            // format ($"{memberVm.Name}: {error}") without accidentally
-            // clearing messages about other members whose name contains this
-            // one as a substring.
+            // Inline revert: drop any stale validation error from the prior
+            // value, then refresh the aggregated pending queue / preview —
+            // otherwise the row lingers red and a stale message stays in
+            // StatusText. StartsWith matches the exact producer format
+            // ($"{memberVm.Name}: {error}") without accidentally clearing
+            // messages about other members whose name contains this one as a
+            // substring.
             memberVm.HasInlineError = false;
             memberVm.InlineErrorMessage = null;
             if (StatusText.StartsWith(memberVm.Name + ":"))
                 StatusText = "";
-            // Evict cleared edit from the store so tree rebuilds don't
+            // Evict the reverted edit from the store so tree rebuilds don't
             // re-populate a value the user just reverted.
             _pendingEditStore.Clear(memberVm.Model);
             RefreshPendingAndPreview();

--- a/src/BlockParam/UI/MemberNodeViewModel.cs
+++ b/src/BlockParam/UI/MemberNodeViewModel.cs
@@ -292,8 +292,16 @@ public class MemberNodeViewModel : ViewModelBase
             if (value != _editableStartValue)
             {
                 _editableStartValue = value;
-                // Same as original → clear pending instead of creating one
-                if (value == StartValue)
+                // No net change → clear pending instead of creating one.
+                // Two no-change shapes: (a) the cell equals the original
+                // value; (b) the cell is emptied but the member never had a
+                // start value (StartValue == null/"") — "clearing" something
+                // already empty changes nothing. Without (b), clearing a
+                // UDT-instance leaf whose value isn't materialized (#142
+                // domain) would stage a phantom edit that gets counted and
+                // charged on Apply for a no-op write.
+                if (value == StartValue
+                    || (string.IsNullOrEmpty(value) && string.IsNullOrEmpty(StartValue)))
                     ClearPending();
                 else
                     PendingValue = value;

--- a/src/BlockParam/addin-publisher-v20.xml
+++ b/src/BlockParam/addin-publisher-v20.xml
@@ -6,7 +6,7 @@
   <Product>
     <Name>BlockParam</Name>
     <Id>BlockParam</Id>
-    <Version>1.0.13-temp</Version>
+    <Version>1.0.14</Version>
   </Product>
   <FeatureAssembly>
     <AssemblyInfo>

--- a/src/BlockParam/addin-publisher-v21.xml
+++ b/src/BlockParam/addin-publisher-v21.xml
@@ -6,7 +6,7 @@
   <Product>
     <Name>BlockParam</Name>
     <Id>BlockParam</Id>
-    <Version>1.0.13-temp</Version>
+    <Version>1.0.14</Version>
   </Product>
   <FeatureAssembly>
     <AssemblyInfo>


### PR DESCRIPTION
## What & why

Clearing an inline start value could not be applied. Two linked bugs:

1. **Writer** emitted an invalid empty `<StartValue></StartValue>` instead of removing the element — TIA rejected/ignored the re-import.
2. **UI** showed the cleared row in the Pending Edits list (built from tree nodes) while the store-backed counter stayed 0, so **Apply was disabled**.

## Changes

- **`SimaticMLWriter`** — a clear now **removes** the `<StartValue>` element (and prunes an emptied `<Subelement>`), the valid SimaticML revert-to-default for both directly-declared and UDT-instance members. A genuine no-op clear records **no** phantom `ValueChange` (no quota charge / audit-log entry).
- **`BulkChangeService`** — clears are forced onto the XML strategy; the Openness Direct API `SetAttribute("StartValue","")` cannot revert-to-default. Defensive guard in `ApplyViaDirect`; doc note on `TiaPortalAdapter`.
- **`BulkChangeViewModel.OnSingleValueEdited`** — branch on `IsPendingInlineEdit` (the single source of truth that renders the Pending list) so list, store counter and Apply gate can never diverge.
- **`MemberNodeViewModel.EditableStartValue`** — clearing a member that never had a value is a no-op, not a phantom staged edit.
- Version → **1.0.14** (real number; supersedes temporary `-temp` / `0.142.0` test builds).

## Testing

- Verified end-to-end in **TIA Portal V20** (user-confirmed: clear applies; Apply enables).
- New regression tests: writer (direct / UDT-instance / array-subelement / idempotent no-op), service strategy, and VM (clear staged & counted; revert; null-StartValue UDT-instance leaf is a no-op).
- **Full suite: 1080 passed, 0 failed.** Plain class methods only — no readonly-struct/`ldflda` IL risk (peverify gate unaffected).

## Review

Reviewed by subagent; one High regression (no-op clear of a null-StartValue member charged quota) found and fixed at the source of truth, with a red→green test. One pre-existing dead quota-warn line was intentionally left out of scope (CLAUDE.md: no unrelated retrofits) — flagged for a separate issue.

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)