### PR TITLE
docs(research): TIA-verified DB consistency-detection facts (#147)

### DIFF
--- a/docs/research/02-openness-api-datablocks.md
+++ b/docs/research/02-openness-api-datablocks.md
@@ -133,6 +133,60 @@ using (ExclusiveAccess exclusiveAccess = tiaPortal.ExclusiveAccess("Bulk editing
 
 This is **critical** for our bulk-change use case.
 
+## DB Consistency Detection (TIA-verified V20, 2026-05-19, issue #147)
+
+Captured with the `#147` diagnostic probe (`InconsistencyProbe`, build
+v0.147.0.0) against two real **inconsistent** `InstanceDB` blocks. The
+make-or-break question for #147 was: *can a DB's inconsistency be detected
+without triggering the export (which throws and, after the follow-up compile,
+mutates the block)?* — **Yes.**
+
+- **`block.GetAttribute("IsConsistent")` → `System.Boolean`. Non-throwing,
+  non-mutating, ~2–4 ms.** Returned `False` for inconsistent DBs. This is the
+  cheap up-front consistency probe; an aggregated single-prompt pre-scan over
+  the whole multi-DB selection does **not** need a probe-export.
+- Only `IsConsistent` is valid. `Consistent`, `IsConsistant`,
+  `ConsistencyState`, `CompileState`, `CompilationState`, `IsCompiled`,
+  `CompiledDate` all throw `EngineeringNotSupportedException`. Spelling trap:
+  the date attribute is **`CompileDate`** (Read), not `CompiledDate`.
+- Full `GetAttributeInfos()` surface of a V20 `InstanceDB` (27 attrs):
+  `AssignedProDiagFB(RW)`, `AutoNumber(RW)`, `CodeModifiedDate(R)`,
+  `CompileDate(R)`, `CreationDate(R)`, `DBAccessibleFromOPCUA(R)`,
+  `DBAccessibleFromWebserver(RW)`, `HeaderAuthor(R)`, `HeaderFamily(R)`,
+  `HeaderName(R)`, `HeaderVersion(R)`, `InstanceOfName(R)`,
+  `InstanceOfNumber(R)`, `InstanceOfType(R)`, `InterfaceModifiedDate(R)`,
+  **`IsConsistent(R)`**, `IsKnowHowProtected(R)`, `IsOnlyStoredInLoadMemory(R)`,
+  `IsWriteProtectedInAS(R)`, `MemoryLayout(RW)`, `ModifiedDate(R)`, `Name(RW)`,
+  `Namespace(R)`, `Number(RW)`, `ParameterModified(R)`,
+  `ProgrammingLanguage(R)`, `StructureModified(R)`.
+- **Exact inconsistent-export failure** (informs `InconsistencyDetector`):
+  `block.Export(...)` throws `Siemens.Engineering.EngineeringTargetInvocationException`
+  with message `Error when calling method 'Export' of type '...InstanceDB'.`
+  + blank line + `Inconsistent blocks and PLC data types (UDT) cannot be
+  exported.` It is **single-level** (no distinct InnerException) and writes
+  **no partial file**. `InconsistencyDetector.Matches()` returns **True** for
+  it — the existing en-US `"inconsistent"` marker is correct for real V20;
+  keep it as the defensive fallback signal.
+- `block.GetService<ICompilable>()` returns a non-null
+  `Siemens.Engineering.Compiler.CompileProvider` **directly on the block** —
+  the parent-`PlcBlockGroup` fallback in `TiaPortalAdapter.CompileBlock` is a
+  safety net, not the normal path.
+- **Not yet verified** (no TIA at write time): whether `IsConsistent` flips to
+  `True` after `ICompilable.Compile()`; whether the attribute exists on plain
+  global `DataBlock` / `ArrayDB` (only `InstanceDB` tested). A fix should fall
+  back to the export-throw `InconsistencyDetector` path if the attribute read
+  ever throws for an exotic subtype.
+
+**#147 fix shape:** a small sibling service reads `IsConsistent` for the
+selected DBs *before* the per-DB `Build` loop in `BulkChangeContextMenu`, then
+shows **one** consolidated prompt (reuse `Db_InconsistentPrompt` /
+`Udt_InconsistentPromptTitle` with a `{0}`-joined name list — no new resx key)
+or one batch compile + summary. Expose it as a mockable `ITiaPortalAdapter`
+member mirroring `TryGetModifiedToken` so DevLauncher/tests still work; leave
+the per-DB `TryExportWithCompilePrompt` retry as the fallback for the single-DB
+and Apply paths. (`BulkChangeContextMenu` is hotspot #81 and `ActiveDbFactory`
+sits in #140's seam — add a sibling, don't enlarge either.)
+
 ## Important Limitations
 
 - XML reimport requires the interface structure to match the current definition


### PR DESCRIPTION
## What

Adds a **TIA-verified** section to `docs/research/02-openness-api-datablocks.md`
documenting how DB inconsistency can be detected in TIA Portal V20 Openness —
the make-or-break unknown for issue #147.

**Documentation only.** No code, no behavior change.

## Why

#147 wants the multi-DB launch path to detect inconsistent DBs in a single
up-front pre-pass and prompt/compile **once**, instead of the per-DB "compile
inconsistent Datablock" modal firing N times. Designing that fix hinged on one
question only a running TIA Portal could answer: *can a DB's inconsistency be
detected without triggering the export* (which throws **and**, after the
follow-up compile, mutates the block)?

Answered against a live V20 session with two real inconsistent `InstanceDB`
blocks, via a throwaway diagnostic probe (kept on the research branch — see
below):

- **`block.GetAttribute("IsConsistent")` → `System.Boolean`, non-throwing,
  non-mutating, ~2–4 ms.** So the aggregated single-prompt pre-scan is feasible
  with no probe-export.
- `"IsConsistent"` is the only valid name; every variant
  (`CompileState`, `IsCompiled`, `CompiledDate`, …) throws
  `EngineeringNotSupportedException`. Spelling trap captured (`CompileDate`,
  not `CompiledDate`).
- Exact inconsistent-export failure recorded:
  `EngineeringTargetInvocationException`, *"Inconsistent blocks and PLC data
  types (UDT) cannot be exported."*, single-level, no partial file — and the
  existing `InconsistencyDetector.Matches()` correctly returns `true` for it
  (good as the defensive fallback).
- Full 27-attribute `GetAttributeInfos()` surface of a V20 `InstanceDB`.
- The recommended #147 fix shape (small sibling pre-scan service, reuse
  `Db_InconsistentPrompt`/`Udt_InconsistentPromptTitle` with a joined name
  list, mockable `ITiaPortalAdapter` member, defensive export-throw fallback,
  respecting the #81 / #140 seams) is written up for the implementer.

## Scope / not in this PR

This **does not fix #147** — it unblocks it. Using `Refs #147` (not a closing
keyword) on purpose so merging this doesn't auto-close the bug.

The diagnostic probe (`InconsistencyProbe`), its launch-path hook, and the
`0.147.0` version bump that produced these facts stay on the research branch
`claude/research-issue-147` and are intentionally **excluded** here — that code
is a diagnostic, explicitly not for `main`.

## Testing

Documentation-only; CI runs but no code paths change. The facts themselves were
verified in TIA Portal V20 (runtime log `bulkchange-v0.147.0.0`), which CI /
DevLauncher cannot exercise (`TIA-required`).

Refs #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)
