### PR TITLE
perf(#159): O(1) batch Apply + O(n) Subelement index + virtualized panels

### DIFF
--- a/src/BlockParam.Tests/BulkChangeViewModelCommandTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelCommandTests.cs
@@ -130,6 +130,57 @@ public class BulkChangeViewModelCommandTests : IDisposable
             "an over-quota apply must not close the dialog — the edit is not committed");
     }
 
+    /// <summary>
+    /// #159 H1 + H3: a successful single-DB Apply must leave the tree showing
+    /// the committed values with no pending edits — exactly as the old
+    /// per-edit-loop + full RefreshTree re-parse did. This pins the
+    /// observable contract of the batched write (H1) plus the in-place
+    /// post-Apply patch that replaces the full re-parse (H3): the patched
+    /// StartValue is read through to the VM and the staged edits are cleared.
+    /// </summary>
+    [Fact]
+    public void ApplyCommand_SingleDb_PatchesTreeInPlace_AndClearsPending()
+    {
+        var vm = CreateViewModel();
+        var speed = vm.Tree.RootMembers.Single(m => m.Name == "Speed");
+        var enable = vm.Tree.RootMembers.Single(m => m.Name == "Enable");
+        speed.EditableStartValue = "4242";
+        enable.EditableStartValue = "true";
+        vm.Pending.PendingInlineEditCount.Should().Be(2, "two valid edits are staged");
+
+        vm.ApplyCommand.Execute(null);
+
+        vm.Pending.PendingInlineEditCount.Should().Be(0,
+            "a committed Apply clears every staged edit (H3 in-place patch)");
+        vm.Tree.RootMembers.Single(m => m.Name == "Speed").StartValue
+            .Should().Be("4242",
+                "the committed value must read through without a full re-parse (H3)");
+        vm.Tree.RootMembers.Single(m => m.Name == "Enable").StartValue
+            .Should().Be("true");
+    }
+
+    /// <summary>
+    /// #159 H1 + H3: clearing a value (empty pending edit) through Apply must
+    /// land as a null/empty StartValue, matching what the re-parse path
+    /// produced (the writer removes the &lt;StartValue&gt; element; the patch
+    /// maps the empty change to a null model value).
+    /// </summary>
+    [Fact]
+    public void ApplyCommand_SingleDb_ClearedValue_PatchesToEmpty()
+    {
+        var vm = CreateViewModel();
+        var speed = vm.Tree.RootMembers.Single(m => m.Name == "Speed");
+        speed.StartValue.Should().NotBeNullOrEmpty("flat-db Speed has an explicit value");
+        speed.EditableStartValue = "";
+        vm.Pending.PendingInlineEditCount.Should().Be(1, "one clear is staged");
+
+        vm.ApplyCommand.Execute(null);
+
+        vm.Pending.PendingInlineEditCount.Should().Be(0);
+        vm.Tree.RootMembers.Single(m => m.Name == "Speed").HasStartValue
+            .Should().BeFalse("a cleared value reverts to the type default (no StartValue)");
+    }
+
     // ─────────────────────────────────────────────────────────────────────
     // DiscardPendingCommand  (#21 mis-click regression)
     // ─────────────────────────────────────────────────────────────────────

--- a/src/BlockParam.Tests/BulkChangeViewModelCommandTests.cs
+++ b/src/BlockParam.Tests/BulkChangeViewModelCommandTests.cs
@@ -144,8 +144,10 @@ public class BulkChangeViewModelCommandTests : IDisposable
         var vm = CreateViewModel();
         var speed = vm.Tree.RootMembers.Single(m => m.Name == "Speed");
         var enable = vm.Tree.RootMembers.Single(m => m.Name == "Enable");
+        // flat-db Speed=1500, Enable=true — pick values that are genuine
+        // changes so the no-op guard in EditableStartValue stages both.
         speed.EditableStartValue = "4242";
-        enable.EditableStartValue = "true";
+        enable.EditableStartValue = "false";
         vm.Pending.PendingInlineEditCount.Should().Be(2, "two valid edits are staged");
 
         vm.ApplyCommand.Execute(null);
@@ -156,7 +158,7 @@ public class BulkChangeViewModelCommandTests : IDisposable
             .Should().Be("4242",
                 "the committed value must read through without a full re-parse (H3)");
         vm.Tree.RootMembers.Single(m => m.Name == "Enable").StartValue
-            .Should().Be("true");
+            .Should().Be("false");
     }
 
     /// <summary>

--- a/src/BlockParam.Tests/SimaticMLWriterTests.cs
+++ b/src/BlockParam.Tests/SimaticMLWriterTests.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Text;
 using FluentAssertions;
 using BlockParam.SimaticML;
 using Xunit;
@@ -449,5 +451,136 @@ public class SimaticMLWriterTests
             + "phantom change would charge quota and audit-log a write that changed nothing");
         second.ModifiedXml.Should().NotContain("<StartValue></StartValue>");
         second.ModifiedXml.Should().NotContain("<StartValue />");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // #159 — batch overload (H1) + O(n) Subelement indexing (H2)
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// #159 H1: the batch overload assigns a distinct value per member in a
+    /// single parse/serialize pass. Verifies each member gets its own value
+    /// (not a shared one) and the change set is complete.
+    /// </summary>
+    [Fact]
+    public void WriteBatch_PerMemberDistinctValues_AllApplied()
+    {
+        var xml = TestFixtures.LoadXml("udt-instances-db.xml");
+        var db = _parser.Parse(xml);
+        var moduleIds = db.AllMembers().Where(m => m.Name == "ModuleId").ToList();
+        moduleIds.Count.Should().BeGreaterThan(1);
+
+        var edits = moduleIds
+            .Select((m, i) => (Member: m, Value: (1000 + i).ToString()))
+            .ToList();
+
+        var result = _writer.ModifyStartValues(xml, edits);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Changes.Should().HaveCount(edits.Count);
+
+        var modified = _parser.Parse(result.ModifiedXml);
+        var reModuleIds = modified.AllMembers().Where(m => m.Name == "ModuleId").ToList();
+        for (int i = 0; i < reModuleIds.Count; i++)
+            reModuleIds[i].StartValue.Should().Be((1000 + i).ToString());
+    }
+
+    /// <summary>
+    /// #159 H1: a member missing from the XML is reported in Errors without
+    /// aborting the batch — the valid edits in the same call still apply.
+    /// Mirrors the old per-edit Apply loop's skip-and-log behaviour.
+    /// </summary>
+    [Fact]
+    public void WriteBatch_MissingMember_RecordedAsError_OthersStillApplied()
+    {
+        var xml = TestFixtures.LoadXml("flat-db.xml");
+        var db = _parser.Parse(xml);
+        var speed = db.Members.First(m => m.Name == "Speed");
+        var ghost = new BlockParam.Models.MemberNode(
+            "Ghost", "Int", "0", "DoesNotExist", null,
+            new List<BlockParam.Models.MemberNode>());
+
+        var result = _writer.ModifyStartValues(
+            xml, new[] { (speed, "2000"), (ghost, "5") });
+
+        result.Changes.Should().ContainSingle(c => c.MemberPath == "Speed");
+        result.Errors.Should().ContainSingle().Which.Should().Contain("DoesNotExist");
+
+        var modified = _parser.Parse(result.ModifiedXml);
+        modified.Members.First(m => m.Name == "Speed").StartValue.Should().Be("2000");
+    }
+
+    /// <summary>
+    /// #159 H1+H2 regression gate. A 10,000-element <c>Array Of DInt</c> with
+    /// an explicit StartValue on every element is the issue's reproduction
+    /// case. The pre-fix Apply path re-parsed + re-serialized the whole
+    /// multi-MB document once per edit (H1, O(n) document cycles) and rescanned
+    /// every Subelement linearly per edit (H2, O(n^2) comparisons), taking
+    /// seconds-to-minutes. The batch overload is one parse/serialize with an
+    /// O(1) Subelement index, so this completes in well under the (generous,
+    /// CI-jitter-tolerant) ceiling. A revert to either O(n) pattern blows
+    /// past it by orders of magnitude.
+    /// </summary>
+    [Fact]
+    public void WriteBatch_TenThousandElementArray_AppliesCorrectlyAndFast()
+    {
+        const int n = 10_000;
+        var xml = BuildLargeArrayDbXml(n);
+        var db = _parser.Parse(xml);
+        var arr = db.Members.First(m => m.Name == "BigArray");
+        arr.Children.Should().HaveCount(n, "the parser expands arrays up to 100k elements");
+
+        // Distinct value per element so a shared-value bug can't pass.
+        var edits = arr.Children
+            .Select((c, i) => (Member: c, Value: (i + 1).ToString()))
+            .ToList();
+
+        var sw = Stopwatch.StartNew();
+        var result = _writer.ModifyStartValues(xml, edits);
+        sw.Stop();
+
+        result.IsSuccess.Should().BeTrue();
+        result.Changes.Should().HaveCount(n);
+        sw.Elapsed.TotalSeconds.Should().BeLessThan(10,
+            "#159 H1+H2: batched single parse + O(1) Subelement index — a "
+            + "regression to per-edit parse (O(n)) or linear Subelement scan "
+            + "(O(n^2)) would take far longer than this generous ceiling");
+
+        var modified = _parser.Parse(result.ModifiedXml);
+        var reArr = modified.Members.First(m => m.Name == "BigArray");
+        reArr.Children[0].StartValue.Should().Be("1");
+        reArr.Children[n / 2].StartValue.Should().Be((n / 2 + 1).ToString());
+        reArr.Children[n - 1].StartValue.Should().Be(n.ToString());
+    }
+
+    /// <summary>
+    /// Builds a SimaticML GlobalDB whose only member is
+    /// <c>BigArray : Array[1..n] Of DInt</c> with an explicit
+    /// <c>&lt;Subelement Path="i"&gt;&lt;StartValue&gt;</c> for every element —
+    /// the synthetic XML the #159 reproduction steps describe.
+    /// </summary>
+    private static string BuildLargeArrayDbXml(int n)
+    {
+        var sb = new StringBuilder(n * 64);
+        sb.Append("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
+        sb.Append("<Document>\n");
+        sb.Append("  <SW.Blocks.GlobalDB ID=\"0\">\n");
+        sb.Append("    <AttributeList>\n");
+        sb.Append("      <Interface>\n");
+        sb.Append("        <Sections xmlns=\"http://www.siemens.com/automation/Openness/SW/Interface/v5\">\n");
+        sb.Append("          <Section Name=\"Static\">\n");
+        sb.Append($"            <Member Name=\"BigArray\" Datatype=\"Array[1..{n}] of DInt\" Accessibility=\"Public\">\n");
+        for (int i = 1; i <= n; i++)
+            sb.Append($"              <Subelement Path=\"{i}\"><StartValue>{i}</StartValue></Subelement>\n");
+        sb.Append("            </Member>\n");
+        sb.Append("          </Section>\n");
+        sb.Append("        </Sections>\n");
+        sb.Append("      </Interface>\n");
+        sb.Append("      <Name>BigArrayDb</Name>\n");
+        sb.Append("      <Number>1</Number>\n");
+        sb.Append("    </AttributeList>\n");
+        sb.Append("  </SW.Blocks.GlobalDB>\n");
+        sb.Append("</Document>\n");
+        return sb.ToString();
     }
 }

--- a/src/BlockParam/Models/MemberNode.cs
+++ b/src/BlockParam/Models/MemberNode.cs
@@ -51,8 +51,21 @@ public class MemberNode
 
     public string Name { get; }
     public string Datatype { get; }
-    public string? StartValue { get; }
+    public string? StartValue { get; private set; }
     public string Path { get; }
+
+    /// <summary>
+    /// Post-Apply fast path (#159 H3). A successful value-only Apply has
+    /// already written the new start value into the DB XML, so the model can
+    /// be updated in place rather than re-parsing the whole (multi-MB)
+    /// document just to refresh the tree. This is the ONLY sanctioned
+    /// mutation of an otherwise parser-immutable model: callers must
+    /// guarantee the XML structure is unchanged (a pure StartValue edit,
+    /// which is exactly what <see cref="SimaticML.SimaticMLWriter"/> yields),
+    /// and the value passed must match what a re-parse would produce
+    /// (constant name or literal text; <c>null</c> for a cleared value).
+    /// </summary>
+    internal void ApplyCommittedStartValue(string? value) => StartValue = value;
     public MemberNode? Parent { get; }
     public IReadOnlyList<MemberNode> Children { get; }
 

--- a/src/BlockParam/SimaticML/SimaticMLWriter.cs
+++ b/src/BlockParam/SimaticML/SimaticMLWriter.cs
@@ -11,8 +11,9 @@ namespace BlockParam.SimaticML;
 public class SimaticMLWriter
 {
     /// <summary>
-    /// Changes the StartValue of all specified members in the XML document.
-    /// Returns the modified XML as a string.
+    /// Changes the StartValue of all specified members to the same value.
+    /// Parses + serializes the document exactly once regardless of how many
+    /// members are targeted. Returns the modified XML as a string.
     /// </summary>
     public WriteResult ModifyStartValues(
         string xml,
@@ -20,59 +21,97 @@ public class SimaticMLWriter
         string newValue)
     {
         var doc = XDocument.Parse(xml);
-        var ns = SimaticMLNamespaces.Detect(doc);
+        var ctx = new WriteContext(doc, SimaticMLNamespaces.Detect(doc));
         var changes = new List<ValueChange>();
         var errors = new List<string>();
 
         foreach (var target in targetMembers)
-        {
-            var location = FindStartValueLocation(doc, ns, target.Path);
-            if (location == null)
-            {
-                errors.Add($"Member not found in XML: {target.Path}");
-                continue;
-            }
-
-            if (string.IsNullOrWhiteSpace(newValue))
-            {
-                var oldCleared = location.ClearStartValue(ns);
-                // ClearStartValue returns null only when there was no
-                // <StartValue> element to remove → a genuine no-op. Don't
-                // record a phantom ValueChange: it would be counted toward
-                // the daily quota and written to the audit log for a write
-                // that changed nothing (bulk-clear over a scope where some
-                // members have no explicit start value hits this).
-                if (oldCleared != null)
-                    changes.Add(new ValueChange(target.Path, target.Datatype, oldCleared, ""));
-                continue;
-            }
-
-            var startValueElement = location.GetOrCreateStartValue(ns);
-
-            // Read old value (from ConstantName attribute or text)
-            var oldValue = startValueElement.Attribute(SE.ConstantName)?.Value?.Trim('"')
-                        ?? startValueElement.Value;
-
-            // Determine if newValue is a constant name or a literal value.
-            // Constants start with a letter but are NOT: bool literals, TIA typed
-            // prefixes (T#, D#, TOD#, etc.), or single-quoted strings.
-            var isConstant = !string.IsNullOrEmpty(newValue)
-                          && char.IsLetter(newValue[0])
-                          && !IsKnownLiteral(newValue);
-
-            // Clear previous content and attributes
-            startValueElement.Value = "";
-            startValueElement.Attribute(SE.ConstantName)?.Remove();
-
-            if (isConstant)
-                startValueElement.SetAttributeValue(SE.ConstantName, $"\"{newValue}\"");
-            else
-                startValueElement.Value = newValue;
-
-            changes.Add(new ValueChange(target.Path, target.Datatype, oldValue, newValue));
-        }
+            ApplyOne(ctx, target, newValue, changes, errors);
 
         return new WriteResult(doc.ToString(), changes, errors);
+    }
+
+    /// <summary>
+    /// Batch overload (#159 H1): applies a distinct value per member while
+    /// parsing and serializing the (potentially multi-MB) document exactly
+    /// once. The Apply loop used to call <see cref="ModifyStartValues(string,
+    /// IReadOnlyList{MemberNode}, string)"/> once per pending edit — an
+    /// O(n) full parse + serialize per edit, O(n) total for n edits. Routing
+    /// the whole pending batch through one call drops that to a single
+    /// parse/serialize pair (O(1) document cycles).
+    /// </summary>
+    public WriteResult ModifyStartValues(
+        string xml,
+        IReadOnlyList<(MemberNode Member, string Value)> edits)
+    {
+        var doc = XDocument.Parse(xml);
+        var ctx = new WriteContext(doc, SimaticMLNamespaces.Detect(doc));
+        var changes = new List<ValueChange>();
+        var errors = new List<string>();
+
+        foreach (var (member, value) in edits)
+            ApplyOne(ctx, member, value, changes, errors);
+
+        return new WriteResult(doc.ToString(), changes, errors);
+    }
+
+    /// <summary>
+    /// Applies a single member's start-value change against an already-parsed
+    /// document. Shared by both <see cref="ModifyStartValues(string,
+    /// IReadOnlyList{MemberNode}, string)"/> and the batch overload so the
+    /// parse/serialize cost is paid by the caller, not per member.
+    /// </summary>
+    private static void ApplyOne(
+        WriteContext ctx,
+        MemberNode target,
+        string newValue,
+        List<ValueChange> changes,
+        List<string> errors)
+    {
+        var location = FindStartValueLocation(ctx, target.Path);
+        if (location == null)
+        {
+            errors.Add($"Member not found in XML: {target.Path}");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(newValue))
+        {
+            var oldCleared = location.ClearStartValue(ctx);
+            // ClearStartValue returns null only when there was no
+            // <StartValue> element to remove → a genuine no-op. Don't
+            // record a phantom ValueChange: it would be counted toward
+            // the daily quota and written to the audit log for a write
+            // that changed nothing (bulk-clear over a scope where some
+            // members have no explicit start value hits this).
+            if (oldCleared != null)
+                changes.Add(new ValueChange(target.Path, target.Datatype, oldCleared, ""));
+            return;
+        }
+
+        var startValueElement = location.GetOrCreateStartValue(ctx);
+
+        // Read old value (from ConstantName attribute or text)
+        var oldValue = startValueElement.Attribute(SE.ConstantName)?.Value?.Trim('"')
+                    ?? startValueElement.Value;
+
+        // Determine if newValue is a constant name or a literal value.
+        // Constants start with a letter but are NOT: bool literals, TIA typed
+        // prefixes (T#, D#, TOD#, etc.), or single-quoted strings.
+        var isConstant = !string.IsNullOrEmpty(newValue)
+                      && char.IsLetter(newValue[0])
+                      && !IsKnownLiteral(newValue);
+
+        // Clear previous content and attributes
+        startValueElement.Value = "";
+        startValueElement.Attribute(SE.ConstantName)?.Remove();
+
+        if (isConstant)
+            startValueElement.SetAttributeValue(SE.ConstantName, $"\"{newValue}\"");
+        else
+            startValueElement.Value = newValue;
+
+        changes.Add(new ValueChange(target.Path, target.Datatype, oldValue, newValue));
     }
 
     /// <summary>
@@ -89,13 +128,14 @@ public class SimaticMLWriter
 
         var doc = XDocument.Parse(xml);
         var ns = SimaticMLNamespaces.Detect(doc);
+        var ctx = new WriteContext(doc, ns);
 
         // Auto-detect language from existing comments in the XML
         var effectiveLanguage = language ?? DetectLanguage(doc, ns);
 
         for (int i = 0; i < targetMembers.Count; i++)
         {
-            var memberElement = FindMemberElement(doc, ns, targetMembers[i].Path);
+            var memberElement = FindMemberElement(ctx, targetMembers[i].Path);
             if (memberElement == null) continue;
 
             SetComment(memberElement, ns, comments[i], effectiveLanguage);
@@ -131,20 +171,20 @@ public class SimaticMLWriter
     public string RemoveMembers(string xml, IReadOnlyList<MemberNode> membersToRemove)
     {
         var doc = XDocument.Parse(xml);
-        var ns = SimaticMLNamespaces.Detect(doc);
+        var ctx = new WriteContext(doc, SimaticMLNamespaces.Detect(doc));
 
         foreach (var member in membersToRemove)
         {
-            var element = FindMemberElement(doc, ns, member.Path);
+            var element = FindMemberElement(ctx, member.Path);
             element?.Remove();
         }
 
         return doc.ToString();
     }
 
-    private XElement? FindMemberElement(XDocument doc, XNamespace ns, string path)
+    private static XElement? FindMemberElement(WriteContext ctx, string path)
     {
-        var location = FindStartValueLocation(doc, ns, path);
+        var location = FindStartValueLocation(ctx, path);
         return location?.Member;
     }
 
@@ -157,13 +197,17 @@ public class SimaticMLWriter
     /// <c>units[1].modules[3].moduleId</c> becomes
     /// <c>&lt;Subelement Path="1,3"&gt;</c> on the <c>moduleId</c> Member.
     /// </summary>
-    private StartValueLocation? FindStartValueLocation(XDocument doc, XNamespace ns, string path)
+    private static StartValueLocation? FindStartValueLocation(WriteContext ctx, string path)
     {
+        var ns = ctx.Ns;
         var tokens = TokenizePath(path);
         if (tokens.Count == 0) return null;
 
-        var sections = doc.Descendants(ns + SE.Section)
-            .FirstOrDefault(s => s.Attribute(SE.Name)?.Value == "Static");
+        // Cached once per document (#159 H1): the Static-section lookup used
+        // to re-run doc.Descendants(...) on every edit — O(n) descendant
+        // walks for n edits. WriteContext memoises it so the batch pays the
+        // traversal once.
+        var sections = ctx.StaticSection;
         if (sections == null) return null;
 
         XElement? current = sections;
@@ -263,6 +307,74 @@ public class SimaticMLWriter
     }
 
     /// <summary>
+    /// Per-document write state shared across every member in one
+    /// <see cref="ModifyStartValues(string, IReadOnlyList{MemberNode}, string)"/>
+    /// / batch call. Memoises the two lookups that used to be re-paid per
+    /// edit and turned bulk Apply quadratic (#159 H1 + H2):
+    /// the Static-section element, and a per-Member <c>Path → Subelement</c>
+    /// index. Lives only for the duration of one call against one parsed
+    /// <see cref="XDocument"/>.
+    /// </summary>
+    private sealed class WriteContext
+    {
+        private readonly Dictionary<XElement, Dictionary<string, XElement>> _subIndex = new();
+        private XElement? _staticSection;
+        private bool _staticResolved;
+
+        public WriteContext(XDocument doc, XNamespace ns)
+        {
+            Doc = doc;
+            Ns = ns;
+        }
+
+        public XDocument Doc { get; }
+        public XNamespace Ns { get; }
+
+        /// <summary>
+        /// The first <c>Section Name="Static"</c> in the document, resolved
+        /// once. Mirrors the original
+        /// <c>doc.Descendants(ns + Section).FirstOrDefault(...)</c> but pays
+        /// the descendant walk a single time per batch instead of per edit.
+        /// </summary>
+        public XElement? StaticSection
+        {
+            get
+            {
+                if (!_staticResolved)
+                {
+                    _staticSection = Doc.Descendants(Ns + SE.Section)
+                        .FirstOrDefault(s => s.Attribute(SE.Name)?.Value == "Static");
+                    _staticResolved = true;
+                }
+                return _staticSection;
+            }
+        }
+
+        /// <summary>
+        /// Lazily-built <c>Path attribute → &lt;Subelement&gt;</c> map for a
+        /// given array Member element. Built once per Member (O(k)); every
+        /// subsequent index access on the same Member is O(1). Writers that
+        /// add or prune a Subelement keep this map in sync.
+        /// </summary>
+        public Dictionary<string, XElement> SubelementIndex(XElement member)
+        {
+            if (!_subIndex.TryGetValue(member, out var index))
+            {
+                index = new Dictionary<string, XElement>(StringComparer.Ordinal);
+                foreach (var sub in LocalElements(member, SE.Subelement))
+                {
+                    var path = sub.Attribute(SE.Path)?.Value;
+                    // First wins, matching the original FirstOrDefault scan.
+                    if (path != null && !index.ContainsKey(path))
+                        index[path] = sub;
+                }
+                _subIndex[member] = index;
+            }
+            return index;
+        }
+    }
+
+    /// <summary>
     /// Points at either a Member's own StartValue or a Subelement's StartValue
     /// within an array Member.
     /// </summary>
@@ -277,8 +389,9 @@ public class SimaticMLWriter
         public XElement Member { get; }
         public string? SubelementPath { get; }
 
-        public XElement GetOrCreateStartValue(XNamespace ns)
+        public XElement GetOrCreateStartValue(WriteContext ctx)
         {
+            var ns = ctx.Ns;
             if (SubelementPath == null)
             {
                 var sv = Member.Element(ns + SE.StartValue);
@@ -291,12 +404,16 @@ public class SimaticMLWriter
             }
 
             // Find or create the matching <Subelement Path="..."> under Member.
-            var sub = LocalElements(Member, SE.Subelement)
-                .FirstOrDefault(e => e.Attribute(SE.Path)?.Value == SubelementPath);
-            if (sub == null)
+            // #159 H2: a linear FirstOrDefault scan over the Member's
+            // Subelements was O(k) per edit, so writing all k elements of a
+            // k-element array cost O(k^2). WriteContext pre-indexes the
+            // Subelements by Path once per Member; this is now an O(1) lookup.
+            var index = ctx.SubelementIndex(Member);
+            if (!index.TryGetValue(SubelementPath, out var sub))
             {
                 sub = new XElement(ns + SE.Subelement, new XAttribute(SE.Path, SubelementPath));
                 Member.Add(sub);
+                index[SubelementPath] = sub;
             }
 
             var inner = LocalElement(sub, SE.StartValue);
@@ -320,10 +437,12 @@ public class SimaticMLWriter
         /// per-instance override) the now-childless &lt;Subelement&gt; is pruned
         /// too. Returns the prior value, or null if there was nothing to clear.
         /// </summary>
-        public string? ClearStartValue(XNamespace ns)
+        public string? ClearStartValue(WriteContext ctx)
         {
+            var ns = ctx.Ns;
             XElement? sv;
             XElement? owningSubelement = null;
+            Dictionary<string, XElement>? index = null;
 
             if (SubelementPath == null)
             {
@@ -331,8 +450,10 @@ public class SimaticMLWriter
             }
             else
             {
-                owningSubelement = LocalElements(Member, SE.Subelement)
-                    .FirstOrDefault(e => e.Attribute(SE.Path)?.Value == SubelementPath);
+                // #159 H2: O(1) Subelement lookup via the per-Member index
+                // instead of a linear FirstOrDefault scan per cleared edit.
+                index = ctx.SubelementIndex(Member);
+                index.TryGetValue(SubelementPath, out owningSubelement);
                 sv = owningSubelement == null ? null : LocalElement(owningSubelement, SE.StartValue);
             }
 
@@ -344,7 +465,13 @@ public class SimaticMLWriter
             // Prune a Subelement that only existed to carry this StartValue. Keep
             // it if it still holds other content (e.g. a per-instance <Comment>).
             if (owningSubelement != null && !owningSubelement.Elements().Any())
+            {
                 owningSubelement.Remove();
+                // Keep the index consistent so a later create for the same
+                // path in this batch re-creates the Subelement instead of
+                // returning the now-detached element.
+                index?.Remove(SubelementPath!);
+            }
 
             return prior;
         }

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -1041,8 +1041,21 @@
                                            TextWrapping="Wrap"/>
                             </Border>
                             <!-- List -->
+                            <!-- #159 H5: virtualized. A bulk edit over a 10k-element
+                                 array used to materialize every preview row at once
+                                 (bare ItemsControl, no virtualization). The bounded
+                                 ScrollViewer in the template + VirtualizingStackPanel
+                                 panel recycle containers so only the visible rows are
+                                 realized. The MaxHeight gives the panel a viewport
+                                 (a StackPanel-hosted ItemsControl is measured with
+                                 infinite height and never virtualizes); below that
+                                 height it is its natural size and the outer inspector
+                                 scroll still moves it as one unit. -->
                             <ItemsControl ItemsSource="{Binding BulkPreview.Entries}"
-                                          Background="White">
+                                          Background="White"
+                                          ScrollViewer.CanContentScroll="True"
+                                          VirtualizingStackPanel.IsVirtualizing="True"
+                                          VirtualizingStackPanel.VirtualizationMode="Recycling">
                                 <ItemsControl.Style>
                                     <Style TargetType="ItemsControl">
                                         <Setter Property="Visibility" Value="Collapsed"/>
@@ -1057,12 +1070,21 @@
                                         </Style.Triggers>
                                     </Style>
                                 </ItemsControl.Style>
-                                <!-- No inner ScrollViewer: the sidebar's outer ScrollViewer
-                                     handles wheel events for the whole inspector. -->
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <VirtualizingStackPanel/>
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
                                 <ItemsControl.Template>
                                     <ControlTemplate TargetType="ItemsControl">
                                         <Border Background="White">
-                                            <ItemsPresenter/>
+                                            <ScrollViewer CanContentScroll="True"
+                                                          MaxHeight="360"
+                                                          VerticalScrollBarVisibility="Auto"
+                                                          HorizontalScrollBarVisibility="Disabled"
+                                                          Focusable="False">
+                                                <ItemsPresenter/>
+                                            </ScrollViewer>
                                         </Border>
                                     </ControlTemplate>
                                 </ItemsControl.Template>
@@ -1193,9 +1215,21 @@
                                            TextWrapping="Wrap"/>
                             </Border>
                             <!-- List -->
+                            <!-- #159 H4: virtualized. Staging edits across a
+                                 10k-element array used to materialize 10k pending
+                                 rows at once (bare ItemsControl), making the panel
+                                 sluggish to render and scroll even before Apply.
+                                 Same recipe as the Bulk Preview list above: bounded
+                                 ScrollViewer in the template + VirtualizingStackPanel
+                                 panel so only visible rows are realized; the MaxHeight
+                                 supplies the viewport that a StackPanel-hosted
+                                 ItemsControl otherwise lacks. -->
                             <ItemsControl x:Name="PendingEditsList"
                                           ItemsSource="{Binding Pending.PendingEdits}"
-                                          Background="White">
+                                          Background="White"
+                                          ScrollViewer.CanContentScroll="True"
+                                          VirtualizingStackPanel.IsVirtualizing="True"
+                                          VirtualizingStackPanel.VirtualizationMode="Recycling">
                                 <ItemsControl.Style>
                                     <Style TargetType="ItemsControl">
                                         <Setter Property="Visibility" Value="Collapsed"/>
@@ -1210,12 +1244,21 @@
                                         </Style.Triggers>
                                     </Style>
                                 </ItemsControl.Style>
-                                <!-- No inner ScrollViewer: the sidebar's outer ScrollViewer
-                                     handles wheel events for the whole inspector. -->
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <VirtualizingStackPanel/>
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
                                 <ItemsControl.Template>
                                     <ControlTemplate TargetType="ItemsControl">
                                         <Border Background="White">
-                                            <ItemsPresenter/>
+                                            <ScrollViewer CanContentScroll="True"
+                                                          MaxHeight="360"
+                                                          VerticalScrollBarVisibility="Auto"
+                                                          HorizontalScrollBarVisibility="Disabled"
+                                                          Focusable="False">
+                                                <ItemsPresenter/>
+                                            </ScrollViewer>
                                         </Border>
                                     </ControlTemplate>
                                 </ItemsControl.Template>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -1050,7 +1050,10 @@
                                  (a StackPanel-hosted ItemsControl is measured with
                                  infinite height and never virtualizes); below that
                                  height it is its natural size and the outer inspector
-                                 scroll still moves it as one unit. -->
+                                 scroll still moves it as one unit. The sticky-header
+                                 math (OnInspectorScrollChanged) keys off the OUTER
+                                 InspectorScroll/InspectorContent geometry only, so a
+                                 bounded inner scroller leaves it unaffected. -->
                             <ItemsControl ItemsSource="{Binding BulkPreview.Entries}"
                                           Background="White"
                                           ScrollViewer.CanContentScroll="True"

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -1520,7 +1520,17 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     {
         var commentTargets = new List<MemberNodeViewModel>();
         CollectPendingCommentNodes(RootMembers, commentTargets);
+        return ApplyCommentPreviews(xml, commentTargets);
+    }
 
+    /// <summary>
+    /// Overload that takes a pre-collected target list so the caller's
+    /// "are there comment previews?" check (#159 H3 fast-path gate) and the
+    /// write itself share a single tree walk instead of two back-to-back.
+    /// </summary>
+    internal string ApplyCommentPreviews(
+        string xml, IReadOnlyList<MemberNodeViewModel> commentTargets)
+    {
         if (commentTargets.Count == 0) return xml;
 
         var config = _configLoader.GetConfig();
@@ -1564,20 +1574,6 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         }
     }
 
-    /// <summary>
-    /// True when any node carries a comment preview that an Apply would
-    /// write to XML. Used by <see cref="ExecuteApply"/> to decide whether
-    /// the post-Apply refresh can take the #159 H3 in-place fast path (a
-    /// comment write changes the tree's comment state, so it still needs
-    /// the full re-parse). Mirrors the predicate
-    /// <see cref="CollectPendingCommentNodes"/> + <see cref="ApplyCommentPreviews"/> use.
-    /// </summary>
-    private bool HasPendingCommentPreviews()
-    {
-        var nodes = new List<MemberNodeViewModel>();
-        CollectPendingCommentNodes(RootMembers, nodes);
-        return nodes.Count > 0;
-    }
 
     /// <summary>
     /// Diagnostic wrapper around <see cref="MemberTreeViewModel.FindNodeByPathInDb"/>.
@@ -2340,13 +2336,22 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             foreach (var error in writeResult.Errors)
                 Log.Warning("Apply skipped: {Error}", error);
 
-            // Apply comment previews. A value-only Apply (no comment
-            // previews, no write errors) leaves the XML structurally
-            // identical to the parsed tree, which enables the #159 H3
-            // in-place refresh below; comment writes change the tree's
-            // comment state, so those still take the full re-parse path.
-            bool hadCommentPreviews = HasPendingCommentPreviews();
-            _active.Xml = ApplyCommentPreviews(_active.Xml);
+            // Apply comment previews. Collect the target nodes once and
+            // reuse the list for both the fast-path gate and the write —
+            // avoids a second full tree walk in the common (value-only) path.
+            var commentTargets = new List<MemberNodeViewModel>();
+            CollectPendingCommentNodes(RootMembers, commentTargets);
+            bool hadCommentPreviews = commentTargets.Count > 0;
+            _active.Xml = ApplyCommentPreviews(_active.Xml, commentTargets);
+
+            // #159 H3 gate. The in-place patch below is only sound when the
+            // re-parsed tree would be structurally identical to the current
+            // one. Two ways that fails: (a) a comment was written (changes
+            // the tree's comment state, not captured by ValueChange); (b) an
+            // edit errored — only the successful edits are in _active.Xml and
+            // writeResult.Changes, so the errored members' models would keep
+            // stale StartValues if patched piecemeal. Either case takes the
+            // full RefreshTree re-parse instead.
             bool structurePreserved =
                 writeResult.Errors.Count == 0 && !hadCommentPreviews;
 
@@ -2962,6 +2967,13 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// </summary>
     private void PatchTreeAfterApply(IReadOnlyList<ValueChange> changes)
     {
+        // Iterating `changes` (not the pending store) is sufficient to clear
+        // every staged VM: the only store entry that would NOT appear in
+        // `changes` is a no-op clear (empty value on a member with no
+        // <StartValue>), and that can never be staged in the first place —
+        // MemberNodeViewModel.EditableStartValue's no-op guard calls
+        // ClearPending() instead of creating a pending edit when clearing an
+        // already-empty value. So every store entry yields a ValueChange here.
         foreach (var change in changes)
         {
             var vm = FindNodeByPathInDb(change.MemberPath, _active);

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -1527,17 +1527,26 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         EnsureTagTableCache();
         var templateGen = config != null ? new TemplateCommentGenerator(config, _tagTableCache) : null;
 
-        foreach (var node in commentTargets)
+        // #159 H1 (minor): batch all comment writes for a language into one
+        // ModifyComments call (one parse/serialize) instead of calling
+        // ModifyComment per node per language (a full XDocument cycle each).
+        foreach (var lang in _projectLanguages)
         {
-            var rule = config?.GetCommentRule(node.Model);
-            if (rule?.CommentTemplate == null) continue;
-
-            foreach (var lang in _projectLanguages)
+            var members = new List<MemberNode>();
+            var comments = new List<string>();
+            foreach (var node in commentTargets)
             {
+                var rule = config?.GetCommentRule(node.Model);
+                if (rule?.CommentTemplate == null) continue;
+
                 var comment = templateGen!.Generate(_active.Info, node.Model, rule.CommentTemplate, lang, ResolvePendingValue);
-                xml = _writer.ModifyComment(xml, node.Model, comment, lang);
+                members.Add(node.Model);
+                comments.Add(comment);
                 Log.Information("Comment updated: {Path} → {Comment} ({Lang})", node.Model.Path, comment, lang);
             }
+
+            if (members.Count > 0)
+                xml = _writer.ModifyComments(xml, members, comments, lang);
         }
 
         return xml;
@@ -1553,6 +1562,21 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                 result.Add(node);
             CollectPendingCommentNodes(node.Children, result);
         }
+    }
+
+    /// <summary>
+    /// True when any node carries a comment preview that an Apply would
+    /// write to XML. Used by <see cref="ExecuteApply"/> to decide whether
+    /// the post-Apply refresh can take the #159 H3 in-place fast path (a
+    /// comment write changes the tree's comment state, so it still needs
+    /// the full re-parse). Mirrors the predicate
+    /// <see cref="CollectPendingCommentNodes"/> + <see cref="ApplyCommentPreviews"/> use.
+    /// </summary>
+    private bool HasPendingCommentPreviews()
+    {
+        var nodes = new List<MemberNodeViewModel>();
+        CollectPendingCommentNodes(RootMembers, nodes);
+        return nodes.Count > 0;
     }
 
     /// <summary>
@@ -2303,29 +2327,28 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
         try
         {
-            int totalChanged = 0;
+            // #159 H1: one parse + serialize for the whole pending batch
+            // instead of a full XDocument cycle per edit (was O(n) parses
+            // for n edits; a 10k-element array meant 10k re-parses of a
+            // multi-MB document). ModifyStartValues applies every edit it
+            // can and reports the rest in Errors — same net effect as the
+            // old per-edit loop, which also skipped-and-logged failures
+            // without aborting the batch.
+            var writeResult = _writer.ModifyStartValues(_active.Xml, pendingEdits);
+            _active.Xml = writeResult.ModifiedXml;
+            int totalChanged = writeResult.Changes.Count;
+            foreach (var error in writeResult.Errors)
+                Log.Warning("Apply skipped: {Error}", error);
 
-            // Apply all pending edits to XML
-            foreach (var (member, value) in pendingEdits)
-            {
-                var writeResult = _writer.ModifyStartValues(
-                    _active.Xml, new[] { member }, value);
-
-                if (writeResult.IsSuccess)
-                {
-                    _active.Xml = writeResult.ModifiedXml;
-                    totalChanged++;
-                    Log.Information("Applied: {Path} → {Value}", member.Path, value);
-                }
-                else
-                {
-                    Log.Warning("Failed for {Path}: {Errors}",
-                        member.Path, string.Join("; ", writeResult.Errors));
-                }
-            }
-
-            // Apply comment previews
+            // Apply comment previews. A value-only Apply (no comment
+            // previews, no write errors) leaves the XML structurally
+            // identical to the parsed tree, which enables the #159 H3
+            // in-place refresh below; comment writes change the tree's
+            // comment state, so those still take the full re-parse path.
+            bool hadCommentPreviews = HasPendingCommentPreviews();
             _active.Xml = ApplyCommentPreviews(_active.Xml);
+            bool structurePreserved =
+                writeResult.Errors.Count == 0 && !hadCommentPreviews;
 
             StatusText = Res.Format("Status_Changed", totalChanged, _active.Info.Name);
             _lastApplySucceeded = true;
@@ -2369,10 +2392,24 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
                     totalChanged);
             }
 
-            // Re-export from TIA to get the canonical XML after import
-            RefreshTree(_active.Xml);
+            // #159 H3: a value-only Apply does not change the XML structure
+            // (no members added/removed — only StartValue text), so the
+            // existing parsed tree is still valid. Re-parsing the whole
+            // (multi-MB) document and re-allocating every MemberNodeViewModel
+            // just to refresh start values re-paid the entire #154 open-path
+            // cost on every Apply. Patch the affected nodes in place instead;
+            // fall back to the full re-parse only when comments were written
+            // or some edits failed (structure may differ).
+            if (structurePreserved)
+            {
+                PatchTreeAfterApply(writeResult.Changes);
+            }
+            else
+            {
+                RefreshTree(_active.Xml);
+            }
 
-            // RefreshTree rebuilds RootMembers (all PendingValue=null), but computed
+            // RefreshTree/PatchTreeAfterApply clear PendingValue, but computed
             // properties only refresh their bindings when PropertyChanged is raised.
             RefreshPendingAndPreview();
         }
@@ -2459,22 +2496,15 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             // through, no TIA mutation has happened so the abort is clean.
             foreach (var (db, edits) in perDb)
             {
-                foreach (var (member, value) in edits)
-                {
-                    var writeResult = _writer.ModifyStartValues(
-                        db.Xml, new[] { member }, value);
-                    if (writeResult.IsSuccess)
-                    {
-                        db.Xml = writeResult.ModifiedXml;
-                        totalChanged++;
-                    }
-                    else
-                    {
-                        Log.Warning("Failed for {Db}/{Path}: {Errors}",
-                            db.Info.Name, member.Path,
-                            string.Join("; ", writeResult.Errors));
-                    }
-                }
+                // #159 H1: batch each DB's edits into a single parse +
+                // serialize instead of one per edit (mirrors the single-DB
+                // path). Failed members are reported in Errors without
+                // aborting the rest, exactly as the old per-edit loop did.
+                var writeResult = _writer.ModifyStartValues(db.Xml, edits);
+                db.Xml = writeResult.ModifiedXml;
+                totalChanged += writeResult.Changes.Count;
+                foreach (var error in writeResult.Errors)
+                    Log.Warning("Failed for {Db}: {Error}", db.Info.Name, error);
             }
 
             _lastApplySucceeded = true;
@@ -2910,6 +2940,63 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             node.ClearPending();
             ClearAllPendingInlineEdits(node.Children);
         }
+    }
+
+    /// <summary>
+    /// Post-Apply fast path (#159 H3). A successful value-only Apply leaves
+    /// the DB XML structurally identical to the already-parsed tree (only
+    /// StartValue text changed), so the heavy <see cref="RefreshTree"/>
+    /// pipeline — full re-parse (#154 H1 O(n^2)), re-allocating every
+    /// <see cref="MemberNodeViewModel"/> (#154 H2), and the path-based
+    /// selection/scope restore needed only because re-parse mints new model
+    /// instances — is pure waste. Instead, patch the committed nodes in
+    /// place and refresh only the derived/flat state.
+    ///
+    /// The patched value mirrors what a re-parse would yield: the writer
+    /// stores a constant as its raw name and a literal as its text, and the
+    /// parser reads exactly that back, so <see cref="ValueChange.NewValue"/>
+    /// is faithful; a cleared value (empty NewValue) maps to a null
+    /// StartValue, matching the parser's "no &lt;StartValue&gt; element"
+    /// result. Selection and scope keep their live model references (the
+    /// instances survive), so no save/restore dance is required.
+    /// </summary>
+    private void PatchTreeAfterApply(IReadOnlyList<ValueChange> changes)
+    {
+        foreach (var change in changes)
+        {
+            var vm = FindNodeByPathInDb(change.MemberPath, _active);
+            if (vm == null) continue;
+
+            // Empty NewValue == cleared start value; the parser represents
+            // that as a null StartValue (no <StartValue> element).
+            vm.Model.ApplyCommittedStartValue(
+                string.IsNullOrEmpty(change.NewValue) ? null : change.NewValue);
+            // Committed → the staged edit is no longer pending; also clears
+            // any inline validation error on the row.
+            vm.ClearPending();
+            vm.NotifyCommittedStartValueChanged();
+        }
+
+        // The committed edits' MemberNode keys are still live (no re-parse),
+        // but they are no longer pending — drop them so the store doesn't
+        // re-seed them onto the tree as staged.
+        _pendingEditStore.ClearAll();
+
+        // Values changed, so rule hints + existing-issue findings must be
+        // recomputed against the new committed state. These are O(n) tree
+        // walks, not the O(n^2) re-parse — they are not the #159 bottleneck.
+        RefreshRuleHints();
+        RebuildExistingIssues();
+        ApplyAllFilters();
+        RefreshFlatList();
+
+        // Mirror RefreshTree's post-Apply reset (#8): the just-committed
+        // value would misrepresent the current state if left in the input.
+        Autocomplete.SuppressSuggestions = true;
+        _newValueTouched = false;
+        _newValue = "";
+        OnPropertyChanged(nameof(NewValue));
+        Autocomplete.SuppressSuggestions = false;
     }
 
     private void RefreshTree(

--- a/src/BlockParam/UI/MemberNodeViewModel.cs
+++ b/src/BlockParam/UI/MemberNodeViewModel.cs
@@ -339,6 +339,19 @@ public class MemberNodeViewModel : ViewModelBase
         OnPropertyChanged(nameof(EditableStartValue));
     }
 
+    /// <summary>
+    /// Re-raises the <see cref="StartValue"/>-derived bindings after the
+    /// owning model's value was patched in place by a committed Apply
+    /// (#159 H3). Without a re-parse the VM instance is unchanged, so the
+    /// table/inspector only refresh if these read-through properties signal.
+    /// </summary>
+    internal void NotifyCommittedStartValueChanged()
+    {
+        OnPropertyChanged(nameof(StartValue));
+        OnPropertyChanged(nameof(HasStartValue));
+        OnPropertyChanged(nameof(EditableStartValue));
+    }
+
     /// <summary>Fired when user edits a start value directly in the table.</summary>
     public event Action<MemberNodeViewModel, string>? StartValueEdited;
 


### PR DESCRIPTION
## Summary

Fixes the five compounding performance defects in #159 — Apply over a large
array (e.g. `Array[1..10000] Of DInt`) was seconds-to-tens-of-seconds and the
staged panels were sluggish even before Apply.

| # | Fix |
|---|---|
| **H1** | `SimaticMLWriter` gains a batch `ModifyStartValues(xml, edits)` overload — one parse + serialize for the whole pending set instead of one full XDocument cycle per edit. Single-DB, multi-DB, and comment-preview Apply loops all batch now. O(n) document cycles → O(1). |
| **H2** | New `WriteContext` pre-indexes a Member's `<Subelement>` children by `Path` (and memoises the Static-section lookup). Per-edit linear `FirstOrDefault` → O(1) `TryGetValue`. O(n²) → O(n). |
| **H3** | `PatchTreeAfterApply` mutates the surviving `MemberNode` tree in place from `WriteResult.Changes` and refreshes only derived/flat state — skips the full re-parse + VM rebuild + selection/scope restore. Falls back to `RefreshTree` when comments were written or any edit failed (structure may differ). |
| **H4/H5** | Pending Edits + Bulk Preview `ItemsControl`s get a `VirtualizingStackPanel` panel + a bounded inner `ScrollViewer` (`CanContentScroll`) so only visible rows are realized. |

## Scope (review here, not the full diff)

The mirror's `main` is behind several already-merged PRs (#135–#158), so the
raw PR diff is noisy. The actual #159 change is **3 commits** (`d139862`,
`c037657`, `558686d`) touching **7 files**:

- `src/BlockParam/SimaticML/SimaticMLWriter.cs` (H1 batch overload, H2 `WriteContext`)
- `src/BlockParam/UI/BulkChangeViewModel.cs` (batch Apply loops, `PatchTreeAfterApply`, H3)
- `src/BlockParam/Models/MemberNode.cs` (`ApplyCommittedStartValue` internal mutator for H3)
- `src/BlockParam/UI/MemberNodeViewModel.cs` (`NotifyCommittedStartValueChanged`)
- `src/BlockParam/UI/BulkChangeDialog.xaml` (H4/H5 virtualization)
- `src/BlockParam.Tests/SimaticMLWriterTests.cs` (batch correctness + 10k-array gate)
- `src/BlockParam.Tests/BulkChangeViewModelCommandTests.cs` (in-place patch + cleared-value)

(`558686d` is an empty `[image-ci]` trigger commit for the visual check — squashable on merge.)

## Test plan

- [x] V20 Build & Test ✅ — 1093 tests pass incl. the new 10k-element-array regression gate
- [x] V21 Build ✅
- [x] Partial-trust IL gate (PEVerify) ✅ — no `ldflda`/readonly-struct regression
- [x] Visual check (H4/H5): rendered this branch via the opt-in screenshots job and inspected `04_pending_queue` (Pending Edits, 8 staged) and `02_bulk_edit_plant` (Bulk Preview, 96 targets) — panels render cleanly and are now bounded as intended; no double scrollbars / clipping / sticky-header breakage. (Numeric baseline diff was inconclusive: the committed `assets/screenshots/*.png` are a stale canvas size vs current headless WPF rendering across *all* scenes — pre-existing, unrelated to #159.)

Closes #159

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArCRgH7WFSA3yAauh2MqSQ)_