### PR TITLE
perf(#154): O(n) DB open — indexed parse, single-Reset flat list, cached highlight, long fingerprint

### DIFF
--- a/src/BlockParam.Tests/BulkObservableCollectionTests.cs
+++ b/src/BlockParam.Tests/BulkObservableCollectionTests.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using BlockParam.UI;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// #154 H3: ReplaceAll must swap the whole contents while raising exactly
+/// ONE CollectionChanged (Reset) — not Clear() + N×Add (N+1 events). The
+/// bound instance is unchanged so existing WPF bindings/selection keep
+/// working; only the notification volume drops.
+/// </summary>
+public class BulkObservableCollectionTests
+{
+    [Fact]
+    public void ReplaceAll_RaisesSingleResetAndReplacesContents()
+    {
+        var col = new BulkObservableCollection<int> { 1, 2, 3 };
+
+        var collectionEvents = new List<NotifyCollectionChangedEventArgs>();
+        var propEvents = new List<string?>();
+        col.CollectionChanged += (_, e) => collectionEvents.Add(e);
+        ((INotifyPropertyChanged)col).PropertyChanged += (_, e) => propEvents.Add(e.PropertyName);
+
+        col.ReplaceAll(new[] { 10, 20, 30, 40, 50 });
+
+        col.Should().Equal(10, 20, 30, 40, 50);
+        collectionEvents.Should().ContainSingle()
+            .Which.Action.Should().Be(NotifyCollectionChangedAction.Reset,
+                "a bulk replace must collapse to one Reset, not N add events");
+        propEvents.Should().Contain(nameof(BulkObservableCollection<int>.Count));
+        propEvents.Should().Contain("Item[]");
+    }
+
+    [Fact]
+    public void ReplaceAll_FromEmpty_AndToEmpty_Work()
+    {
+        var col = new BulkObservableCollection<string>();
+
+        col.ReplaceAll(new[] { "a", "b" });
+        col.Should().Equal("a", "b");
+
+        var events = new List<NotifyCollectionChangedEventArgs>();
+        col.CollectionChanged += (_, e) => events.Add(e);
+        col.ReplaceAll(new string[0]);
+
+        col.Should().BeEmpty();
+        events.Should().ContainSingle().Which.Action
+            .Should().Be(NotifyCollectionChangedAction.Reset);
+    }
+}

--- a/src/BlockParam.Tests/FlatTreeManagerTests.cs
+++ b/src/BlockParam.Tests/FlatTreeManagerTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using FluentAssertions;
 using BlockParam.Models;
 using BlockParam.UI;
@@ -307,5 +308,45 @@ public class FlatTreeManagerTests
         mgr.Refresh(new[] { root });
 
         GetFlatNames(mgr).Should().Equal("Root", "Child1", "Leaf1B", "Child2", "Leaf2B");
+    }
+
+    // ===== #154 H3/H4: large flat array =====
+
+    /// <summary>
+    /// #154 H4 regression gate. A smart-expanded parent of a 5 000-element
+    /// flat array: pre-fix, <c>AddNodeToFlatList</c> called the recursive
+    /// <c>HasHighlightedDescendant</c> for every sibling — O(n²). With the
+    /// one-shot <c>RefreshHighlightCache</c> pass it is O(n). Asserts the
+    /// smart-expand filter still shows exactly the highlighted element (so
+    /// the cache is correct, not just fast) and that the build is well under
+    /// a generous, CI-jitter-tolerant ceiling.
+    /// </summary>
+    [Fact]
+    public void FlatList_LargeArray_SmartExpand_IsLinearAndFiltersCorrectly()
+    {
+        const int n = 5_000;
+        var leaves = new MemberNode[n];
+        for (int i = 0; i < n; i++)
+            leaves[i] = new MemberNode($"[{i}]", "DInt", i.ToString(),
+                $"Big[{i}]", null, Array.Empty<MemberNode>());
+        var rootModel = new MemberNode("Big", "Array[0..4999] of DInt", null,
+            "Big", null, leaves);
+
+        var rootVm = new MemberNodeViewModel(rootModel, null);
+        rootVm.IsExpanded = true;
+        rootVm.IsSmartExpanded = true;
+        // Exactly one element highlighted, deep in the middle.
+        rootVm.Children[n / 2].IsAffected = true;
+
+        var mgr = new FlatTreeManager();
+        var sw = Stopwatch.StartNew();
+        mgr.Refresh(new[] { rootVm });
+        sw.Stop();
+
+        // Smart-expand under the array shows only the highlighted child.
+        GetFlatNames(mgr).Should().Equal("Big", $"[{n / 2}]");
+        sw.Elapsed.TotalSeconds.Should().BeLessThan(5,
+            "#154 H4: O(n) cached highlight pass — a regression to the "
+            + "per-node recursive scan (O(n²)) would exceed this ceiling");
     }
 }

--- a/src/BlockParam.Tests/HierarchyAnalyzerTests.cs
+++ b/src/BlockParam.Tests/HierarchyAnalyzerTests.cs
@@ -228,4 +228,69 @@ public class HierarchyAnalyzerTests
         result.Scopes.Should().ContainSingle(s => s.AncestorPath == "MyArray");
         result.Scopes.Should().NotContain(s => s.AncestorPath.StartsWith("MyArray["));
     }
+
+    // --- #90 / #154 H5 fingerprint correctness tests ---
+
+    /// <summary>
+    /// #90 invariant: two partial-dim scopes with equal MatchCount but disjoint
+    /// path sets (e.g. SquareMatrix[0,*] and SquareMatrix[*,0] on a 3x3 array,
+    /// each covering 3 cells but different cells) must NOT be collapsed by
+    /// DeduplicateByMatchCount. This pins the correctness side of the #154 H5
+    /// fingerprint change (HashSet&lt;string&gt; → HashSet&lt;long&gt; via FNV-1a).
+    /// Behavioral test through the public Analyze API.
+    /// </summary>
+    [Fact]
+    public void Analyze_SquareMatrix_SameCountDifferentPaths_BothScopesKept()
+    {
+        // SquareMatrix is Array[0..2, 0..2] of Int in array-db.xml.
+        // Selecting [0,0] yields:
+        //   SquareMatrix[0,*]  — row 0: [0,0], [0,1], [0,2]   MatchCount = 3
+        //   SquareMatrix[*,0]  — col 0: [0,0], [1,0], [2,0]   MatchCount = 3
+        //   SquareMatrix       — full:  all 9 elements          MatchCount = 9
+        // The two 3-element scopes share the same MatchCount but target completely
+        // different cells; the deduplicator must keep both.
+        var db = _parser.Parse(TestFixtures.LoadXml("array-db.xml"));
+        var squareMatrix = db.Members.First(m => m.Name == "SquareMatrix");
+        var elem00 = squareMatrix.Children.First(c => c.Name == "[0,0]");
+
+        var result = _analyzer.Analyze(db, elem00);
+
+        var rowScope = result.Scopes.FirstOrDefault(s => s.AncestorPath == "SquareMatrix[0,*]");
+        var colScope = result.Scopes.FirstOrDefault(s => s.AncestorPath == "SquareMatrix[*,0]");
+
+        rowScope.Should().NotBeNull("row-0 scope must be present");
+        colScope.Should().NotBeNull("col-0 scope must be present");
+        rowScope!.MatchCount.Should().Be(3);
+        colScope!.MatchCount.Should().Be(3);
+
+        // Verify the path sets are indeed disjoint (no false collision in the fingerprint).
+        var rowPaths = rowScope.MatchingMembers.Select(m => m.Name).ToHashSet();
+        var colPaths = colScope.MatchingMembers.Select(m => m.Name).ToHashSet();
+        rowPaths.Should().NotBeEquivalentTo(colPaths,
+            "row-0 and col-0 cover different cells; fingerprints must differ");
+    }
+
+    /// <summary>
+    /// Complementary check: two scopes with identical MatchCount AND identical
+    /// path sets must collapse to one entry. This confirms the dedup still works
+    /// for the "genuine duplicate" case after the fingerprint type change.
+    /// Behavioral test: SquareMatrix[0,*] appears via within-DB analysis and
+    /// must not be repeated in the result even if the analyzer builds it twice.
+    /// Because the analyzer only builds each partial-dim scope once per select,
+    /// we verify uniqueness via result cardinality (no scope with the same
+    /// AncestorPath appears more than once).
+    /// </summary>
+    [Fact]
+    public void Analyze_SquareMatrix_ScopeAppearsExactlyOnce()
+    {
+        var db = _parser.Parse(TestFixtures.LoadXml("array-db.xml"));
+        var squareMatrix = db.Members.First(m => m.Name == "SquareMatrix");
+        var elem01 = squareMatrix.Children.First(c => c.Name == "[0,1]");
+
+        var result = _analyzer.Analyze(db, elem01);
+
+        // Each distinct AncestorPath should appear at most once (dedup works).
+        var paths = result.Scopes.Select(s => s.AncestorPath).ToList();
+        paths.Should().OnlyHaveUniqueItems("duplicate scopes indicate a fingerprint collision");
+    }
 }

--- a/src/BlockParam.Tests/OpenPathPerfTests.cs
+++ b/src/BlockParam.Tests/OpenPathPerfTests.cs
@@ -1,0 +1,246 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Text;
+using System.Xml.Linq;
+using BlockParam.Models;
+using BlockParam.SimaticML;
+using BlockParam.UI;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// #154 quantified before/after for the DB-open path, analogous to the #159
+/// benchmark (PR #161). Unlike #159 — where the pre-fix code path was a
+/// retained overload — #154's old algorithms were replaced in place, so the
+/// "before" for H1/H4 is a FAITHFUL in-test reproduction of the removed code
+/// run against identical inputs, while the "after" is the real product code.
+/// H3 needs no reproduction: "before" is stock <see cref="ObservableCollection{T}"/>
+/// and the metric is an exact, deterministic CollectionChanged count (the
+/// fan-out #154 H3 is about), not a flaky wall-time.
+/// Each test prints its numbers to the CI test output and asserts a
+/// conservative floor so a revert trips it without runner-jitter flake.
+/// </summary>
+public class OpenPathPerfTests
+{
+    private readonly ITestOutputHelper _out;
+    private readonly SimaticMLParser _parser = new();
+
+    public OpenPathPerfTests(ITestOutputHelper output) => _out = output;
+
+    // ───────────────────────── H1: parser subelement read ─────────────────
+
+    /// <summary>
+    /// #154 H1. Isolates the fixed dimension on identical input: "before" is
+    /// the removed pattern (linear &lt;Subelement&gt; scan per element, O(n²)),
+    /// "after" is the new strategy (index the children once, then O(1) lookups
+    /// — exactly what <see cref="SimaticMLParser"/> now does internally). Both
+    /// are reproduced so the comparison isolates the algorithm rather than
+    /// being muddied by the rest of Parse; correctness is tied back to the
+    /// real product by asserting both reproductions equal the values
+    /// <see cref="SimaticMLParser.Parse"/> actually produced.
+    /// </summary>
+    [Fact]
+    public void H1_ParserSubelementRead_BeforeAfter()
+    {
+        const int n = 10_000;
+        var xml = BuildLargeArrayDbXml(n);
+
+        var doc = XDocument.Parse(xml);
+        var arrEl = doc.Descendants()
+            .First(e => e.Name.LocalName == "Member"
+                        && e.Attribute("Name")?.Value == "BigArray");
+
+        // before: ReadSubelementValue-per-element linear scan (O(n²)).
+        var swOld = Stopwatch.StartNew();
+        var oldValues = new string?[n];
+        for (int i = 1; i <= n; i++)
+        {
+            string? val = null;
+            foreach (var sub in arrEl.Elements().Where(e => e.Name.LocalName == "Subelement"))
+            {
+                if (sub.Attribute("Path")?.Value != i.ToString()) continue;
+                val = sub.Elements().FirstOrDefault(e => e.Name.LocalName == "StartValue")?.Value;
+                break;
+            }
+            oldValues[i - 1] = val;
+        }
+        swOld.Stop();
+
+        // after: index the Subelements once, then O(1) per element (O(n)).
+        var swNew = Stopwatch.StartNew();
+        var index = new Dictionary<string, XElement>(StringComparer.Ordinal);
+        foreach (var sub in arrEl.Elements().Where(e => e.Name.LocalName == "Subelement"))
+        {
+            var p = sub.Attribute("Path")?.Value;
+            if (p != null && !index.ContainsKey(p)) index[p] = sub;
+        }
+        var newValues = new string?[n];
+        for (int i = 1; i <= n; i++)
+            newValues[i - 1] = index.TryGetValue(i.ToString(), out var s)
+                ? s.Elements().FirstOrDefault(e => e.Name.LocalName == "StartValue")?.Value
+                : null;
+        swNew.Stop();
+
+        // Equivalence + tie to real product code: both reproductions must
+        // agree with each other AND with SimaticMLParser.Parse's output.
+        var arr = _parser.Parse(xml).Members.First(m => m.Name == "BigArray");
+        arr.Children.Should().HaveCount(n);
+        for (int i = 0; i < n; i++)
+        {
+            newValues[i].Should().Be(oldValues[i]);
+            arr.Children[i].StartValue.Should().Be(oldValues[i]);
+        }
+
+        var oldMs = swOld.Elapsed.TotalMilliseconds;
+        var newMs = swNew.Elapsed.TotalMilliseconds;
+        _out.WriteLine(
+            $"[#154 H1] N={n}  before/per-element-scan={oldMs:F0} ms  "
+            + $"after/indexed={newMs:F1} ms  "
+            + $"speedup≈{oldMs / System.Math.Max(newMs, 0.001):F1}x");
+
+        newMs.Should().BeLessThan(oldMs);
+        (oldMs / System.Math.Max(newMs, 0.001)).Should().BeGreaterThan(5,
+            "#154 H1 turns an O(n²) per-element scan into an O(n) indexed read "
+            + "— at N=10000 the gap is enormous; a <5x result means the index "
+            + "regressed");
+    }
+
+    // ───────────────────────── H3: CollectionChanged fan-out ──────────────
+
+    /// <summary>
+    /// #154 H3. Exact, deterministic before/after — no timing. The old flat
+    /// list rebuilt with Clear() + N×Add (N+1 CollectionChanged events through
+    /// WPF's binding engine on every open/filter/keystroke/edit);
+    /// <see cref="BulkObservableCollection{T}.ReplaceAll"/> raises exactly 1.
+    /// </summary>
+    [Fact]
+    public void H3_FlatListNotifications_BeforeAfter()
+    {
+        const int n = 5000;
+        var items = Enumerable.Range(0, n).ToArray();
+
+        // before: stock ObservableCollection, the exact old Clear()+N×Add.
+        var old = new ObservableCollection<int>(Enumerable.Range(-3, 3));
+        int oldEvents = 0;
+        old.CollectionChanged += (_, __) => oldEvents++;
+        old.Clear();
+        foreach (var x in items) old.Add(x);
+
+        // after: BulkObservableCollection.ReplaceAll — one Reset.
+        var @new = new BulkObservableCollection<int>();
+        foreach (var s in Enumerable.Range(-3, 3)) @new.Add(s);
+        int newEvents = 0;
+        NotifyCollectionChangedAction lastAction = default;
+        @new.CollectionChanged += (_, e) => { newEvents++; lastAction = e.Action; };
+        @new.ReplaceAll(items);
+
+        @new.Should().Equal(items);
+        _out.WriteLine(
+            $"[#154 H3] N={n}  before/CollectionChanged={oldEvents} events  "
+            + $"after/CollectionChanged={newEvents} event  reduction={oldEvents}→{newEvents}");
+
+        oldEvents.Should().Be(n + 1, "Clear() + N×Add fires N+1 events");
+        newEvents.Should().Be(1, "ReplaceAll must collapse to a single notification");
+        lastAction.Should().Be(NotifyCollectionChangedAction.Reset);
+    }
+
+    // ───────────────────────── H4: smart-expand flat build ────────────────
+
+    /// <summary>
+    /// #154 H4. "Before": the removed recursive HasHighlightedDescendant
+    /// called per visible node under a smart-expanded parent (O(n²) on a flat
+    /// array). "After": the real <see cref="FlatTreeManager.Refresh"/>, which
+    /// fills the highlight cache in one O(n) pass. Asserts both produce the
+    /// identical visible sequence (timing equivalent work) plus a speedup.
+    /// </summary>
+    [Fact]
+    public void H4_SmartExpandFlatBuild_BeforeAfter()
+    {
+        const int n = 5000;
+        var leaves = new MemberNode[n];
+        for (int i = 0; i < n; i++)
+            leaves[i] = new MemberNode($"[{i}]", "DInt", i.ToString(),
+                $"Big[{i}]", null, Array.Empty<MemberNode>());
+        var rootModel = new MemberNode("Big", "Array[0..4999] of DInt", null,
+            "Big", null, leaves);
+        var rootVm = new MemberNodeViewModel(rootModel, null);
+        rootVm.IsExpanded = true;
+        rootVm.IsSmartExpanded = true;
+        rootVm.Children[n / 2].IsAffected = true; // one highlighted, mid-array
+
+        // ---- before: reproduce old per-node recursive scan (O(n²)) ----
+        var swOld = Stopwatch.StartNew();
+        var oldFlat = new List<MemberNodeViewModel>();
+        OldAddNodeToFlatList(rootVm, oldFlat);
+        swOld.Stop();
+
+        // ---- after: real product flat-list build (O(n) cached) ----
+        var mgr = new FlatTreeManager();
+        var swNew = Stopwatch.StartNew();
+        mgr.Refresh(new[] { rootVm });
+        swNew.Stop();
+
+        // Equivalence: identical visible sequence.
+        mgr.FlatList.Select(v => v.Name)
+            .Should().Equal(oldFlat.Select(v => v.Name));
+        oldFlat.Select(v => v.Name).Should().Equal("Big", $"[{n / 2}]");
+
+        var oldMs = swOld.Elapsed.TotalMilliseconds;
+        var newMs = swNew.Elapsed.TotalMilliseconds;
+        _out.WriteLine(
+            $"[#154 H4] N={n}  before/recursive-scan={oldMs:F1} ms  "
+            + $"after/cached={newMs:F1} ms  "
+            + $"speedup≈{oldMs / System.Math.Max(newMs, 0.001):F1}x");
+
+        newMs.Should().BeLessThan(oldMs,
+            "the cached O(n) highlight pass must beat the old O(n²) per-node recursion");
+    }
+
+    // Faithful reproduction of the REMOVED FlatTreeManager.AddNodeToFlatList +
+    // HasHighlightedDescendant (pre-#154-H4): the highlighted-descendant check
+    // recursed the whole subtree for every visible node.
+    private static void OldAddNodeToFlatList(
+        MemberNodeViewModel node, List<MemberNodeViewModel> flat,
+        bool parentIsSmartExpanded = false)
+    {
+        if (!node.IsVisible) return;
+        if (parentIsSmartExpanded && !OldIsHighlighted(node) && !OldHasHighlightedDescendant(node))
+            return;
+        flat.Add(node);
+        if (node.IsExpanded)
+            foreach (var child in node.Children)
+                OldAddNodeToFlatList(child, flat, node.IsSmartExpanded);
+    }
+
+    private static bool OldIsHighlighted(MemberNodeViewModel n)
+        => n.IsAffected || n.IsAlreadyMatching || n.IsSearchMatch
+           || n.IsPendingInlineEdit || n.HasInlineError;
+
+    private static bool OldHasHighlightedDescendant(MemberNodeViewModel node)
+    {
+        foreach (var child in node.Children)
+            if (OldIsHighlighted(child) || OldHasHighlightedDescendant(child))
+                return true;
+        return false;
+    }
+
+    private static string BuildLargeArrayDbXml(int n)
+    {
+        var sb = new StringBuilder(n * 64);
+        sb.Append("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Document>\n");
+        sb.Append("  <SW.Blocks.GlobalDB ID=\"0\">\n    <AttributeList>\n      <Interface>\n");
+        sb.Append("        <Sections xmlns=\"http://www.siemens.com/automation/Openness/SW/Interface/v5\">\n");
+        sb.Append("          <Section Name=\"Static\">\n");
+        sb.Append($"            <Member Name=\"BigArray\" Datatype=\"Array[1..{n}] of DInt\" Accessibility=\"Public\">\n");
+        for (int i = 1; i <= n; i++)
+            sb.Append($"              <Subelement Path=\"{i}\"><StartValue>{i}</StartValue></Subelement>\n");
+        sb.Append("            </Member>\n          </Section>\n        </Sections>\n");
+        sb.Append("      </Interface>\n      <Name>BigArrayDb</Name>\n      <Number>1</Number>\n");
+        sb.Append("    </AttributeList>\n  </SW.Blocks.GlobalDB>\n</Document>\n");
+        return sb.ToString();
+    }
+}

--- a/src/BlockParam.Tests/SimaticMLParserTests.cs
+++ b/src/BlockParam.Tests/SimaticMLParserTests.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Text;
 using FluentAssertions;
 using BlockParam.SimaticML;
 using Xunit;
@@ -492,5 +494,53 @@ public class SimaticMLParserTests
         // Belt: tree size should be small (4 visible members), not the 10,000+
         // we'd see if the array got expanded.
         db.AllMembers().Should().HaveCount(4);
+    }
+
+    /// <summary>
+    /// #154 H1 regression gate. A 10 000-element <c>Array Of DInt</c> where
+    /// every element carries an explicit <c>&lt;Subelement&gt;</c> start value
+    /// is the issue's repro. Pre-fix, <c>ExpandArrayMember</c> re-scanned all
+    /// 10 000 <c>&lt;Subelement&gt;</c> children once per element → ~100M
+    /// comparisons (O(n²)) before the tree was even built. With the one-shot
+    /// Path index it is O(n + k); this completes far under the generous,
+    /// CI-jitter-tolerant ceiling while a revert blows past it. Also asserts
+    /// every element's value parsed correctly (the index must be faithful).
+    /// </summary>
+    [Fact]
+    public void Parse_TenThousandElementArray_IsLinearAndCorrect()
+    {
+        const int n = 10_000;
+        var xml = BuildLargeArrayDbXml(n);
+
+        var sw = Stopwatch.StartNew();
+        var db = _parser.Parse(xml);
+        sw.Stop();
+
+        var arr = db.Members.First(m => m.Name == "BigArray");
+        arr.Children.Should().HaveCount(n);
+        arr.Children[0].StartValue.Should().Be("1");
+        arr.Children[n / 2].StartValue.Should().Be((n / 2 + 1).ToString());
+        arr.Children[n - 1].StartValue.Should().Be(n.ToString());
+
+        sw.Elapsed.TotalSeconds.Should().BeLessThan(8,
+            "#154 H1: O(n) indexed Subelement reads — a regression to the "
+            + "per-element linear scan (O(n²)) would take far longer than this "
+            + "generous ceiling");
+    }
+
+    private static string BuildLargeArrayDbXml(int n)
+    {
+        var sb = new StringBuilder(n * 64);
+        sb.Append("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Document>\n");
+        sb.Append("  <SW.Blocks.GlobalDB ID=\"0\">\n    <AttributeList>\n      <Interface>\n");
+        sb.Append("        <Sections xmlns=\"http://www.siemens.com/automation/Openness/SW/Interface/v5\">\n");
+        sb.Append("          <Section Name=\"Static\">\n");
+        sb.Append($"            <Member Name=\"BigArray\" Datatype=\"Array[1..{n}] of DInt\" Accessibility=\"Public\">\n");
+        for (int i = 1; i <= n; i++)
+            sb.Append($"              <Subelement Path=\"{i}\"><StartValue>{i}</StartValue></Subelement>\n");
+        sb.Append("            </Member>\n          </Section>\n        </Sections>\n");
+        sb.Append("      </Interface>\n      <Name>BigArrayDb</Name>\n      <Number>1</Number>\n");
+        sb.Append("    </AttributeList>\n  </SW.Blocks.GlobalDB>\n</Document>\n");
+        return sb.ToString();
     }
 }

--- a/src/BlockParam/Services/HierarchyAnalyzer.cs
+++ b/src/BlockParam/Services/HierarchyAnalyzer.cs
@@ -140,7 +140,7 @@ public class HierarchyAnalyzer
         // on a square 2D array (#90). Keying on the path set as well means
         // scopes only collapse when they actually point at the same nodes.
         // Stable: ties on the same key go to the first occurrence.
-        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var seen = new HashSet<long>();
         var result = new List<ScopeLevel>(scopes.Count);
         foreach (var s in scopes.OrderBy(x => x.MatchCount))
         {
@@ -149,12 +149,46 @@ public class HierarchyAnalyzer
         return result;
     }
 
-    private static string ScopeFingerprint(ScopeLevel s)
+    /// <summary>
+    /// Returns a 64-bit allocation-free fingerprint for a scope.
+    ///
+    /// Preserves the #90 correctness invariant: two scopes with equal MatchCount
+    /// but different path sets (e.g. Matrix[1,*] vs Matrix[*,2] on a square
+    /// array) must NOT be treated as equal, so the fingerprint encodes BOTH
+    /// MatchCount AND the exact set of Path strings.
+    ///
+    /// Implementation (#154 H5 -- allocation-free): each path is hashed with
+    /// deterministic 64-bit FNV-1a (stable across processes, unlike
+    /// string.GetHashCode). Per-path hashes are combined with unchecked addition
+    /// (order-independent, so no Sort/OrderBy/Join is needed), then mixed with
+    /// MatchCount via a prime multiply to keep the two dimensions orthogonal.
+    /// No LINQ, no intermediate strings or arrays -- a plain foreach over the
+    /// IReadOnlyList&lt;MemberNode&gt;.
+    /// </summary>
+    private static long ScopeFingerprint(ScopeLevel s)
     {
-        var paths = s.MatchingMembers
-            .Select(m => m.Path)
-            .OrderBy(p => p, StringComparer.Ordinal);
-        return $"{s.MatchCount}|{string.Join("", paths)}";
+        // 64-bit FNV-1a constants.
+        const ulong FnvOffset = 14695981039346656037UL;
+        const ulong FnvPrime = 1099511628211UL;
+
+        // Unchecked-sum of per-path FNV-1a hashes -- order-independent aggregate.
+        ulong pathSetHash = 0;
+        foreach (var m in s.MatchingMembers)
+        {
+            ulong h = FnvOffset;
+            foreach (char c in m.Path)
+            {
+                h ^= (uint)c;
+                h = unchecked(h * FnvPrime);
+            }
+            pathSetHash += h; // commutative: no sort needed (#154 H5)
+        }
+
+        // Mix in MatchCount so a 0-member scope never falsely equals another.
+        unchecked
+        {
+            return (long)(pathSetHash * 397UL + (ulong)s.MatchCount);
+        }
     }
 
     private List<ScopeLevel> AnalyzeWithinDb(DataBlockInfo db, MemberNode selectedMember)

--- a/src/BlockParam/SimaticML/SimaticMLParser.cs
+++ b/src/BlockParam/SimaticML/SimaticMLParser.cs
@@ -346,6 +346,11 @@ public class SimaticMLParser
             elementPathWithinUdt = pathWithinUdt;
         }
 
+        // #154 H1: index the <Subelement> children ONCE for the whole array
+        // instead of letting each element re-scan them linearly (O(n²) when
+        // every element has an explicit start value — the 10k-element freeze).
+        var subByPath = BuildSubelementIndex(memberElement);
+
         foreach (var indexTuple in EnumerateIndexTuples(resolvedRanges))
         {
             var indexLabel = $"[{string.Join(",", indexTuple)}]";
@@ -357,7 +362,7 @@ public class SimaticMLParser
 
             if (elementIsPrimitive)
             {
-                var sv = ReadSubelementValue(memberElement, ns, string.Join(",", childIndexStack));
+                var sv = ReadSubelementValue(subByPath, string.Join(",", childIndexStack));
                 var leaf = new MemberNode(
                     name: indexLabel,
                     datatype: elementType,
@@ -528,6 +533,44 @@ public class SimaticMLParser
             return LocalElement(sub, Comment);
         }
         return null;
+    }
+
+    /// <summary>
+    /// #154 H1: builds a one-shot <c>Path attribute → &lt;Subelement&gt;</c>
+    /// index for an array Member. <see cref="ExpandArrayMember"/> used to call
+    /// <see cref="ReadSubelementValue(XElement,XNamespace,string)"/> once per
+    /// element, and each call re-scanned every <c>&lt;Subelement&gt;</c>
+    /// linearly — O(n·k), i.e. O(n²) when all n elements carry an explicit
+    /// start value (the 10 000-element repro). Indexing the children once and
+    /// doing O(1) lookups per element collapses that to O(n + k). "First wins"
+    /// reproduces the original <c>foreach … return</c> first-match semantics.
+    /// </summary>
+    private static Dictionary<string, XElement> BuildSubelementIndex(XElement memberElement)
+    {
+        var map = new Dictionary<string, XElement>(StringComparer.Ordinal);
+        foreach (var sub in LocalElements(memberElement, Subelement))
+        {
+            var p = sub.Attribute(Path)?.Value;
+            if (p != null && !map.ContainsKey(p))
+                map[p] = sub;
+        }
+        return map;
+    }
+
+    private static string? ReadSubelementValue(
+        IReadOnlyDictionary<string, XElement> subByPath, string subelementPath)
+    {
+        if (!subByPath.TryGetValue(subelementPath, out var sub)) return null;
+        var sv = LocalElement(sub, StartValue);
+        return sv?.Attribute(ConstantName)?.Value?.Trim('"') ?? sv?.Value;
+    }
+
+    private static XElement? ReadSubelementComment(
+        IReadOnlyDictionary<string, XElement> subByPath, string subelementPath)
+    {
+        return subByPath.TryGetValue(subelementPath, out var sub)
+            ? LocalElement(sub, Comment)
+            : null;
     }
 
     private static IEnumerable<int[]> EnumerateIndexTuples(List<(int low, int high)> ranges)

--- a/src/BlockParam/UI/BulkObservableCollection.cs
+++ b/src/BlockParam/UI/BulkObservableCollection.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+namespace BlockParam.UI;
+
+/// <summary>
+/// <see cref="ObservableCollection{T}"/> with a bulk <see cref="ReplaceAll"/>
+/// that raises a single <see cref="NotifyCollectionChangedAction.Reset"/>
+/// instead of one <c>CollectionChanged</c> per item.
+///
+/// <para>
+/// #154 H3: the flat member list was rebuilt with <c>Clear()</c> + N×
+/// <c>Add()</c>, firing N+1 <c>CollectionChanged</c> events through WPF's
+/// binding engine on every open, every filter change, every search keystroke
+/// and every pending-edit mutation. For a 10 000-element array that is
+/// 10 001 events per rebuild. <c>ReplaceAll</c> mutates the backing
+/// <see cref="Collection{T}.Items"/> list directly (no per-item events) then
+/// raises exactly one Reset — the same notification <c>Clear()</c> already
+/// raised, so the bound instance is unchanged and no binding/selection
+/// re-plumbing is required.
+/// </para>
+/// </summary>
+public sealed class BulkObservableCollection<T> : ObservableCollection<T>
+{
+    public void ReplaceAll(IReadOnlyList<T> items)
+    {
+        Items.Clear();
+        for (int i = 0; i < items.Count; i++)
+            Items.Add(items[i]);
+
+        OnPropertyChanged(new PropertyChangedEventArgs(nameof(Count)));
+        OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
+        OnCollectionChanged(
+            new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+    }
+}

--- a/src/BlockParam/UI/FlatTreeManager.cs
+++ b/src/BlockParam/UI/FlatTreeManager.cs
@@ -10,7 +10,7 @@ namespace BlockParam.UI;
 /// </summary>
 public class FlatTreeManager
 {
-    private readonly ObservableCollection<MemberNodeViewModel> _flatList = new();
+    private readonly BulkObservableCollection<MemberNodeViewModel> _flatList = new();
 
     public ObservableCollection<MemberNodeViewModel> FlatList => _flatList;
 
@@ -20,11 +20,45 @@ public class FlatTreeManager
     /// </summary>
     public void BuildFlatList(IEnumerable<MemberNodeViewModel> rootMembers)
     {
-        _flatList.Clear();
-        foreach (var root in rootMembers)
+        var roots = rootMembers as IReadOnlyList<MemberNodeViewModel>
+                    ?? rootMembers.ToList();
+
+        // #154 H4: refresh every node's HasHighlightedDescendantCache in one
+        // O(n) post-order pass instead of letting AddNodeToFlatList recurse
+        // the whole subtree per visible node (O(n²) on a flat array). Done
+        // here, not in ApplyFilter, so the cache is correct on EVERY rebuild
+        // trigger — search, filter, expand, AND pending-edit/inline-error
+        // mutations that change IsHighlighted without re-running ApplyFilter.
+        foreach (var root in roots)
+            RefreshHighlightCache(root);
+
+        // #154 H3: assemble into a plain List then push it in one shot so the
+        // bound collection raises a single Reset instead of Clear()+N×Add
+        // (N+1 CollectionChanged events through WPF on every rebuild).
+        var flat = new List<MemberNodeViewModel>();
+        foreach (var root in roots)
+            AddNodeToFlatList(root, flat);
+        _flatList.ReplaceAll(flat);
+    }
+
+    /// <summary>
+    /// Post-order pass: sets
+    /// <see cref="MemberNodeViewModel.HasHighlightedDescendantCache"/> (true
+    /// iff any descendant is highlighted) and returns whether this node OR
+    /// any descendant is highlighted, so a parent folds its subtree in O(1).
+    /// One walk over the forest — O(n) total.
+    /// </summary>
+    private static bool RefreshHighlightCache(MemberNodeViewModel node)
+    {
+        bool descendantHighlighted = false;
+        foreach (var child in node.Children)
         {
-            AddNodeToFlatList(root);
+            // No short-circuit: every node's cache must be set.
+            if (RefreshHighlightCache(child))
+                descendantHighlighted = true;
         }
+        node.HasHighlightedDescendantCache = descendantHighlighted;
+        return IsHighlighted(node) || descendantHighlighted;
     }
 
     /// <summary>
@@ -35,16 +69,21 @@ public class FlatTreeManager
         BuildFlatList(rootMembers);
     }
 
-    private void AddNodeToFlatList(MemberNodeViewModel node, bool parentIsSmartExpanded = false)
+    private void AddNodeToFlatList(
+        MemberNodeViewModel node,
+        List<MemberNodeViewModel> flat,
+        bool parentIsSmartExpanded = false)
     {
         if (!node.IsVisible) return;
 
         // Inside a smart-expanded parent, only show highlighted nodes
-        // (affected or already-matching) or nodes that have such descendants
-        if (parentIsSmartExpanded && !IsHighlighted(node) && !HasHighlightedDescendant(node))
+        // (affected or already-matching) or nodes that have such descendants.
+        // #154 H4: HasHighlightedDescendantCache was filled by the single
+        // RefreshHighlightCache pass — O(1) here instead of a fresh recursion.
+        if (parentIsSmartExpanded && !IsHighlighted(node) && !node.HasHighlightedDescendantCache)
             return;
 
-        _flatList.Add(node);
+        flat.Add(node);
 
         if (node.IsExpanded)
         {
@@ -53,23 +92,13 @@ public class FlatTreeManager
             // even if its parent was smart-expanded.
             foreach (var child in node.Children)
             {
-                AddNodeToFlatList(child, node.IsSmartExpanded);
+                AddNodeToFlatList(child, flat, node.IsSmartExpanded);
             }
         }
     }
 
     private static bool IsHighlighted(MemberNodeViewModel node)
         => node.IsAffected || node.IsAlreadyMatching || node.IsSearchMatch || node.IsPendingInlineEdit || node.HasInlineError;
-
-    private static bool HasHighlightedDescendant(MemberNodeViewModel node)
-    {
-        foreach (var child in node.Children)
-        {
-            if (IsHighlighted(child) || HasHighlightedDescendant(child))
-                return true;
-        }
-        return false;
-    }
 
     // Keep for CycleExpandState (determines if smart-expand toggle is offered)
     private static bool HasAffectedDescendant(MemberNodeViewModel node)

--- a/src/BlockParam/UI/MemberNodeViewModel.cs
+++ b/src/BlockParam/UI/MemberNodeViewModel.cs
@@ -181,6 +181,16 @@ public class MemberNodeViewModel : ViewModelBase
         set => SetProperty(ref _isVisible, value);
     }
 
+    /// <summary>
+    /// #154 H4: cached "does any descendant satisfy the smart-expand
+    /// highlight predicate?" flag. Recomputed in one O(n) post-order pass at
+    /// the top of every flat-list rebuild
+    /// (<see cref="FlatTreeManager"/>), replacing a per-visible-node
+    /// recursive scan that was O(n²) on a large flat array. Pure flat-list
+    /// scratch state — not data-bound, so no change notification.
+    /// </summary>
+    internal bool HasHighlightedDescendantCache;
+
     /// <summary>True if this node was auto-expanded by scope highlighting (not by user).</summary>
     public bool IsSmartExpanded
     {


### PR DESCRIPTION
## Summary

Fixes #154 — opening a DB with `Array[1..10000] Of DInt` froze the dialog. Four of the five hypotheses are fixed; **H2 (lazy VM construction) is deferred** per the issue's own priority note ("requires a larger structural change … consider as a follow-on once H1–H4 are landed").

| # | Fix |
|---|---|
| **H1** | `SimaticMLParser.ExpandArrayMember` builds a one-shot `Path → <Subelement>` index instead of `ReadSubelementValue` re-scanning every `<Subelement>` per element. O(n·k) (O(n²) when all elements have explicit values) → O(n+k). Direct read-side twin of the merged #159 H2 `WriteContext` fix. |
| **H3** | New `BulkObservableCollection<T>.ReplaceAll` mutates the backing list and raises **one** `Reset` instead of `Clear()` + N×`Add` (N+1 `CollectionChanged` events per open/filter/keystroke/edit). The bound instance is unchanged, so **no binding/selection re-plumbing** — `FlatTreeManager` just swaps to it. |
| **H4** | `MemberNodeViewModel.HasHighlightedDescendantCache` filled by one O(n) post-order pass at the top of every flat-list rebuild; `AddNodeToFlatList` reads the cached flag instead of recursing the subtree per visible node (O(n²) on a flat array). Done at rebuild time (not in `ApplyFilter`) so it stays correct on every trigger incl. pending-edit/inline-error changes. |
| **H5** | `HierarchyAnalyzer.ScopeFingerprint` returns an allocation-free 64-bit FNV-1a (order-independent path-set sum mixed with `MatchCount`) instead of a ~200 KB `string.Join` per member-click. Preserves the #90 invariant (same-count-different-paths must not collapse). |

H1 + H4 are the highest-impact (the O(n²) terms). H3 is the per-keystroke fan-out. H5 removes the per-click large-string allocation.

## Test plan

- [ ] V20 Build & Test green, incl. new regression gates:
  - `Parse_TenThousandElementArray_IsLinearAndCorrect` (H1)
  - `BulkObservableCollectionTests` — single Reset, correct contents (H3)
  - `FlatList_LargeArray_SmartExpand_IsLinearAndFiltersCorrectly` (H4)
  - `Analyze_SquareMatrix_SameCountDifferentPaths_BothScopesKept` + `…ScopeAppearsExactlyOnce` (H5, #90 invariant)
  - existing `FlatTreeManagerTests` smart-expand suite stays green (H4 correctness net)
- [ ] V21 Build, PEVerify unaffected

## Notes
- H2 intentionally out of scope (issue-directed). 64-bit fingerprint comparison is in-process only (never persisted) so the FNV change is safe.
- Mirror-`main` lag caveat as in #160/#161: the real change is the 9 files in this branch's single commit.

Closes #154

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArCRgH7WFSA3yAauh2MqSQ)_