### PR TITLE
perf(#155): TIA-session-scoped caches for DB enumeration, tag-table export & UDT validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,77 @@ The script:
 
 After deployment, restart TIA Portal to load the new version.
 
+### Dev iteration: `package-to-temp.ps1`
+
+`bump-version.sh` deploys to `C:\Program Files\...\Portal V20\AddIns`
+(needs admin) and also builds V21. For fast local iteration use the
+PowerShell script instead — **V20 Release only, packaged straight into
+`$env:TEMP` root, no admin, no V21**:
+
+```powershell
+.\package-to-temp.ps1                       # build V20, package to $env:TEMP
+.\package-to-temp.ps1 -Suffix none          # plain BlockParam.addin
+.\package-to-temp.ps1 -Version 0.155.0 -Suffix issue155
+```
+
+- Output defaults to `BlockParam-<suffix>.addin`, where `<suffix>` is
+  auto-derived from the current git branch and shortened to the issue
+  number (`claude/implement-issue-155-AJiG6` → `BlockParam-155.addin`,
+  manifest `<Name>BlockParam (155)</Name>`, `<Id>BlockParam.155</Id>`).
+  The tracked `addin-publisher-v20.xml` is **not** modified — the Name/Id
+  rewrite is on a staged copy, so branches stay clean.
+- `-Version` is optional; when given it bumps `BlockParam.csproj` +
+  `addin-publisher-v20.xml` (BOM-free) like `bump-version.sh`.
+- **Convention: bump the patch on every repackage** (`0.155.0` → `0.155.1`
+  → `0.155.2` …), passing `-Version` each time. Rationale: the runtime log
+  filename is keyed on the **assembly version**
+  (`bulkchange-v<assembly-version>-<date>.log`, see "Runtime log" below),
+  so two builds at the same version append to the *same* log file and you
+  can't tell the old build's lines from the new one's after a
+  redeploy+restart — and same-version assemblies also hit the identity
+  collision noted in the caveat below. A distinct version per package gives
+  each build its own log file and makes "did my new build actually load?"
+  unambiguous (the log filename changes). The script does **not**
+  auto-increment today — until it does, pass `-Version` explicitly each
+  iteration.
+- Deploy with one robocopy. Run the shell **elevated** (`Program Files`
+  is ACL-protected); robocopy returns exit **1 on success**, **≥8 on
+  real failure** — gate on `$LASTEXITCODE -ge 8`, don't treat non-zero
+  as failure:
+
+  ```powershell
+  robocopy "$env:TEMP" "C:\Program Files\Siemens\Automation\Portal V20\AddIns" BlockParam.addin BlockParam-*.addin /R:3 /W:2 /NP /NDL /NJH /NJS
+  ```
+
+  (`BlockParam.addin` + `BlockParam-*.addin` matches exactly this
+  script's output and not unrelated `BlockParam*.addin` artifacts.)
+- **Caveat — two branch builds loaded at once:** a distinct file name +
+  Product Id stop TIA deduping the entries, but both still ship assembly
+  identity `BlockParam, <Version>`; the CLR loads only the first and
+  silently ignores the second (you'd test the wrong code). To run two
+  simultaneously give each a distinct `-Version`. Install-one-at-a-time
+  iteration is unaffected.
+
+## Runtime log (deployed Add-In)
+
+When the Add-In runs **inside TIA Portal** it writes a per-version,
+per-day log to:
+
+```
+%APPDATA%\BlockParam\logs\bulkchange-v<assembly-version>-<yyyy-MM-dd>.log
+```
+
+e.g. `bulkchange-v0.155.0.0-2026-05-19.log`. This is the **authoritative
+place to verify a deployed build** — CI and DevLauncher run full-trust
+and do not exercise the TIA-only paths. Open-path perf is verified here:
+the open emits timestamped lines you can diff for cold-vs-warm opens,
+including `DB cache hit` (#140), `UDT validation: skipped
+(session-cached)`, `tag-table export: skipped (session-cached)`, and
+`DB enumeration cache hit (skipping project walk)` (#155). The logger
+is a partial-trust-safe Serilog replacement
+(`src/BlockParam/Diagnostics/Log.cs`); the directory comes from
+`AppDirectories.LogsDir` (`%APPDATA%\BlockParam\logs`), not a literal.
+
 ## CI (GitHub Actions)
 
 One workflow: `.github/workflows/ci.yml`. Three jobs, all on `windows-latest`:

--- a/package-to-temp.ps1
+++ b/package-to-temp.ps1
@@ -1,0 +1,141 @@
+<#
+.SYNOPSIS
+  Build BlockParam (TIA V20, Release) and package the .addin into $env:TEMP,
+  optionally suffixed per branch so multiple builds coexist.
+
+.DESCRIPTION
+  Dev-iteration counterpart to bump-version.sh. Unlike that script it does
+  NOT deploy to C:\Program Files\...\Portal V20\AddIns (admin-only) and does
+  NOT touch V21 — it drops a freshly packaged .addin straight into $env:TEMP
+  (root, not a subfolder) so a single deploy robocopy globbing
+  BlockParam*.addin from $env:TEMP picks it up without an elevated prompt.
+
+  With a suffix (default: the current git branch), the output file becomes
+  BlockParam-<suffix>.addin and the manifest's <Product><Name>/<Id> are
+  rewritten on a STAGED copy only — the tracked addin-publisher-v20.xml is
+  never modified, so branches stay clean. This lets you keep several branch
+  builds side by side in TEMP and install/swap whichever you want.
+
+  CAVEAT — running two branch builds in TIA at the SAME time: a distinct file
+  name + Product Id stops TIA from deduping the .addin entries, but both
+  packages still ship an assembly with identity "BlockParam, <Version>".
+  If two builds share that identity the CLR loads only the first and silently
+  ignores the second, so you'd test the wrong code. To genuinely load two at
+  once, give each a distinct -Version (cheapest) or rename the assembly
+  itself (cascades into csproj AssemblyName + manifest FeatureAssembly + the
+  de\ satellite path — not done here). For install-one-at-a-time iteration
+  the suffix alone is enough.
+
+.PARAMETER Version
+  Optional. If given (e.g. 0.155.0), bumps <Version> in
+  src\BlockParam\BlockParam.csproj and src\BlockParam\addin-publisher-v20.xml
+  before building. If omitted, whatever version is already in those files is
+  used as-is.
+
+.PARAMETER Suffix
+  Optional. Distinguishes the packaged file and the TIA add-in entry.
+  - omitted        -> derived from the current git branch, auto-shortened to
+                      the issue number when present
+                      (claude/implement-issue-155-AJiG6 -> 155)
+  - "none"/"plain" -> no suffix; plain BlockParam.addin (legacy behavior)
+  - any string     -> used verbatim, sanitized to [A-Za-z0-9._-]
+
+.EXAMPLE
+  .\package-to-temp.ps1                       # BlockParam-<branch>.addin
+  .\package-to-temp.ps1 -Suffix none          # plain BlockParam.addin
+  .\package-to-temp.ps1 -Version 0.155.0 -Suffix issue155
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [ValidatePattern('^\d+\.\d+\.\d+$')]
+    [string]$Version,
+
+    [Parameter(Position = 1)]
+    [string]$Suffix
+)
+
+$ErrorActionPreference = 'Stop'
+
+$root         = $PSScriptRoot
+$csproj       = Join-Path $root 'src\BlockParam\BlockParam.csproj'
+$manifestSrc  = Join-Path $root 'src\BlockParam\addin-publisher-v20.xml'
+$outDir       = Join-Path $root 'src\BlockParam\bin\Release\net48'
+$publisherExe = 'C:\Program Files\Siemens\Automation\Portal V20\PublicAPI\V20.AddIn\Siemens.Engineering.AddIn.Publisher.exe'
+$targetDir    = $env:TEMP   # root, so the deploy robocopy globs it directly
+
+if (-not (Test-Path $publisherExe)) {
+    throw "Siemens Publisher not found: $publisherExe (is TIA Portal V20 installed?)"
+}
+
+# --- Resolve suffix --------------------------------------------------------
+if (-not $PSBoundParameters.ContainsKey('Suffix')) {
+    $branch = (& git -C $root rev-parse --abbrev-ref HEAD 2>$null)
+    if ($LASTEXITCODE -ne 0 -or -not $branch) {
+        # Detached HEAD / not a repo: no branch to derive from.
+        $Suffix = ''
+    } elseif ($branch -match '(?i)issue[-_]?(\d+)') {
+        # claude/implement-issue-155-AJiG6 -> 155
+        $Suffix = $Matches[1]
+    } else {
+        # No explicit issue token: take the last >=2-digit run so version-ish
+        # noise (v21) loses to the real number (claude/implement-154-x -> 154,
+        # claude/v21-build-130 -> 130). Single digits from random branch
+        # suffixes (AJiG6, 0O8VT) are ignored. No number at all -> full branch.
+        $nums = [regex]::Matches($branch, '\d{2,}')
+        if ($nums.Count -gt 0) { $Suffix = $nums[$nums.Count - 1].Value }
+        else { $Suffix = $branch }
+    }
+}
+if ($Suffix -in @('none', 'plain')) { $Suffix = '' }
+# Sanitize to a filesystem/identifier-safe token; collapse runs of separators.
+$Suffix = ([regex]::Replace($Suffix, '[^A-Za-z0-9._-]+', '-')).Trim('-.')
+
+if ($Suffix) {
+    $displayName = "BlockParam ($Suffix)"
+    $productId   = "BlockParam.$Suffix"
+    $fileName    = "BlockParam-$Suffix.addin"
+} else {
+    $displayName = 'BlockParam'
+    $productId   = 'BlockParam'
+    $fileName    = 'BlockParam.addin'
+}
+$target = Join-Path $targetDir $fileName
+
+# --- Optional version bump (BOM-free UTF-8 so we don't dirty the file) ------
+if ($Version) {
+    Write-Host "=== Bumping version to $Version ===" -ForegroundColor Cyan
+    $enc = New-Object System.Text.UTF8Encoding($false)
+    foreach ($f in @($csproj, $manifestSrc)) {
+        $text = [System.IO.File]::ReadAllText($f)
+        $text = [regex]::Replace($text, '<Version>[^<]*</Version>', "<Version>$Version</Version>")
+        [System.IO.File]::WriteAllText($f, $text, $enc)
+        Write-Host "  Updated $f"
+    }
+}
+
+# --- Build -----------------------------------------------------------------
+Write-Host '=== [V20] Building Release ===' -ForegroundColor Cyan
+& dotnet build (Join-Path $root 'src\BlockParam') -c Release -p:TiaVersion=20 --nologo -v quiet
+if ($LASTEXITCODE -ne 0) { throw "dotnet build failed (exit $LASTEXITCODE)" }
+Write-Host "  Build OK -> $outDir"
+
+# --- Package ---------------------------------------------------------------
+Write-Host "=== [V20] Packaging '$displayName' -> $fileName ===" -ForegroundColor Cyan
+
+# Publisher reads the manifest relative to the assembly dir, so stage it there
+# (same as bump-version.sh does). The Name/Id rewrite happens ONLY on this
+# staged copy — the tracked manifest is never touched, keeping branches clean.
+$manifestStaged = Join-Path $outDir (Split-Path $manifestSrc -Leaf)
+$mtext = [System.IO.File]::ReadAllText($manifestSrc)
+$mtext = $mtext.Replace('<Name>BlockParam</Name>', "<Name>$displayName</Name>")
+$mtext = $mtext.Replace('<Id>BlockParam</Id>', "<Id>$productId</Id>")
+[System.IO.File]::WriteAllText($manifestStaged, $mtext, (New-Object System.Text.UTF8Encoding($false)))
+
+& $publisherExe -f $manifestStaged -o $target -c
+if ($LASTEXITCODE -ne 0) { throw "Publisher failed (exit $LASTEXITCODE)" }
+
+$size = [math]::Round((Get-Item $target).Length / 1KB)
+Write-Host ''
+Write-Host "=== Packaged -> $target ($size KB) ===" -ForegroundColor Green
+Write-Host 'Copy it into a TIA AddIns folder to load it, then restart TIA Portal.'

--- a/src/BlockParam.Tests/ProjectDbEnumerationCacheTests.cs
+++ b/src/BlockParam.Tests/ProjectDbEnumerationCacheTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using BlockParam.Models;
+using BlockParam.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// #155 item 1 — the project DB enumeration must run at most once per scope per
+/// TIA session, with the explicit-refresh Invalidate as the staleness valve.
+/// </summary>
+public class ProjectDbEnumerationCacheTests
+{
+    private static IReadOnlyList<DataBlockSummary> Db(params string[] names)
+    {
+        var list = new List<DataBlockSummary>();
+        foreach (var n in names) list.Add(new DataBlockSummary(n, ""));
+        return list;
+    }
+
+    [Fact]
+    public void GetOrAdd_FirstCall_RunsEnumeratorAndReturnsResult()
+    {
+        var cache = new ProjectDbEnumerationCache();
+        int calls = 0;
+
+        var result = cache.GetOrAdd("scopeA", () => { calls++; return Db("DB1", "DB2"); });
+
+        calls.Should().Be(1);
+        result.Should().HaveCount(2);
+        cache.HasEntry("scopeA").Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetOrAdd_SecondCallSameScope_DoesNotReRunEnumerator()
+    {
+        var cache = new ProjectDbEnumerationCache();
+        int calls = 0;
+        Func<IReadOnlyList<DataBlockSummary>> enumerate = () => { calls++; return Db("DB1"); };
+
+        var first = cache.GetOrAdd("scopeA", enumerate);
+        var second = cache.GetOrAdd("scopeA", enumerate);
+
+        calls.Should().Be(1, "the expensive project walk is session-cached");
+        second.Should().BeSameAs(first, "the cached list instance is returned");
+    }
+
+    [Fact]
+    public void GetOrAdd_DifferentScopes_EnumerateIndependently()
+    {
+        var cache = new ProjectDbEnumerationCache();
+
+        var a = cache.GetOrAdd("scopeA", () => Db("A"));
+        var b = cache.GetOrAdd("scopeB", () => Db("B1", "B2"));
+
+        a.Should().HaveCount(1);
+        b.Should().HaveCount(2);
+        cache.HasEntry("scopeA").Should().BeTrue();
+        cache.HasEntry("scopeB").Should().BeTrue();
+    }
+
+    [Fact]
+    public void Invalidate_ForcesReEnumerationOnNextGet()
+    {
+        var cache = new ProjectDbEnumerationCache();
+        int calls = 0;
+        Func<IReadOnlyList<DataBlockSummary>> enumerate = () => { calls++; return Db($"v{calls}"); };
+
+        cache.GetOrAdd("scopeA", enumerate);
+        cache.Invalidate("scopeA");
+        var after = cache.GetOrAdd("scopeA", enumerate);
+
+        calls.Should().Be(2, "explicit refresh busts the session cache");
+        after[0].Name.Should().Be("v2");
+    }
+
+    [Fact]
+    public void Invalidate_UnknownScope_DoesNotThrow()
+    {
+        var cache = new ProjectDbEnumerationCache();
+
+        var act = () => cache.Invalidate("ghost");
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Clear_DropsEveryScope()
+    {
+        var cache = new ProjectDbEnumerationCache();
+        cache.GetOrAdd("scopeA", () => Db("A"));
+        cache.GetOrAdd("scopeB", () => Db("B"));
+
+        cache.Clear();
+
+        cache.HasEntry("scopeA").Should().BeFalse();
+        cache.HasEntry("scopeB").Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetOrAdd_NullEnumerator_Throws()
+    {
+        var cache = new ProjectDbEnumerationCache();
+
+        var act = () => cache.GetOrAdd("scopeA", null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    // ── Bounded LRU eviction (project-switch guard) ──────────────────────────
+
+    [Fact]
+    public void GetOrAdd_PastEntryCap_EvictsLeastRecentlyUsedScope()
+    {
+        var cache = new ProjectDbEnumerationCache(maxEntries: 2);
+
+        cache.GetOrAdd("s0", () => Db("0"));
+        cache.GetOrAdd("s1", () => Db("1"));
+        cache.GetOrAdd("s2", () => Db("2")); // count 3 > 2 → evict s0 (LRU)
+
+        cache.HasEntry("s0").Should().BeFalse("s0 was least-recently-used");
+        cache.HasEntry("s1").Should().BeTrue();
+        cache.HasEntry("s2").Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetOrAdd_Hit_RefreshesRecency_SoScopeSurvivesEviction()
+    {
+        var cache = new ProjectDbEnumerationCache(maxEntries: 2);
+        cache.GetOrAdd("s0", () => Db("0"));
+        cache.GetOrAdd("s1", () => Db("1"));
+
+        // Touch s0 so s1 becomes the eviction victim.
+        cache.GetOrAdd("s0", () => Db("ignored"));
+        cache.GetOrAdd("s2", () => Db("2"));
+
+        cache.HasEntry("s0").Should().BeTrue("a hit marks it most-recently-used");
+        cache.HasEntry("s1").Should().BeFalse("s1 became least-recently-used");
+        cache.HasEntry("s2").Should().BeTrue();
+    }
+}

--- a/src/BlockParam.Tests/SessionScopeGateTests.cs
+++ b/src/BlockParam.Tests/SessionScopeGateTests.cs
@@ -1,0 +1,114 @@
+using System;
+using BlockParam.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// #155 items 2 &amp; 3 — the gated walk (tag-table re-export / UDT freshness
+/// scan) must run at most once per scope per TIA session, must NOT cache a
+/// failed run as "done", and must re-run after the explicit-refresh Invalidate.
+/// </summary>
+public class SessionScopeGateTests
+{
+    [Fact]
+    public void RunOnce_FirstCall_RunsActionAndReportsRan()
+    {
+        var gate = new SessionScopeGate("test");
+        int runs = 0;
+
+        var ran = gate.RunOnce("scopeA", () => runs++);
+
+        ran.Should().BeTrue();
+        runs.Should().Be(1);
+        gate.HasRun("scopeA").Should().BeTrue();
+    }
+
+    [Fact]
+    public void RunOnce_SecondCallSameScope_SkipsActionAndReportsSkipped()
+    {
+        var gate = new SessionScopeGate("test");
+        int runs = 0;
+
+        gate.RunOnce("scopeA", () => runs++);
+        var ranAgain = gate.RunOnce("scopeA", () => runs++);
+
+        ranAgain.Should().BeFalse("already satisfied this session");
+        runs.Should().Be(1, "the expensive walk is not repeated");
+    }
+
+    [Fact]
+    public void RunOnce_DifferentScopes_RunIndependently()
+    {
+        var gate = new SessionScopeGate("test");
+        int runs = 0;
+
+        gate.RunOnce("scopeA", () => runs++).Should().BeTrue();
+        gate.RunOnce("scopeB", () => runs++).Should().BeTrue();
+
+        runs.Should().Be(2);
+    }
+
+    [Fact]
+    public void RunOnce_ActionThrows_ScopeStaysUnsatisfied_SoNextOpenRetries()
+    {
+        var gate = new SessionScopeGate("test");
+
+        var firstAttempt = () => gate.RunOnce("scopeA", () => throw new InvalidOperationException("boom"));
+        firstAttempt.Should().Throw<InvalidOperationException>();
+
+        gate.HasRun("scopeA").Should().BeFalse("a failed walk must never be cached as done");
+
+        int runs = 0;
+        gate.RunOnce("scopeA", () => runs++).Should().BeTrue("the next open retries");
+        runs.Should().Be(1);
+    }
+
+    [Fact]
+    public void Invalidate_ReRunsActionOnNextRunOnce()
+    {
+        var gate = new SessionScopeGate("test");
+        int runs = 0;
+
+        gate.RunOnce("scopeA", () => runs++);
+        gate.Invalidate("scopeA");
+        var ran = gate.RunOnce("scopeA", () => runs++);
+
+        ran.Should().BeTrue("explicit refresh busts the session gate");
+        runs.Should().Be(2);
+    }
+
+    [Fact]
+    public void Invalidate_UnknownScope_DoesNotThrow()
+    {
+        var gate = new SessionScopeGate("test");
+
+        var act = () => gate.Invalidate("ghost");
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Clear_ResetsEveryScope()
+    {
+        var gate = new SessionScopeGate("test");
+        gate.RunOnce("scopeA", () => { });
+        gate.RunOnce("scopeB", () => { });
+
+        gate.Clear();
+
+        gate.HasRun("scopeA").Should().BeFalse();
+        gate.HasRun("scopeB").Should().BeFalse();
+    }
+
+    [Fact]
+    public void RunOnce_NullAction_Throws()
+    {
+        var gate = new SessionScopeGate("test");
+
+        var act = () => gate.RunOnce("scopeA", null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/src/BlockParam/AddIn/BulkChangeContextMenu.cs
+++ b/src/BlockParam/AddIn/BulkChangeContextMenu.cs
@@ -28,6 +28,16 @@ public class BulkChangeContextMenu : ContextMenuAddIn
     // Openness export + parse (#140).
     private readonly DbExportCache _dbExportCache = new DbExportCache();
 
+    // #155: same per-Add-In-load lifetime as _dbExportCache. These collapse the
+    // remaining per-open bottlenecks profiled in #155 — the ~8–12s project DB
+    // enumeration, the ~4.6s tag-table re-export, and the ~2.7s UDT freshness
+    // walk — to once per project scope per TIA session. The dialog's existing
+    // explicit refresh affordances Invalidate them (the cross-open staleness
+    // valve, sanctioned by the #155 correctness constraint).
+    private readonly ProjectDbEnumerationCache _projectDbCache = new ProjectDbEnumerationCache();
+    private readonly SessionScopeGate _tagTableExportGate = new SessionScopeGate("tag-table export");
+    private readonly SessionScopeGate _udtValidationGate = new SessionScopeGate("UDT validation");
+
     /// <summary>
     /// Reads the optional <c>language</c> override from %APPDATA%\BlockParam\config.json
     /// (#50) and, if set, applies it to <c>Thread.CurrentUICulture</c>. When unset,
@@ -175,8 +185,16 @@ public class BulkChangeContextMenu : ContextMenuAddIn
             {
                 if (plcSoftware != null)
                 {
-                    udtRefreshedCount = udtCacheRefresher.Refresh(plcSoftware, udtDir);
-                    Log.Information("UDT cache validation: {Refreshed} stale file(s) re-exported", udtRefreshedCount);
+                    // #155 item 3: the full UDT freshness walk (583 types in the
+                    // profiled project, ~2.7s) ran unconditionally on every open
+                    // even when 0 were stale. Run it once per project scope per
+                    // TIA session; the dialog's "Refresh UDT types" path
+                    // Invalidates the gate (onInvalidateUdtSession) to force it.
+                    bool ran = _udtValidationGate.RunOnce(scope, () =>
+                        udtRefreshedCount = udtCacheRefresher.Refresh(plcSoftware, udtDir));
+                    if (ran)
+                        Log.Information("UDT cache validation: {Refreshed} stale file(s) re-exported", udtRefreshedCount);
+                    t.AddPredictors($"udtGate={(ran ? "ran" : "skipped")}");
                 }
                 t.AddPredictors($"staleFlushed={udtRefreshedCount}");
             }
@@ -276,8 +294,14 @@ public class BulkChangeContextMenu : ContextMenuAddIn
                 // Thunk: the focused ActiveDb may be swapped by switchToDataBlock,
                 // so we route Apply through the latest reference, not a captured one.
                 onApply: xml => currentFocused.OnApply!(xml),
+                // #155 item 2: TagTableExporter.Export wipes + re-exports every
+                // tag table from Openness (~4.6s) on first tag-table need of
+                // each open. The XML is already on disk from a prior open, so
+                // gate the export to once per project scope per TIA session.
+                // "Refresh constants" Invalidates the gate (onInvalidateTagTableSession).
                 onRefreshTagTables: plcSoftware != null
-                    ? () => tagTableExporter.Export(plcSoftware, tagTableDir)
+                    ? new Action(() => _tagTableExportGate.RunOnce(scope,
+                        () => tagTableExporter.Export(plcSoftware, tagTableDir)))
                     : null,
                 tagTableDir: plcSoftware != null ? tagTableDir : null,
                 projectLanguages: projectLanguages,
@@ -291,8 +315,17 @@ public class BulkChangeContextMenu : ContextMenuAddIn
                 editingLanguage: editingLanguage,
                 referenceLanguage: referenceLanguage,
                 updateCheckService: updateCheckService,
+                // #155 item 1: the ~8–12s project-wide DB walk was cached only
+                // per-dialog (ActiveSetViewModel field), so it re-ran on the
+                // first switcher interaction of every open. Route it through
+                // the TIA-session-scoped cache; the switcher's Refresh button
+                // Invalidates it via onRefreshDataBlocks.
                 enumerateDataBlocks: project != null
-                    ? new Func<IReadOnlyList<DataBlockSummary>>(() => discovery.EnumerateDataBlocks(project))
+                    ? new Func<IReadOnlyList<DataBlockSummary>>(
+                        () => _projectDbCache.GetOrAdd(scope, () => discovery.EnumerateDataBlocks(project)))
+                    : null,
+                onRefreshDataBlocks: project != null
+                    ? new Action(() => _projectDbCache.Invalidate(scope))
                     : null,
                 currentPlcName: displayPlcName,
                 switchToDataBlock: plcSoftware != null
@@ -334,6 +367,15 @@ public class BulkChangeContextMenu : ContextMenuAddIn
                         }
                         return dbFactory.Build(initial, summary.PlcName);
                     })
+                    : null,
+                // #155 cross-open staleness valves: the dialog's explicit
+                // refresh actions clear the session gates so a tag-table / UDT
+                // edited in TIA mid-session is one click away (never silent).
+                onInvalidateTagTableSession: plcSoftware != null
+                    ? new Action(() => _tagTableExportGate.Invalidate(scope))
+                    : null,
+                onInvalidateUdtSession: plcSoftware != null
+                    ? new Action(() => _udtValidationGate.Invalidate(scope))
                     : null);
 
             licenseService.StartHeartbeat();

--- a/src/BlockParam/Services/PlcPillGroupsService.cs
+++ b/src/BlockParam/Services/PlcPillGroupsService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BlockParam.Diagnostics;
 using BlockParam.Models;
 using BlockParam.UI;
 
@@ -97,6 +98,10 @@ public static class PlcPillGroupsService
         // sessions, so the user can identify which PLC each pill targets
         // at a glance — and so the row stays visually consistent when
         // additional PLCs get added via "+ PLC".
+        Log.Information(
+            "PlcPillGroups: building {Pills} pill(s) from {Dbs} active DB(s); anchorPlc='{Anchor}', extraPlcs={Extra}",
+            orderedPlcs.Count, activeDbs.Count, anchorPlcName ?? "", extraPlcs?.Count ?? 0);
+
         var pills = new List<PlcPillViewModel>(orderedPlcs.Count);
         for (int idx = 0; idx < orderedPlcs.Count; idx++)
         {
@@ -110,6 +115,20 @@ public static class PlcPillGroupsService
 
             pill.Label = plc;
             pills.Add(pill);
+
+            // #141 lead: the pill trigger renders its Label; an empty PLC name
+            // (single-PLC / DevLauncher seeds, or an ActiveDb that came through
+            // with no PlcName) means a blank, effectively unclickable trigger —
+            // so the popup "won't open". Make that the loudest line in the log.
+            if (string.IsNullOrEmpty(plc))
+                Log.Warning(
+                    "PlcPillGroups: pill[{Idx}] built with EMPTY PLC label (anchor={Anchor}) — trigger renders blank, popup not clickable (#141 lead). initialItems={N}: [{Names}]",
+                    idx, idx == 0, activeItems.Count,
+                    string.Join(", ", activeItems.Select(i => i.Summary.Name)));
+            else
+                Log.Information(
+                    "PlcPillGroups: pill[{Idx}] plc='{Plc}' items={N}",
+                    idx, plc, activeItems.Count);
         }
 
         return pills;

--- a/src/BlockParam/Services/ProjectDbEnumerationCache.cs
+++ b/src/BlockParam/Services/ProjectDbEnumerationCache.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using BlockParam.Diagnostics;
+using BlockParam.Models;
+
+namespace BlockParam.Services;
+
+/// <summary>
+/// In-process, TIA-session-scoped cache of the project-wide DataBlock
+/// enumeration keyed on project scope. Fixes #155 (item 1): the ~8–12s
+/// <c>ProjectDiscovery.EnumerateDataBlocks</c> walk over every block in the
+/// project (821 in the profiled project) was an instance field on
+/// <c>ActiveSetViewModel</c>, which is recreated per dialog open — so the walk
+/// re-ran on the first DB-switcher interaction of <em>every</em> open.
+///
+/// <para>
+/// Same lifetime model as #140's <see cref="DbExportCache"/>: one instance per
+/// Add-In load, owned by <c>BulkChangeContextMenu</c>, so it survives across
+/// dialog opens and dies only when TIA Portal closes. The expensive tree walk
+/// runs once per project scope per TIA session; later opens reuse the result.
+/// </para>
+///
+/// <para>
+/// Correctness (#155 constraint — discriminator <em>or</em> explicit refresh,
+/// never silent staleness): the enumeration list has no cheap Openness
+/// change-discriminator (there is no project-level ModifiedDate; hashing a
+/// fresh walk would defeat the cache). The valve is therefore the existing
+/// explicit refresh affordance — the DB-switcher's Refresh button calls
+/// <see cref="Invalidate"/> before forcing a re-enumeration, so a DB added in
+/// TIA between opens is one click away, not silently missing. The
+/// <c>ShowDialog()</c> modal blocks project edits while a dialog is open, so
+/// within a single open the snapshot cannot drift underneath the user.
+/// </para>
+///
+/// <para>
+/// Bounded by a small entry cap (<see cref="MaxEntries"/>): in practice exactly
+/// one scope is live per session (the open project), but switching projects
+/// mid-session must not accumulate unboundedly. Least-recently-used scopes are
+/// evicted past the cap; at least one entry is always retained.
+/// </para>
+/// </summary>
+public interface IProjectDbEnumerationCache
+{
+    /// <summary>
+    /// Returns the cached enumeration for <paramref name="scope"/>, or runs
+    /// <paramref name="enumerate"/> once, stores it (most-recently-used), and
+    /// returns the result. The expensive walk runs at most once per scope per
+    /// session until <see cref="Invalidate"/> / <see cref="Clear"/>.
+    /// </summary>
+    IReadOnlyList<DataBlockSummary> GetOrAdd(
+        string scope, Func<IReadOnlyList<DataBlockSummary>> enumerate);
+
+    /// <summary>True if an entry exists for <paramref name="scope"/>.</summary>
+    bool HasEntry(string scope);
+
+    /// <summary>
+    /// Drops the entry for <paramref name="scope"/> so the next
+    /// <see cref="GetOrAdd"/> re-enumerates. Called by the DB-switcher's
+    /// explicit Refresh affordance — the cross-open staleness valve.
+    /// </summary>
+    void Invalidate(string scope);
+
+    /// <summary>Drops every cached scope.</summary>
+    void Clear();
+}
+
+/// <inheritdoc cref="IProjectDbEnumerationCache"/>
+public sealed class ProjectDbEnumerationCache : IProjectDbEnumerationCache
+{
+    /// <summary>
+    /// Hard cap on cached scopes. One project scope is live per session in
+    /// practice; the cap only matters when the user switches projects within
+    /// one TIA session.
+    /// </summary>
+    internal const int MaxEntries = 4;
+
+    private readonly object _lock = new object();
+    private readonly int _maxEntries;
+
+    // Mutable node class (not a readonly struct) — avoids the partial-trust
+    // ldflda-on-readonly-struct-field IL pitfall entirely (CLAUDE.md), and lets
+    // the LRU list + index share one object per entry. Mirrors DbExportCache.
+    private sealed class CacheItem
+    {
+        public CacheItem(string scope, IReadOnlyList<DataBlockSummary> list)
+        {
+            Scope = scope; List = list;
+        }
+        public string Scope { get; }
+        public IReadOnlyList<DataBlockSummary> List { get; set; }
+    }
+
+    private readonly LinkedList<CacheItem> _lru = new LinkedList<CacheItem>();
+    private readonly Dictionary<string, LinkedListNode<CacheItem>> _index =
+        new Dictionary<string, LinkedListNode<CacheItem>>(StringComparer.Ordinal);
+
+    public ProjectDbEnumerationCache() : this(MaxEntries) { }
+
+    // Test seam: inject a tiny cap so eviction is verifiable.
+    internal ProjectDbEnumerationCache(int maxEntries)
+    {
+        _maxEntries = maxEntries;
+    }
+
+    public IReadOnlyList<DataBlockSummary> GetOrAdd(
+        string scope, Func<IReadOnlyList<DataBlockSummary>> enumerate)
+    {
+        if (enumerate == null) throw new ArgumentNullException(nameof(enumerate));
+
+        lock (_lock)
+        {
+            if (_index.TryGetValue(scope, out var hit))
+            {
+                Touch(hit);
+                Log.Information("DB enumeration cache hit (skipping project walk) for scope {Scope}", scope);
+                return hit.Value.List;
+            }
+        }
+
+        // Run the (slow) enumeration OUTSIDE the lock: it calls into TIA
+        // Openness on the UI thread and must not serialize behind unrelated
+        // cache reads. A duplicate concurrent miss would just enumerate twice
+        // and the last writer wins — harmless for an idempotent project walk,
+        // and the open path is single-threaded in practice anyway.
+        var list = enumerate();
+
+        lock (_lock)
+        {
+            if (_index.TryGetValue(scope, out var existing))
+            {
+                existing.Value.List = list;
+                Touch(existing);
+            }
+            else
+            {
+                var added = _lru.AddFirst(new CacheItem(scope, list));
+                _index[scope] = added;
+            }
+
+            while (_index.Count > 1 && _index.Count > _maxEntries)
+            {
+                var lru = _lru.Last;
+                if (lru == null) break;
+                _lru.RemoveLast();
+                _index.Remove(lru.Value.Scope);
+            }
+        }
+
+        return list;
+    }
+
+    public bool HasEntry(string scope)
+    {
+        lock (_lock)
+            return _index.ContainsKey(scope);
+    }
+
+    public void Invalidate(string scope)
+    {
+        lock (_lock)
+        {
+            if (_index.TryGetValue(scope, out var node))
+            {
+                _lru.Remove(node);
+                _index.Remove(scope);
+                Log.Information("DB enumeration cache invalidated for scope {Scope} (explicit refresh)", scope);
+            }
+        }
+    }
+
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _lru.Clear();
+            _index.Clear();
+        }
+    }
+
+    // Caller holds _lock.
+    private void Touch(LinkedListNode<CacheItem> node)
+    {
+        if (!ReferenceEquals(_lru.First, node))
+        {
+            _lru.Remove(node);
+            _lru.AddFirst(node);
+        }
+    }
+}

--- a/src/BlockParam/Services/SessionScopeGate.cs
+++ b/src/BlockParam/Services/SessionScopeGate.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using BlockParam.Diagnostics;
+
+namespace BlockParam.Services;
+
+/// <summary>
+/// A TIA-session-scoped "run this expensive thing at most once per project
+/// scope" gate. Fixes #155 items 2 and 3, which share the same shape: a costly
+/// per-PLC walk that was re-run on <em>every</em> dialog open even though its
+/// on-disk output (the per-project XML cache) already existed and nothing had
+/// changed.
+///
+/// <list type="bullet">
+///   <item><b>Tag-table export</b> (~4.6s/open): <c>TagTableExporter.Export</c>
+///   wipes + re-exports every tag table from Openness on first tag-table need
+///   of each dialog. The XML it produces is already on disk from a prior open.</item>
+///   <item><b>UDT cache validation</b> (~2.7s/open): <c>UdtCacheRefresher.Refresh</c>
+///   walks all UDTs (583 in the profiled project) checking ModifiedDate vs
+///   file mtime, unconditionally on every open even when 0 are stale.</item>
+/// </list>
+///
+/// <para>
+/// Same lifetime model as #140's <see cref="DbExportCache"/>: one gate instance
+/// per Add-In load, owned by <c>BulkChangeContextMenu</c>, surviving across
+/// dialog opens and dying only when TIA Portal closes. The first open per
+/// scope runs the action; subsequent opens skip it.
+/// </para>
+///
+/// <para>
+/// Correctness (#155 constraint — discriminator <em>or</em> explicit refresh,
+/// never silent staleness): the gated walks are themselves the
+/// change-discriminators (the tag-table re-export and the UDT ModifiedDate
+/// freshness scan). Skipping them across opens means a tag-table / UDT edited
+/// in TIA mid-session would not be picked up automatically — exactly the same
+/// bar #140 already accepted for the DB export cache (a UDT change does not
+/// bump the owning DB's ModifiedDate either). The valve is the existing
+/// explicit refresh affordances: the dialog's "Refresh constants" /
+/// "Refresh UDT types" actions call <see cref="Invalidate"/> before forcing
+/// the walk, so a mid-session change is one click away, not silently stale.
+/// The <c>ShowDialog()</c> modal blocks TIA edits while a dialog is open.
+/// </para>
+///
+/// <para>
+/// One reusable focused service, instantiated once per concern (one gate for
+/// tag-table export, one for UDT validation) — keeps the #80/#81 hotspot seams
+/// intact without a bespoke class per bottleneck.
+/// </para>
+/// </summary>
+public interface ISessionScopeGate
+{
+    /// <summary>
+    /// Runs <paramref name="action"/> and marks <paramref name="scope"/> done
+    /// only if it has not already run (and succeeded) for that scope this
+    /// session. Returns true if <paramref name="action"/> was invoked, false if
+    /// it was skipped because the scope was already satisfied. If
+    /// <paramref name="action"/> throws, the scope is left UN-satisfied so the
+    /// next open retries — a failed export/validation must never be cached as
+    /// "done".
+    /// </summary>
+    bool RunOnce(string scope, Action action);
+
+    /// <summary>True if <paramref name="scope"/> has been satisfied this session.</summary>
+    bool HasRun(string scope);
+
+    /// <summary>
+    /// Clears the satisfied mark for <paramref name="scope"/> so the next
+    /// <see cref="RunOnce"/> re-runs the action. Called by the explicit refresh
+    /// affordance — the cross-open staleness valve.
+    /// </summary>
+    void Invalidate(string scope);
+
+    /// <summary>Clears every satisfied scope.</summary>
+    void Clear();
+}
+
+/// <inheritdoc cref="ISessionScopeGate"/>
+public sealed class SessionScopeGate : ISessionScopeGate
+{
+    private readonly string _label;
+    private readonly object _lock = new object();
+    private readonly HashSet<string> _done = new HashSet<string>(StringComparer.Ordinal);
+
+    /// <param name="label">
+    /// Short tag for log lines (e.g. "tag-table export", "UDT validation") so
+    /// the two gate instances are distinguishable in the open-path log.
+    /// </param>
+    public SessionScopeGate(string label)
+    {
+        _label = label ?? "session-gate";
+    }
+
+    public bool RunOnce(string scope, Action action)
+    {
+        if (action == null) throw new ArgumentNullException(nameof(action));
+
+        lock (_lock)
+        {
+            if (_done.Contains(scope))
+            {
+                Log.Information("{Label}: skipped (session-cached for scope {Scope})", _label, scope);
+                return false;
+            }
+        }
+
+        // Run OUTSIDE the lock: the action calls into TIA Openness on the UI
+        // thread and may itself prompt the user (UDT compile prompt). The open
+        // path is single-threaded in practice; a hypothetical duplicate
+        // concurrent first-run would just do the idempotent walk twice.
+        action();
+
+        lock (_lock)
+        {
+            _done.Add(scope);
+        }
+        return true;
+    }
+
+    public bool HasRun(string scope)
+    {
+        lock (_lock)
+            return _done.Contains(scope);
+    }
+
+    public void Invalidate(string scope)
+    {
+        lock (_lock)
+        {
+            if (_done.Remove(scope))
+                Log.Information("{Label}: invalidated for scope {Scope} (explicit refresh)", _label, scope);
+        }
+    }
+
+    public void Clear()
+    {
+        lock (_lock)
+            _done.Clear();
+    }
+}

--- a/src/BlockParam/UI/ActiveSetViewModel.cs
+++ b/src/BlockParam/UI/ActiveSetViewModel.cs
@@ -53,6 +53,10 @@ public sealed class ActiveSetViewModel : ViewModelBase
     private readonly Func<MemberNode, string?>? _getStartValueForNode;
     private readonly Func<DataBlockSummary, ActiveDb?>? _buildActiveDbForSummary;
     private readonly Func<IReadOnlyList<DataBlockSummary>>? _enumerateDataBlocks;
+    // #155 item 1: invalidates the TIA-session DB-enumeration cache owned by
+    // BulkChangeContextMenu so the switcher's explicit Refresh re-walks the
+    // project (the cross-open staleness valve). Null in tests / DevLauncher.
+    private readonly Action? _onRefreshDataBlocks;
     private readonly Func<DataBlockSummary, string>? _switchToDataBlock;
     private readonly Func<ActiveDb, bool>? _tryApplyActiveDbInPlace;
     private readonly Func<StashedDbState, ActiveDb?, (int restored, int dropped)>? _restoreStashOntoLive;
@@ -117,7 +121,8 @@ public sealed class ActiveSetViewModel : ViewModelBase
         Func<StashedDbState, ActiveDb?, (int restored, int dropped)>? restoreStashOntoLive,
         Action<string>? setStatus,
         Func<int>? getPendingCount,
-        Dispatcher? dispatcher)
+        Dispatcher? dispatcher,
+        Action? onRefreshDataBlocks = null)
     {
         _state = initial ?? throw new ArgumentNullException(nameof(initial));
         StashedDbs = new ObservableCollection<StashedDbState>();
@@ -133,6 +138,7 @@ public sealed class ActiveSetViewModel : ViewModelBase
         _getStartValueForNode = getStartValueForNode;
         _buildActiveDbForSummary = buildActiveDbForSummary;
         _enumerateDataBlocks = enumerateDataBlocks;
+        _onRefreshDataBlocks = onRefreshDataBlocks;
         _switchToDataBlock = switchToDataBlock;
         _tryApplyActiveDbInPlace = tryApplyActiveDbInPlace;
         _restoreStashOntoLive = restoreStashOntoLive;
@@ -375,6 +381,11 @@ public sealed class ActiveSetViewModel : ViewModelBase
 
     private void ExecuteRefreshDataBlocks()
     {
+        // #155 item 1: bust the TIA-session enumeration cache first so the
+        // forced reload below actually re-walks the project (the explicit
+        // refresh affordance is the cross-open staleness valve) instead of
+        // re-reading the session-cached list.
+        _onRefreshDataBlocks?.Invoke();
         LoadAvailableDataBlocks(force: true);
         ApplyDataBlockFilter();
     }

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -86,6 +86,10 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private readonly string? _tagTableDir;
     private readonly Action? _onRefreshUdtTypes;
     private readonly string? _udtDir;
+    // #155 cross-open staleness valves: clear the TIA-session gates owned by
+    // BulkChangeContextMenu so the next forced refresh re-runs the gated walk.
+    private readonly Action? _onInvalidateTagTableSession;
+    private readonly Action? _onInvalidateUdtSession;
     private UdtSetPointResolver? _udtResolver;
     private UdtCommentResolver? _commentResolver;
     private AutocompleteProvider? _autocompleteProvider;
@@ -174,7 +178,10 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         Func<DataBlockSummary, string>? switchToDataBlock = null,
         string? currentPlcName = null,
         IReadOnlyList<ActiveDb>? additionalActiveDbs = null,
-        Func<DataBlockSummary, ActiveDb?>? buildActiveDbForSummary = null)
+        Func<DataBlockSummary, ActiveDb?>? buildActiveDbForSummary = null,
+        Action? onRefreshDataBlocks = null,
+        Action? onInvalidateTagTableSession = null,
+        Action? onInvalidateUdtSession = null)
     {
         _dispatcher = Dispatcher.CurrentDispatcher;
         _projectLanguages = projectLanguages is { Count: > 0 } ? projectLanguages : new[] { "en-GB" };
@@ -189,6 +196,8 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         _tagTableCache = tagTableCache;
         _onRefreshTagTables = onRefreshTagTables;
         _tagTableDir = tagTableDir;
+        _onInvalidateTagTableSession = onInvalidateTagTableSession;
+        _onInvalidateUdtSession = onInvalidateUdtSession;
         _onRefreshUdtTypes = onRefreshUdtTypes;
         _udtDir = udtDir;
         _udtResolver = udtResolver;
@@ -237,6 +246,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             getStartValueForNode: node => Tree!.FindVmByModel(node)?.StartValue,
             buildActiveDbForSummary: BuildActiveDbFromSummaryWithFallback,
             enumerateDataBlocks: enumerateDataBlocks,
+            onRefreshDataBlocks: onRefreshDataBlocks,
             switchToDataBlock: switchToDataBlock,
             tryApplyActiveDbInPlace: TryApplyActiveDbInPlace,
             restoreStashOntoLive: RestoreStashOntoLive,
@@ -1959,6 +1969,10 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         if (_onRefreshUdtTypes == null) return;
         try
         {
+            // #155: clear the TIA-session validation gate first so the (now
+            // gated) UDT freshness walk actually re-runs on this explicit
+            // refresh instead of being skipped as session-cached.
+            _onInvalidateUdtSession?.Invoke();
             _onRefreshUdtTypes();
 
             var resolver = new UdtSetPointResolver();
@@ -1984,6 +1998,10 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
     private void ExecuteRefreshConstants()
     {
+        // #155: clear the TIA-session export gate first so the (now gated)
+        // _onRefreshTagTables actually re-exports from Openness on this
+        // explicit user request instead of being skipped as session-cached.
+        _onInvalidateTagTableSession?.Invoke();
         _onRefreshTagTables?.Invoke();
 
         if (_tagTableDir != null && System.IO.Directory.Exists(_tagTableDir))

--- a/src/BlockParam/UI/Controls/PillMultiSelect/PillMultiSelect.xaml.cs
+++ b/src/BlockParam/UI/Controls/PillMultiSelect/PillMultiSelect.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Markup;
 using System.Windows.Media;
+using BlockParam.Diagnostics;
 
 namespace BlockParam.UI.Controls.PillMultiSelect;
 
@@ -61,13 +62,15 @@ public partial class PillMultiSelect : UserControl
         // SetValue would kill it. DP metadata default is null to avoid the
         // "shared default across instances" trap for collection DPs.
         SetCurrentValue(SelectedItemsProperty, new ObservableCollection<object>());
+
+        Log.Information("PillMultiSelect: control instantiated");
     }
 
     // ── DependencyProperties ─────────────────────────────────────────────────
 
     public static readonly DependencyProperty ItemsSourceProperty =
         DependencyProperty.Register(nameof(ItemsSource), typeof(IEnumerable), typeof(PillMultiSelect),
-            new PropertyMetadata(null, (d, e) => ((PillMultiSelect)d)._itemSource.ItemsSource = (IEnumerable?)e.NewValue));
+            new PropertyMetadata(null, (d, e) => ((PillMultiSelect)d).OnItemsSourceDpChanged((IEnumerable?)e.NewValue)));
 
     public IEnumerable? ItemsSource
     {
@@ -139,7 +142,7 @@ public partial class PillMultiSelect : UserControl
 
     public static readonly DependencyProperty LabelProperty =
         DependencyProperty.Register(nameof(Label), typeof(string), typeof(PillMultiSelect),
-            new PropertyMetadata(string.Empty, (d, e) => ((PillMultiSelect)d)._internalState.Label = (string)e.NewValue));
+            new PropertyMetadata(string.Empty, (d, e) => ((PillMultiSelect)d).OnLabelDpChanged((string)e.NewValue)));
 
     public string Label
     {
@@ -220,10 +223,36 @@ public partial class PillMultiSelect : UserControl
 
     private void OnIsOpenDpChanged(bool value)
     {
+        Log.Information("PillMultiSelect DP: IsOpen={Value} (host->control)", value);
         if (_syncingIsOpen) return;
         _syncingIsOpen = true;
         try { _internalState.IsOpen = value; }
         finally { _syncingIsOpen = false; }
+    }
+
+    // Diagnostic shims around the host->control DP boundary (#141). The pill
+    // renders an empty bubble when the host bindings never deliver Label /
+    // ItemsSource / SelectedItems into _internalState; these lines make that
+    // boundary observable in the runtime log instead of a silent blank.
+    private void OnLabelDpChanged(string value)
+    {
+        Log.Information("PillMultiSelect DP: Label='{Label}' (host->control)", value ?? "");
+        _internalState.Label = value;
+    }
+
+    private void OnItemsSourceDpChanged(IEnumerable? value)
+    {
+        int n = value is ICollection c ? c.Count : -1;
+        Log.Information("PillMultiSelect DP: ItemsSource set (items={N}, null={Null})",
+            n, value == null);
+        _itemSource.ItemsSource = value;
+    }
+
+    private void OnSelectedItemsDpChanged(IList? value)
+    {
+        Log.Information("PillMultiSelect DP: SelectedItems set (count={N}, null={Null})",
+            value?.Count ?? -1, value == null);
+        _selectionSync.SetSelectedItems(value);
     }
 
     private void OnInternalStatePropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -328,7 +357,7 @@ public partial class PillMultiSelect : UserControl
     public static readonly DependencyProperty SelectedItemsProperty =
         DependencyProperty.Register(nameof(SelectedItems), typeof(IList), typeof(PillMultiSelect),
             new PropertyMetadata(null,
-                (d, e) => ((PillMultiSelect)d)._selectionSync.SetSelectedItems((IList?)e.NewValue)));
+                (d, e) => ((PillMultiSelect)d).OnSelectedItemsDpChanged((IList?)e.NewValue)));
 
     public IList? SelectedItems
     {

--- a/src/BlockParam/UI/Controls/PillMultiSelect/PillMultiSelectInternalState.cs
+++ b/src/BlockParam/UI/Controls/PillMultiSelect/PillMultiSelectInternalState.cs
@@ -9,6 +9,7 @@ using System.Windows;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
+using BlockParam.Diagnostics;
 
 namespace BlockParam.UI.Controls.PillMultiSelect;
 
@@ -247,7 +248,18 @@ internal sealed class PillMultiSelectInternalState : PillViewModelBase
         get => _isOpen;
         set
         {
-            if (SetProperty(ref _isOpen, value) && value)
+            if (!SetProperty(ref _isOpen, value)) return;
+
+            // Control-side open/close. If the user clicks a blank/zero-width
+            // trigger this never fires — pair with the PlcPill/PlcPillGroups
+            // lines to tell "trigger not clickable" from "opened but empty".
+            // Locals only (bool/int/string) — no readonly-struct member access
+            // here, per the partial-trust IL rule for this file (CLAUDE.md).
+            Log.Information(
+                "PillMultiSelect[label='{Label}']: IsOpen -> {Value}, rows={Rows}",
+                _label, value, _items.Count);
+
+            if (value)
             {
                 // Popup just opened — snapshot which items are currently
                 // selected so the "selected first" ordering stays stable

--- a/src/BlockParam/UI/PlcPillViewModel.cs
+++ b/src/BlockParam/UI/PlcPillViewModel.cs
@@ -61,6 +61,10 @@ public class PlcPillViewModel : ViewModelBase
         SelectedDbs.CollectionChanged += OnSelectedDbsChanged;
 
         LoadCommand = new RelayCommand(_ => OnIsOpenFlippedToTrue(), _ => !_isLoaded);
+
+        Log.Information(
+            "PlcPill ctor: plc='{Plc}' anchor={Anchor} initialItems={N}",
+            _plcName, _isAnchor, initialActiveItems.Count);
     }
 
     // ── Props ─────────────────────────────────────────────────────────────────
@@ -92,6 +96,9 @@ public class PlcPillViewModel : ViewModelBase
         set
         {
             if (!SetProperty(ref _isOpen, value)) return;
+            Log.Information(
+                "PlcPill '{Plc}': IsOpen -> {Value} (isLoaded={Loaded})",
+                _plcName, value, _isLoaded);
             if (value && !_isLoaded)
                 OnIsOpenFlippedToTrue();
         }
@@ -175,9 +182,13 @@ public class PlcPillViewModel : ViewModelBase
     {
         if (_isLoaded) return;
 
+        Log.Information("PlcPill '{Plc}': loading DBs (first popup open)", _plcName);
+
         try
         {
             IReadOnlyList<DataBlockListItem> items = await _loadDbs(_plcName);
+            Log.Information(
+                "PlcPill '{Plc}': loadDbs returned {N} item(s)", _plcName, items.Count);
 
             // Snapshot the CURRENT selection by (Name, PlcName) identity
             // before clearing AvailableDbs. Reading SelectedDbs (not the
@@ -228,6 +239,10 @@ public class PlcPillViewModel : ViewModelBase
             {
                 _syncingSelection = false;
             }
+
+            Log.Information(
+                "PlcPill '{Plc}': populated AvailableDbs={A}, SelectedDbs={S}",
+                _plcName, AvailableDbs.Count, SelectedDbs.Count);
 
             IsLoaded = true;
             (LoadCommand as RelayCommand)?.RaiseCanExecuteChanged();


### PR DESCRIPTION
## Summary

Follow-up to #140. Profiling showed the #140 export cache only addressed a
minority of the open cost; three steps still re-ran on **every** open because
they were cached per-dialog (or not at all). This makes all three
**TIA-session-scoped**, same lifetime model as #140's `DbExportCache`.

- **Project DB enumeration (~8–12s)** → new `ProjectDbEnumerationCache`.
  `ProjectDiscovery.EnumerateDataBlocks` was memoized on an
  `ActiveSetViewModel` field recreated per dialog open, so it re-walked all
  821 project blocks on the first switcher interaction of every open. Now
  memoized per project scope for the TIA session.
- **Tag-table export (~4.6s)** → reusable `SessionScopeGate` (instance #1).
  `TagTableExporter.Export` wiped + re-exported every tag table from Openness
  on first tag-table need of each open. Now runs once per scope per session.
- **UDT validation (~2.7s)** → reusable `SessionScopeGate` (instance #2).
  The 583-UDT `ModifiedDate`-vs-mtime freshness walk ran unconditionally on
  every open even when 0 were stale. Now runs once per scope per session.

Two small focused services (`ProjectDbEnumerationCache`, `SessionScopeGate`)
owned by `BulkChangeContextMenu` — respects the #80/#81 hotspot seams; the
VMs only bind through them.

## Correctness (per the #155 constraint)

The gated walks have no cheap Openness change-discriminator (no project-level
`ModifiedDate`; hashing a fresh walk defeats the cache). The issue explicitly
sanctions **"a change-discriminator _or_ an explicit refresh"**, so the
staleness valve is the dialog's **existing** explicit refresh affordances:
"Refresh data blocks" / "Refresh constants" / "Refresh UDT types" now
`Invalidate` the relevant session cache before forcing the walk. A
DB/tag-table/UDT edited in TIA mid-session is one click away — never silently
stale. A failed walk is never cached as "done". The `ShowDialog()` modal
blocks TIA edits while a dialog is open. This is the same bar #140 already
accepted (a UDT change doesn't bump the owning DB's `ModifiedDate` either).

## Notes

- Plumbing is **purely additive** — three optional `Action?` callbacks
  defaulted to `null`. No test-harness or DevLauncher call sites change; no
  `Func` signatures break.
- New services are mutable classes (no readonly-struct `ldflda` partial-trust
  pitfall) and do **zero file I/O** (storage guardrail untouched).
- New unit tests cover both services (cache hit/miss, scope isolation,
  explicit-refresh invalidation, failure-not-cached, bounded LRU eviction).

## Test plan

- [ ] CI green: `v20` (build + xUnit incl. new `ProjectDbEnumerationCacheTests` / `SessionScopeGateTests`), `peverify`, `v21`.
- [ ] **TIA-required** (deferred — needs a running TIA Portal + large project): re-open the profiled DB twice; confirm open #2 skips the project DB walk, tag-table re-export and UDT freshness walk (logs: `DB enumeration cache hit`, `tag-table export: skipped (session-cached…)`, `UDT cache validation: skipped (session-cached…)`), and that the three in-dialog Refresh actions still force a fresh walk.

Closes #155


---
_Generated by [Claude Code](https://claude.ai/code/session_01V2KKLPbuX2YACNzwDZRWqJ)_