### PR TITLE
fix(#141): pill VMs public so WPF binding resolves under TIA partial trust

### DIFF
--- a/src/BlockParam.Tests/PartialTrustSandboxTests.cs
+++ b/src/BlockParam.Tests/PartialTrustSandboxTests.cs
@@ -135,6 +135,13 @@ public sealed class PartialTrustSandboxTests
         typeof(PillMultiSelectInternalState).IsPublic.Should().BeTrue(why);
         typeof(PillRowViewModel).IsPublic.Should().BeTrue(why);
         typeof(PillGroupViewModel).IsPublic.Should().BeTrue(why);
+
+        // Converters referenced by `{Binding … Converter={StaticResource …}}`
+        // and the ICommand implementation handed out through public command
+        // properties — same partial-trust foreign-assembly reflection rule.
+        typeof(PillGroupHeaderVisibilityConverter).IsPublic.Should().BeTrue(why);
+        typeof(PillGroupExpandedVisibilityConverter).IsPublic.Should().BeTrue(why);
+        typeof(PillRelayCommand).IsPublic.Should().BeTrue(why);
     }
 
     [Fact]
@@ -356,6 +363,9 @@ public sealed class PartialTrustWorker : MarshalByRefObject
                 "BlockParam.UI.Controls.PillMultiSelect.PillMultiSelectInternalState",
                 "BlockParam.UI.Controls.PillMultiSelect.PillRowViewModel",
                 "BlockParam.UI.Controls.PillMultiSelect.PillGroupViewModel",
+                "BlockParam.UI.Controls.PillMultiSelect.PillGroupHeaderVisibilityConverter",
+                "BlockParam.UI.Controls.PillMultiSelect.PillGroupExpandedVisibilityConverter",
+                "BlockParam.UI.Controls.PillMultiSelect.PillRelayCommand",
             };
 
             foreach (var fullName in checks)

--- a/src/BlockParam.Tests/PartialTrustSandboxTests.cs
+++ b/src/BlockParam.Tests/PartialTrustSandboxTests.cs
@@ -4,7 +4,10 @@ using System.IO;
 using System.Reflection;
 using System.Security;
 using System.Security.Permissions;
+using System.Windows;
+using System.Windows.Data;
 using BlockParam.Services;
+using BlockParam.UI.Controls.PillMultiSelect;
 using FluentAssertions;
 using Xunit;
 
@@ -88,6 +91,110 @@ public sealed class PartialTrustSandboxTests
             try { AppDomain.Unload(domain); }
             finally { TryDeleteDir(baseDir); }
         }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // #141 — partial-trust WPF binding regression
+    //
+    // The PillMultiSelect UserControl's content DataContext is a
+    // PillMultiSelectInternalState; rows bind to PillRowViewModel; groups bind
+    // to PillGroupViewModel. WPF's binding engine resolves `{Binding Member}`
+    // by reflecting from PresentationFramework (a foreign assembly) over the
+    // bound object. Under TIA Portal V20's partial-trust SandboxDomain that
+    // reflection silently fails on non-public types — the trigger renders
+    // blank, the popup never opens. Full-trust CI/DevLauncher never see it.
+    //
+    // The two tests below are the regression gate:
+    //
+    //   * Structural: each bound pill VM type must be `public`. Fast, exact,
+    //     refuses to merge a future "let's make this internal again" PR.
+    //
+    //   * Behavioural (sandbox): from inside the same partial-trust grant
+    //     set TIA gives the Add-In, load BlockParam.dll and confirm each
+    //     pill VM type is reachable AND public. This mirrors what
+    //     PresentationFramework does when it loads bound types for {Binding}
+    //     resolution — `Assembly.Load(name)` is the same code path.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Bound_pill_vm_types_are_public_for_partial_trust_binding()
+    {
+        // WPF's binding engine reflects over bound source objects from
+        // PresentationFramework, a foreign assembly. Under TIA V20's
+        // partial-trust SandboxDomain, that reflection yields no value for
+        // non-public types — the pill trigger renders empty, no IsOpen
+        // write-back, the popup never opens. Full-trust CI/DevLauncher hide
+        // this, which is why #141 regressed twice before this gate landed.
+        const string why =
+            "WPF data binding can't resolve members of a non-public type "
+            + "from PresentationFramework under TIA's partial-trust sandbox — "
+            + "see #141. Keep this `public`; the type is still presentation "
+            + "infrastructure, hosts use the PillMultiSelect UserControl's DPs.";
+
+        typeof(PillViewModelBase).IsPublic.Should().BeTrue(why);
+        typeof(PillMultiSelectInternalState).IsPublic.Should().BeTrue(why);
+        typeof(PillRowViewModel).IsPublic.Should().BeTrue(why);
+        typeof(PillGroupViewModel).IsPublic.Should().BeTrue(why);
+    }
+
+    [Fact]
+    public void Pill_vm_types_resolve_as_public_inside_partial_trust_sandbox()
+    {
+        var baseDir = StageAssemblies();
+        var domain = CreateTiaLikeSandbox(baseDir);
+        try
+        {
+            var worker = CreateWorker(domain);
+            var result = worker.ProbePillVmTypeVisibility();
+
+            // "C:OK" → all four bound pill VM types loaded from BlockParam.dll
+            //          and reported IsPublic = true under TIA's grant set.
+            //          That is the contract WPF binding depends on for #141.
+            // anything else encodes which type went back to internal (or the
+            // assembly stopped loading in the sandbox, which would also break
+            // binding).
+            result.Should().Be(
+                "C:OK",
+                "each pill VM bound by {Binding ...} must reflect as a public "
+                + "type from inside the sandbox; otherwise WPF binding fails "
+                + "silently under TIA Portal and the control renders blank (#141)");
+        }
+        finally
+        {
+            try { AppDomain.Unload(domain); }
+            finally { TryDeleteDir(baseDir); }
+        }
+    }
+
+    [UIFact]
+    public void Pill_internal_state_property_binds_through_wpf()
+    {
+        // Behavioural positive test (full trust): drive a real WPF {Binding}
+        // against a PillMultiSelectInternalState instance and verify the
+        // bound DependencyProperty receives the source value. This proves
+        // the surface that mattered for #141 — Label / IsOpen / HasSelection
+        // / SelectedCount on the internal state — actually resolves through
+        // WPF's binding engine end-to-end.
+        //
+        // Why this catches future regressions despite running in full trust:
+        // pairing it with the structural test above means "internal again"
+        // breaks the visibility gate, "renamed/removed bound property" breaks
+        // this one. Together they cover the silent-binding-failure mode that
+        // #141's TIA reproduction surfaced.
+        var pill = new PillMultiSelect();
+        pill.Label = "Bound";
+
+        var source = (PillMultiSelectInternalState)((FrameworkElement)pill.Content).DataContext;
+        source.IsOpen = true;
+
+        var target = new BindingTarget();
+        BindingOperations.SetBinding(target, BindingTarget.LabelValueProperty,
+            new Binding(nameof(PillMultiSelectInternalState.Label)) { Source = source, Mode = BindingMode.OneWay });
+        BindingOperations.SetBinding(target, BindingTarget.OpenValueProperty,
+            new Binding(nameof(PillMultiSelectInternalState.IsOpen)) { Source = source, Mode = BindingMode.OneWay });
+
+        target.LabelValue.Should().Be("Bound", "Label binding must resolve via reflection on the public VM type");
+        target.OpenValue.Should().Be(true, "IsOpen binding must resolve via reflection on the public VM type");
     }
 
     // The ORIGINAL deployed directory of an assembly. vstest shadow-copies
@@ -227,6 +334,72 @@ public sealed class PartialTrustWorker : MarshalByRefObject
         {
             return "B:ERR:" + ex.GetType().FullName + ":" + ex.Message;
         }
+    }
+
+    /// <summary>
+    /// #141 gate, run from inside the partial-trust sandbox. Loads
+    /// BlockParam.dll via <see cref="Assembly.Load(string)"/> — the same
+    /// code path PresentationFramework takes when it resolves bound types
+    /// for <c>{Binding}</c> — and asserts each pill VM type is reachable
+    /// and <see cref="Type.IsPublic"/>. If any went back to internal,
+    /// WPF binding fails silently in TIA and the pill renders blank.
+    /// </summary>
+    public string ProbePillVmTypeVisibility()
+    {
+        try
+        {
+            var asm = Assembly.Load("BlockParam");
+
+            var checks = new[]
+            {
+                "BlockParam.UI.Controls.PillMultiSelect.PillViewModelBase",
+                "BlockParam.UI.Controls.PillMultiSelect.PillMultiSelectInternalState",
+                "BlockParam.UI.Controls.PillMultiSelect.PillRowViewModel",
+                "BlockParam.UI.Controls.PillMultiSelect.PillGroupViewModel",
+            };
+
+            foreach (var fullName in checks)
+            {
+                var t = asm.GetType(fullName);
+                if (t == null) return "C:MISSING:" + fullName;
+                if (!t.IsPublic) return "C:INTERNAL:" + fullName;
+            }
+            return "C:OK";
+        }
+        catch (Exception ex)
+        {
+            return "C:ERR:" + ex.GetType().FullName + ":" + ex.Message;
+        }
+    }
+}
+
+/// <summary>
+/// Tiny <see cref="DependencyObject"/> used by the #141 binding test to
+/// receive bound values. Two DPs (string + bool) cover the property types
+/// the pill control's trigger renders against — Label (string),
+/// IsOpen / HasSelection (bool). Public so the WPF binding engine can
+/// reflect on it the same way it does on any host VM.
+/// </summary>
+public sealed class BindingTarget : DependencyObject
+{
+    public static readonly DependencyProperty LabelValueProperty =
+        DependencyProperty.Register(nameof(LabelValue), typeof(string), typeof(BindingTarget),
+            new PropertyMetadata(null));
+
+    public static readonly DependencyProperty OpenValueProperty =
+        DependencyProperty.Register(nameof(OpenValue), typeof(bool), typeof(BindingTarget),
+            new PropertyMetadata(false));
+
+    public string? LabelValue
+    {
+        get => (string?)GetValue(LabelValueProperty);
+        set => SetValue(LabelValueProperty, value);
+    }
+
+    public bool OpenValue
+    {
+        get => (bool)GetValue(OpenValueProperty);
+        set => SetValue(OpenValueProperty, value);
     }
 }
 

--- a/src/BlockParam/UI/Controls/PillMultiSelect/PillGroupTemplateConverters.cs
+++ b/src/BlockParam/UI/Controls/PillMultiSelect/PillGroupTemplateConverters.cs
@@ -12,7 +12,14 @@ namespace BlockParam.UI.Controls.PillMultiSelect;
 /// Used in <c>PillMultiSelect.xaml</c>'s shared GroupItem template to swap
 /// between the explicit-group header and the selected-first 1px divider.
 /// </summary>
-internal sealed class PillGroupHeaderVisibilityConverter : IValueConverter
+// `public`, not `internal`: this converter is referenced by XAML
+// `{StaticResource GroupHeaderVis}` and applied to a `{Binding ... Converter=…}`.
+// When grouping is active, WPF's binding pipeline reflects on the converter
+// instance from PresentationFramework — same partial-trust foreign-assembly
+// reflection rule as the bound pill VM types. See #141. Today no production
+// host enables grouping on the pill, but keep the safety net so the next one
+// doesn't reopen this bug.
+public sealed class PillGroupHeaderVisibilityConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         => value is PillGroupViewModel ? Visibility.Visible : Visibility.Collapsed;
@@ -28,7 +35,9 @@ internal sealed class PillGroupHeaderVisibilityConverter : IValueConverter
 /// and <see cref="Visibility.Collapsed"/> only when an explicit-group
 /// <see cref="PillGroupViewModel.IsExpanded"/> is <c>false</c>.
 /// </summary>
-internal sealed class PillGroupExpandedVisibilityConverter : IValueConverter
+// `public`, not `internal`: same #141 reasoning as
+// PillGroupHeaderVisibilityConverter above.
+public sealed class PillGroupExpandedVisibilityConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         => value is bool b && !b ? Visibility.Collapsed : Visibility.Visible;

--- a/src/BlockParam/UI/Controls/PillMultiSelect/PillGroupViewModel.cs
+++ b/src/BlockParam/UI/Controls/PillMultiSelect/PillGroupViewModel.cs
@@ -28,7 +28,12 @@ namespace BlockParam.UI.Controls.PillMultiSelect;
 /// row passing the filter and restores the prior value when search clears.
 /// </para>
 /// </remarks>
-internal sealed class PillGroupViewModel : PillViewModelBase
+// `public`, not `internal`: see PillViewModelBase comment / #141. The group
+// header template binds `{Binding Header}`, `{Binding IsSelected}`,
+// `{Binding IsExpanded}`, `{Binding SelectedCount}`, `{Binding TotalCount}`
+// against instances of this type — same partial-trust reflection failure
+// otherwise.
+public sealed class PillGroupViewModel : PillViewModelBase
 {
     private readonly List<PillRowViewModel> _children = new();
     private bool _isExpanded = true;

--- a/src/BlockParam/UI/Controls/PillMultiSelect/PillMultiSelectInternalState.cs
+++ b/src/BlockParam/UI/Controls/PillMultiSelect/PillMultiSelectInternalState.cs
@@ -43,7 +43,14 @@ namespace BlockParam.UI.Controls.PillMultiSelect;
 /// want localization bind the corresponding DPs on <see cref="PillMultiSelect"/>
 /// to their own resource lookup.
 /// </remarks>
-internal sealed class PillMultiSelectInternalState : PillViewModelBase
+// `public`, not `internal`: see PillViewModelBase comment / #141. WPF's
+// binding engine resolves `{Binding IsOpen}`, `{Binding HasSelection}`, etc.
+// against an instance of this type via reflection from PresentationFramework
+// (a foreign assembly). Under TIA's partial-trust SandboxDomain those
+// reflections silently fail for non-public types, producing the empty-pill
+// regression. The members are still control infrastructure — hosts use the
+// PillMultiSelect UserControl's DependencyProperties.
+public sealed class PillMultiSelectInternalState : PillViewModelBase
 {
     private readonly ObservableCollection<PillRowViewModel> _items;
     private readonly ListCollectionView _filteredView;

--- a/src/BlockParam/UI/Controls/PillMultiSelect/PillRelayCommand.cs
+++ b/src/BlockParam/UI/Controls/PillMultiSelect/PillRelayCommand.cs
@@ -5,7 +5,15 @@ namespace BlockParam.UI.Controls.PillMultiSelect;
 
 // Minimal ICommand for the pill control's footer buttons and toggle action.
 // Kept here so the folder has zero dependency on a host MVVM helper.
-internal sealed class PillRelayCommand : ICommand
+//
+// `public`, not `internal`: instances of this class are exposed through the
+// public `ICommand` properties on PillMultiSelectInternalState and bound via
+// `Command="{Binding ClearCommand}"` etc. Interface dispatch handles
+// Execute/CanExecute, but CommandManager.RequerySuggested re-evaluation and
+// some WPF binding diagnostics may reflect on the concrete type — keep the
+// type publicly reachable under TIA's partial-trust SandboxDomain so the
+// same #141 hazard class can't bite the command path.
+public sealed class PillRelayCommand : ICommand
 {
     private readonly Action<object?> _execute;
     private readonly Func<object?, bool>? _canExecute;

--- a/src/BlockParam/UI/Controls/PillMultiSelect/PillRowViewModel.cs
+++ b/src/BlockParam/UI/Controls/PillMultiSelect/PillRowViewModel.cs
@@ -26,7 +26,12 @@ namespace BlockParam.UI.Controls.PillMultiSelect;
 /// <see cref="OwningGroup"/> so the row can notify its group on selection
 /// changes without a tree walk.
 /// </remarks>
-internal sealed class PillRowViewModel : PillViewModelBase
+// `public`, not `internal`: see PillViewModelBase comment / #141. The row
+// DataTemplate binds `{Binding Display}`, `{Binding Abbreviation}`,
+// `{Binding IsSelected}` against instances of this type, which WPF resolves
+// by reflection — non-public under TIA's partial-trust SandboxDomain means
+// rows render blank.
+public sealed class PillRowViewModel : PillViewModelBase
 {
     private string _display;
     private string _abbreviation;

--- a/src/BlockParam/UI/Controls/PillMultiSelect/PillViewModelBase.cs
+++ b/src/BlockParam/UI/Controls/PillMultiSelect/PillViewModelBase.cs
@@ -6,7 +6,14 @@ namespace BlockParam.UI.Controls.PillMultiSelect;
 
 // Minimal INotifyPropertyChanged base for the pill control's internal VMs.
 // Kept here so the folder has zero dependency on a host MVVM helper.
-internal abstract class PillViewModelBase : INotifyPropertyChanged
+//
+// Must be `public`, not `internal`: WPF's binding engine reflects over bound
+// objects from PresentationFramework, a foreign assembly. Under TIA Portal's
+// partial-trust SandboxDomain, reflecting non-public types from a foreign
+// assembly is rejected and bindings yield no value — pill renders blank, the
+// trigger toggle doesn't write back. Full-trust CI/DevLauncher hides this.
+// See #141.
+public abstract class PillViewModelBase : INotifyPropertyChanged
 {
     public event PropertyChangedEventHandler? PropertyChanged;
 


### PR DESCRIPTION
## Root cause (#141)

The `PillMultiSelect` control's content `DataContext` is a `PillMultiSelectInternalState`; rows bind to `PillRowViewModel`; groups bind to `PillGroupViewModel`. WPF's binding engine reflects over those source objects from **PresentationFramework — a foreign assembly**. Under TIA Portal V20's partial-trust `SandboxDomain`, that reflection silently fails on **non-public types**: `{Binding Label}`, `{Binding IsOpen}`, `{Binding HasSelection}`, … all yield no value → pill renders as an empty blue badge + `X` with no label, and the trigger toggle never writes `IsOpen` back so the popup won't open.

Full-trust CI/DevLauncher hide this entirely, which is why #141 regressed twice before being root-caused live in TIA on `v0.155.1.0`.

Same hazard family as the `ldflda`-on-readonly-struct partial-trust IL crashes in `docs/research/06-addin-deployment.md` — different manifestation: a **silent binding failure**, not a `VerificationException`.

## Fix

Promote the four bound pill VM types from `internal` to `public`:

- `PillViewModelBase` (the INPC base — bindings walk the type hierarchy)
- `PillMultiSelectInternalState` (the content `DataContext`)
- `PillRowViewModel` (each row in the popup `ListBox`)
- `PillGroupViewModel` (group headers when `GroupKeyMemberPath` is set)

Their members were already `public`. Internal ctors / helpers stay internal — hosts still wire up through `PillMultiSelect`'s `DependencyProperties`, this only flips the type accessibility so PresentationFramework's reflection succeeds cross-assembly under TIA's grant set.

## Regression gates (`PartialTrustSandboxTests.cs`)

A full-trust-only green is how this bug shipped twice. Three new tests, all green locally:

- **Structural** (`Bound_pill_vm_types_are_public_for_partial_trust_binding`): each bound pill VM type must report `IsPublic`. Fast, exact, refuses a future "let's make this internal again."
- **Sandbox-loaded** (`Pill_vm_types_resolve_as_public_inside_partial_trust_sandbox`): same assertion run *from inside* the partial-trust `AppDomain` that mirrors TIA's grant set — exercises the `Assembly.Load(name)` code path PresentationFramework actually uses when it resolves bound types for `{Binding}`.
- **Behavioural** (`Pill_internal_state_property_binds_through_wpf`, `[UIFact]`): real `BindingOperations.SetBinding` driving `Binding("Label")` + `Binding("IsOpen")` on a `DependencyObject` against a `PillMultiSelectInternalState` instance — confirms the source values resolve all the way through into the target DPs end-to-end.

Pairing the structural gate with the behavioural one means: "internal again" breaks the visibility test; "renamed/removed bound property" breaks the binding test.

## Verification

- `dotnet build src/BlockParam/BlockParam.csproj -c Release` — clean (pre-existing CS8601 only)
- `dotnet test src/BlockParam.Tests` — 1158 / 1158 pass
- **Live in TIA Portal V20** on this branch's `BlockParam-141.addin` (v0.141.0): pill renders label + count, click opens the popup, selection round-trips. Reproducer DB (`Gen_Main_IDB`) confirmed resolved.

## Test plan

- [x] Full unit suite green (1158 pass)
- [x] V20 Release build clean
- [x] Manual TIA Portal V20 test on `Gen_Main_IDB`: pill renders, popup toggles
- [ ] CI green on PR

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)