### PR TITLE
fix(#141): Display fallback for numberless-DB pill trigger summary

### DIFF
--- a/src/BlockParam.DevLauncher/PillRowCapture.cs
+++ b/src/BlockParam.DevLauncher/PillRowCapture.cs
@@ -159,32 +159,38 @@ internal static class PillRowCapture
     private static IReadOnlyList<SceneDef> BuildSceneDefs(
         IReadOnlyList<DataBlockSummary> realDbs)
     {
+        var scenes = new List<SceneDef>();
+
         if (realDbs.Count == 0)
         {
-            return new List<SceneDef>
-            {
-                new("No real fixtures found",
-                    $"Expected DBs in {Path.Combine(Path.GetTempPath(), "BlockParam")}",
-                    () => BuildEmptyScene()),
-            };
+            // Hosted CI runners have no %TEMP%\BlockParam\ exports, so the
+            // real-fixtures section is empty there. Emit one placeholder for
+            // context, then fall through to the synthetic + #141 scenes so
+            // --capture-pill-row is still meaningful on CI (which is the only
+            // place the screenshots job actually runs). Before this, an empty
+            // %TEMP% short-circuited the WHOLE capture to just this placeholder
+            // — the synthetic showcase never rendered on CI at all.
+            scenes.Add(new("No real fixtures found",
+                $"Expected DBs in {Path.Combine(Path.GetTempPath(), "BlockParam")} — synthetic + #141 scenes follow.",
+                () => BuildEmptyScene(),
+                SectionHeader: "Real fixtures (from %TEMP%\\BlockParam\\)"));
         }
-
-        // Anchor = first real DB. The user's interactive session lands on
-        // this DB by default (BulkChangeDialog opens with index 0 active).
-        var anchor = realDbs[0];
-        var firstThree = realDbs.Take(Math.Min(3, realDbs.Count)).ToList();
-        var firstHalf = realDbs.Take((realDbs.Count + 1) / 2).ToList();
-        var secondHalf = realDbs.Skip((realDbs.Count + 1) / 2).ToList();
-
-        // DevLauncher fixtures don't carry a real PLC name; rebrand to a
-        // demo label so the always-on PLC label policy is visible in the
-        // composite. Real TIA Openness sessions populate the PLC name
-        // for free.
-        const string demoPlc = "PLC_1";
-
-        var scenes = new List<SceneDef>
+        else
         {
-            new("Real fixtures · single DB active (anchor only)",
+            // Anchor = first real DB. The user's interactive session lands on
+            // this DB by default (BulkChangeDialog opens with index 0 active).
+            var anchor = realDbs[0];
+            var firstThree = realDbs.Take(Math.Min(3, realDbs.Count)).ToList();
+            var firstHalf = realDbs.Take((realDbs.Count + 1) / 2).ToList();
+            var secondHalf = realDbs.Skip((realDbs.Count + 1) / 2).ToList();
+
+            // DevLauncher fixtures don't carry a real PLC name; rebrand to a
+            // demo label so the always-on PLC label policy is visible in the
+            // composite. Real TIA Openness sessions populate the PLC name
+            // for free.
+            const string demoPlc = "PLC_1";
+
+            scenes.Add(new("Real fixtures · single DB active (anchor only)",
                 $"Active set: {anchor.Name}. Matches the dialog's launch state.",
                 () => BuildRowScene(new[]
                 {
@@ -193,9 +199,9 @@ internal static class PillRowCapture
                         Source: realDbs,
                         ActiveNames: new[] { anchor.Name }),
                 }, openIndex: -1, openAddPlc: false),
-                SectionHeader: "Real fixtures (from %TEMP%\\BlockParam\\)"),
+                SectionHeader: "Real fixtures (from %TEMP%\\BlockParam\\)"));
 
-            new("Real fixtures · multiple DBs active (same PLC)",
+            scenes.Add(new("Real fixtures · multiple DBs active (same PLC)",
                 $"Active set: {string.Join(", ", firstThree.Select(d => d.Name))}",
                 () => BuildRowScene(new[]
                 {
@@ -203,9 +209,9 @@ internal static class PillRowCapture
                         OverridePlc: demoPlc,
                         Source: realDbs,
                         ActiveNames: firstThree.Select(d => d.Name).ToList()),
-                }, openIndex: -1, openAddPlc: false)),
+                }, openIndex: -1, openAddPlc: false)));
 
-            new("Real fixtures · first pill's popup open",
+            scenes.Add(new("Real fixtures · first pill's popup open",
                 "Reproduces the 'no abbreviations in row' state when DB.Number is null.",
                 () => BuildRowScene(new[]
                 {
@@ -213,14 +219,23 @@ internal static class PillRowCapture
                         OverridePlc: demoPlc,
                         Source: realDbs,
                         ActiveNames: new[] { anchor.Name }),
-                }, openIndex: 0, openAddPlc: false)),
-        };
+                }, openIndex: 0, openAddPlc: false)));
+
+            // firstHalf / secondHalf are kept from earlier scene drafts;
+            // unused locals are tolerated here (parity with prior behaviour).
+            _ = (firstHalf, secondHalf);
+        }
 
         // ── Synthetic multi-PLC showcase ─────────────────────────────────────
         // Pure synthetic data (numbers + PLC labels are made up) so the
         // overflow / wrap / multi-PLC visuals can be iterated on without
         // depending on what the developer happens to have in %TEMP%.
         scenes.AddRange(BuildSyntheticShowcaseScenes());
+
+        // #141 regression repro — numberless instance DB, closed pill, NO
+        // OverflowOptions. Always rendered (it's synthetic, not gated on
+        // %TEMP% fixtures) so the screenshots job verifies the fix on CI.
+        scenes.Add(BuildIssue141NumberlessScene());
 
         return scenes;
     }
@@ -364,6 +379,41 @@ internal static class PillRowCapture
         };
     }
 
+    /// <summary>
+    /// #141 regression repro. A numberless instance DB
+    /// (<c>Gen_Main_IDB</c> — <c>_IDB</c> suffix, no DB number → empty
+    /// <see cref="DataBlockListItem.Abbreviation"/>) in a CLOSED pill built
+    /// WITHOUT <c>OverflowOptions</c>. That is the exact path the fix
+    /// repairs: the default <c>PillTriggerToken</c> summary (no
+    /// <c>_displayFormatter</c>). Pre-fix the trigger rendered BLANK (only
+    /// the count badge + ×); post-fix it falls back to the full DB name.
+    /// Pure synthetic so it renders on every run, including hosted CI where
+    /// there are no <c>%TEMP%\BlockParam\</c> fixtures.
+    /// </summary>
+    private static SceneDef BuildIssue141NumberlessScene() =>
+        new("#141 · numberless instance DB · closed pill, no OverflowOptions",
+            "Gen_Main_IDB has no DB number so its abbreviation is empty. "
+            + "With no OverflowOptions wired the trigger summary uses the "
+            + "default token path — pre-fix this rendered blank, post-fix it "
+            + "falls back to the full DB name.",
+            () => BuildRowScene(new[]
+            {
+                new PillSeed(
+                    OverridePlc: "CPU_1",
+                    Source: new[]
+                    {
+                        new DataBlockSummary(
+                            name: "Gen_Main_IDB",
+                            folderPath: "",
+                            blockType: "InstanceDB",
+                            isInstanceDb: true,
+                            plcName: "CPU_1",
+                            number: null),
+                    },
+                    ActiveNames: new[] { "Gen_Main_IDB" }),
+            }, openIndex: -1, openAddPlc: false, wireOverflowOptions: false),
+            SectionHeader: "#141 regression — closed-pill default-path summary");
+
     // ── Window construction ──────────────────────────────────────────────────
 
     private static (Window Window, FrameworkElement? PopupHost) BuildRowScene(
@@ -372,7 +422,8 @@ internal static class PillRowCapture
         bool openAddPlc,
         bool showAddButton = false,
         IReadOnlyList<DataBlockSummary>? addPlcSource = null,
-        int hoverTooltipIndex = -1)
+        int hoverTooltipIndex = -1,
+        bool wireOverflowOptions = true)
     {
         // Route pill construction through PlcPillGroupsService.Build so the
         // capture stays honest if Build's ordering / anchor / extraPlcs
@@ -456,12 +507,18 @@ internal static class PillRowCapture
                 AbbreviationMemberPath = nameof(DataBlockListItem.Abbreviation),
                 Icon = Geometry.Parse(DatabaseIconPath),
                 TooltipMode = PillTooltipMode.FullNames,
-                // Mirror BulkChangeDialog.xaml's DbPillOverflowOptions so the
-                // trigger renders full DB names until they exceed ~30 chars
-                // or 4 entries, then degrades to abbreviations.
-                OverflowOptions = PillOverflowOptions.DataBlockDefault(),
                 Margin = new Thickness(0, 0, 8, 0),
             };
+            if (wireOverflowOptions)
+            {
+                // Mirror BulkChangeDialog.xaml's DbPillOverflowOptions so the
+                // trigger renders full DB names until they exceed ~30 chars
+                // or 4 entries, then degrades to abbreviations. The #141 repro
+                // scene passes wireOverflowOptions:false to exercise the
+                // DEFAULT token path (no _displayFormatter) — the exact path
+                // the fix repairs for a numberless instance DB.
+                ms.OverflowOptions = PillOverflowOptions.DataBlockDefault();
+            }
             if (i == openIndex)
             {
                 // Set IsOpen on the control directly so PlcPillViewModel's

--- a/src/BlockParam.DevLauncher/PillRowCapture.cs
+++ b/src/BlockParam.DevLauncher/PillRowCapture.cs
@@ -181,8 +181,6 @@ internal static class PillRowCapture
             // this DB by default (BulkChangeDialog opens with index 0 active).
             var anchor = realDbs[0];
             var firstThree = realDbs.Take(Math.Min(3, realDbs.Count)).ToList();
-            var firstHalf = realDbs.Take((realDbs.Count + 1) / 2).ToList();
-            var secondHalf = realDbs.Skip((realDbs.Count + 1) / 2).ToList();
 
             // DevLauncher fixtures don't carry a real PLC name; rebrand to a
             // demo label so the always-on PLC label policy is visible in the
@@ -220,10 +218,6 @@ internal static class PillRowCapture
                         Source: realDbs,
                         ActiveNames: new[] { anchor.Name }),
                 }, openIndex: 0, openAddPlc: false)));
-
-            // firstHalf / secondHalf are kept from earlier scene drafts;
-            // unused locals are tolerated here (parity with prior behaviour).
-            _ = (firstHalf, secondHalf);
         }
 
         // ── Synthetic multi-PLC showcase ─────────────────────────────────────

--- a/src/BlockParam.Tests/PillSelectionSyncTests.cs
+++ b/src/BlockParam.Tests/PillSelectionSyncTests.cs
@@ -715,8 +715,11 @@ public class PillTriggerSummary_NumberlessDb_Tests
 
         // No OverflowOptions / DisplayFormatter wired → exercises the
         // DEFAULT PillTriggerTokenBuilder path, not PillOverflowFormatter.
-        sync.SetSelectedItems(new ObservableCollection<object> { idb });
+        // ItemsSource first, then SelectedItems, so the row is selected via
+        // ReconcileRowsFromSelectedItems — the documented DP-order scenario
+        // (cf. PlcPillViewModelTests ClosedPill_…_FullControlPath).
         itemSource.ItemsSource = new ObservableCollection<object> { idb };
+        sync.SetSelectedItems(new ObservableCollection<object> { idb });
         state.DisplayFormatter.Should().BeNull("the default path must be under test");
 
         state.HasSelection.Should().BeTrue();

--- a/src/BlockParam.Tests/PillSelectionSyncTests.cs
+++ b/src/BlockParam.Tests/PillSelectionSyncTests.cs
@@ -5,6 +5,8 @@ using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using FluentAssertions;
+using BlockParam.Models;
+using BlockParam.UI;
 using BlockParam.UI.Controls.PillMultiSelect;
 using Xunit;
 
@@ -671,6 +673,57 @@ public class PillSelectionSync_OrderIndependence_Tests
         // Normal Edge-A still works after the empty-seed path.
         selected.Add(src);
         state.Items[0].IsSelected.Should().BeTrue();
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #141 — closed-trigger summary for a numberless instance DB on the DEFAULT
+// (no OverflowOptions / no _displayFormatter) path.
+//
+// 7882cc1 added the empty-Abbreviation → Display fallback ONLY to
+// PillOverflowFormatter.Format (the _displayFormatter path). The default
+// path in PillMultiSelectInternalState.SelectedAbbreviationsText joined
+// PillTriggerToken.Abbreviation directly, so a numberless instance DB
+// (Gen_Main_IDB — empty Abbreviation) rendered a BLANK closed-trigger
+// summary whenever OverflowOptions wasn't wired (or hadn't been applied
+// yet). That is symptom A of #141. Every prior #141 regression test set
+// OverflowOptions, so they all exercised the already-fixed formatter path
+// and never covered this. This pins parity: the default path must also
+// fall back to Display so the closed pill is never blank — with NO popup
+// ever opened.
+// ─────────────────────────────────────────────────────────────────────────────
+
+public class PillTriggerSummary_NumberlessDb_Tests
+{
+    [Fact]
+    public void NumberlessInstanceDb_DefaultPath_RendersDisplayNotBlank()
+    {
+        var state = new PillMultiSelectInternalState();
+        var resolver = new MemberPathResolver();
+        var itemSource = new PillItemSource(state, resolver);
+        var sync = new PillSelectionSync(state, itemSource, resolver);
+
+        // The #141 repro: instance DB, _IDB suffix, no DB number → the
+        // Abbreviation ("DB{Number}") is empty; only Display is populated.
+        var idb = new DataBlockListItem(
+            new DataBlockSummary("Gen_Main_IDB", "", blockType: "InstanceDB",
+                isInstanceDb: true, plcName: "CPU_1", number: null),
+            isActive: true, isAnchor: true);
+
+        itemSource.DisplayMemberPath = nameof(DataBlockListItem.Display);
+        itemSource.AbbreviationMemberPath = nameof(DataBlockListItem.Abbreviation);
+
+        // No OverflowOptions / DisplayFormatter wired → exercises the
+        // DEFAULT PillTriggerTokenBuilder path, not PillOverflowFormatter.
+        sync.SetSelectedItems(new ObservableCollection<object> { idb });
+        itemSource.ItemsSource = new ObservableCollection<object> { idb };
+        state.DisplayFormatter.Should().BeNull("the default path must be under test");
+
+        state.HasSelection.Should().BeTrue();
+        // Before the fix this was "" (join of the empty Abbreviation),
+        // leaving the closed pill blank. It must show the DB name with no
+        // popup-open and no OverflowOptions.
+        state.SelectedAbbreviationsText.Should().Be("Gen_Main_IDB");
     }
 }
 

--- a/src/BlockParam/UI/Controls/PillMultiSelect/PillMultiSelectInternalState.cs
+++ b/src/BlockParam/UI/Controls/PillMultiSelect/PillMultiSelectInternalState.cs
@@ -312,7 +312,14 @@ internal sealed class PillMultiSelectInternalState : PillViewModelBase
                 return _displayFormatter(selected);
 
             var tokens = PillTriggerTokenBuilder.Build(selected);
-            return string.Join(", ", tokens.Select(t => t.Abbreviation));
+            // #141: a numberless instance DB (e.g. Gen_Main_IDB — _IDB
+            // suffix, no DB number) has an empty Abbreviation. Joining the
+            // bare Abbreviation here rendered a BLANK closed-trigger summary
+            // when no OverflowOptions/_displayFormatter is wired. Fall back
+            // to the full Display name — the same rule PillOverflowFormatter
+            // already applies on the _displayFormatter path (kept in parity).
+            return string.Join(", ", tokens.Select(
+                t => string.IsNullOrEmpty(t.Abbreviation) ? t.Display : t.Abbreviation));
         }
     }
 


### PR DESCRIPTION
## Summary

- **Root cause of #141 (symptom A — blank pill).** Commit `7882cc1` added the "empty `Abbreviation` → fall back to `Display`" rule **only** in `PillOverflowFormatter.Format` (the path used when `OverflowOptions` is wired). `PillMultiSelectInternalState.SelectedAbbreviationsText` has a **second, default path** (no `OverflowOptions`/`_displayFormatter`) that joined `PillTriggerToken.Abbreviation` raw, with no fallback. A numberless instance DB like `Gen_Main_IDB` has an empty abbreviation (`"DB{Number}"` with no number) → the default path produced `""` → blank trigger summary. Every prior #141 regression test set `OverflowOptions`, so they all exercised the already-fixed formatter path and never this one — which is why the bug "passed in the harness but reproduced live".
- **Fix:** the default path now falls back to `Display` when `Abbreviation` is empty — parity with `PillOverflowFormatter`. Symptom B (popup won't open) follows causally per the issue's "shared root cause": a label-less, summary-less pill collapses to a sliver dominated by the `×` clear button (whose handler sets `e.Handled = true` and swallows the click); restoring the summary restores a real click target.
- **Unit regression test** (`PillTriggerSummary_NumberlessDb_Tests`) drives the default no-`OverflowOptions` path with `Gen_Main_IDB`: fails before the fix (blank), passes after — the exact coverage gap all prior tests had.
- **Screenshot-CI pipeline fixes** (so the fix is visually verifiable): the pill-row capture short-circuited to a single "No real fixtures found" placeholder on hosted CI (no `%TEMP%\BlockParam\` exports), so the synthetic showcase never rendered there; and no scene reproduced #141. `BuildSceneDefs` now always renders the synthetic + #141 scenes; `BuildRowScene` gained `wireOverflowOptions` (default true); new `BuildIssue141NumberlessScene` exercises the exact repaired path.

## Verification

CI run #259 — all four jobs green (V20 build+test incl. the new unit test, PEVerify, V21, Screenshots). The rendered `pill-row.png` composite shows the closed pill as `CPU_1  Gen_Main_IDB  ①  ×` (pre-fix: only the badge + ×, blank summary).

## Test plan

- [x] `dotnet test` — full xUnit suite incl. `NumberlessInstanceDb_DefaultPath_RendersDisplayNotBlank` (CI V20: green)
- [x] PEVerify partial-trust IL gate (CI: green — no #131-class regression)
- [x] V21 build (CI: green)
- [x] Screenshot-CI renders the #141 scene with the DB name (not blank)
- [ ] Final confirmation under a live TIA V20 session with the original `Gen_Main_IDB` DB

Closes #141

https://claude.ai/code/session_013kdhLAWbvjXyx8E6Yx34A5

---
_Generated by [Claude Code](https://claude.ai/code/session_013kdhLAWbvjXyx8E6Yx34A5)_