### PR TITLE
fix(#146): cross-thread Apply progress + foreground recovery

### DIFF
--- a/src/BlockParam.Tests/ApplyProgressTests.cs
+++ b/src/BlockParam.Tests/ApplyProgressTests.cs
@@ -64,10 +64,19 @@ public class ApplyProgressTests : IDisposable
         {
             public string InitialStatus { get; }
             public List<string> Reports { get; } = new();
+            public List<string> Counters { get; } = new();
             public string? Summary { get; private set; }
             public int SummaryHoldMs { get; private set; }
             public int DisposeCount { get; private set; }
-            public bool Closed => DisposeCount > 0 || Summary != null;
+            public int SummaryCallCount { get; private set; }
+            // Mirrors the WpfApplyProgressHandle Interlocked gate: Dispose
+            // and ShowSummaryAndClose are mutually exclusive, only the first
+            // one called does work (review nit #6). Without this, the fake
+            // diverges from prod and a test that asserts "exactly one close
+            // path ran" would pass on the fake and fail on real WPF (or
+            // vice versa).
+            private int _closed;
+            public bool Closed => _closed != 0;
 
             public RecordingHandle(string initialStatus)
             {
@@ -76,13 +85,21 @@ public class ApplyProgressTests : IDisposable
 
             public void Report(string status) => Reports.Add(status);
 
+            public void SetCounter(string counter) => Counters.Add(counter);
+
             public void ShowSummaryAndClose(string summary, int holdMs)
             {
+                SummaryCallCount++;
+                if (System.Threading.Interlocked.Exchange(ref _closed, 1) != 0) return;
                 Summary = summary;
                 SummaryHoldMs = holdMs;
             }
 
-            public void Dispose() => DisposeCount++;
+            public void Dispose()
+            {
+                if (System.Threading.Interlocked.Exchange(ref _closed, 1) != 0) return;
+                DisposeCount++;
+            }
         }
     }
 
@@ -137,11 +154,36 @@ public class ApplyProgressTests : IDisposable
         vm.ApplyCommand.Execute(null);
 
         progress.Handles.Should().HaveCount(1, "plain Apply opens one session");
-        progress.Handles[0].DisposeCount.Should().BeGreaterOrEqualTo(1,
-            "the session must be closed so the splash thread tears down");
+        progress.Handles[0].DisposeCount.Should().Be(1,
+            "exactly one close path runs (the using-var Dispose) — pins the " +
+            "mutual-exclusion contract that ShowSummaryAndClose isn't also " +
+            "called on the plain-Apply path");
         progress.Handles[0].Summary.Should().BeNull(
             "plain Apply never holds a summary — dialog stays open and " +
             "StatusText repaints; a held splash would be duplicate noise");
+    }
+
+    /// <summary>
+    /// Apply &amp; Close: the close path runs via ShowSummaryAndClose, not via
+    /// the using-var Dispose. The two are mutually exclusive in production
+    /// (see <c>WpfApplyProgressHandle</c>'s <c>Interlocked.Exchange</c>
+    /// gate); this test pins that contract through the recording fake.
+    /// </summary>
+    [Fact]
+    public void ApplyAndClose_ClosesViaSummaryNotDispose()
+    {
+        var (vm, progress) = MakeVm();
+        vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+
+        vm.ApplyAndCloseCommand.Execute(null);
+
+        progress.Handles.Should().HaveCount(1);
+        progress.Handles[0].SummaryCallCount.Should().Be(1,
+            "Apply &amp; Close routes through ShowSummaryAndClose exactly once");
+        progress.Handles[0].DisposeCount.Should().Be(0,
+            "the subsequent using-var Dispose is gated and must be a no-op — " +
+            "double-closing the underlying splash would tear down its " +
+            "dispatcher thread twice");
     }
 
     /// <summary>
@@ -179,12 +221,15 @@ public class ApplyProgressTests : IDisposable
 
     /// <summary>
     /// ApplyFinished is raised on every Apply outcome so the dialog code-
-    /// behind can re-foreground above TIA. Verifies the success path; the
-    /// guarantee comes from the <c>finally</c> block so failure paths
-    /// fire too (covered by inspection — the finally is unconditional).
+    /// behind can re-foreground above TIA. The guarantee comes from the
+    /// <c>finally</c> block in <c>ExecuteApplyCore</c>; this and the two
+    /// failure-path tests below pin that — if a future edit moves the
+    /// <c>ApplyFinished?.Invoke()</c> line out of <c>finally</c> into the
+    /// <c>try</c> body, the failure paths will stop firing the event and
+    /// these tests fail.
     /// </summary>
     [Fact]
-    public void Apply_RaisesApplyFinished()
+    public void Apply_Success_RaisesApplyFinished()
     {
         var (vm, _) = MakeVm();
         vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
@@ -197,6 +242,76 @@ public class ApplyProgressTests : IDisposable
         finishedCount.Should().Be(1,
             "every Apply attempt must raise ApplyFinished so the host can " +
             "re-foreground the dialog above TIA (#146 H3)");
+    }
+
+    /// <summary>
+    /// User declined the compile-prompt on an inconsistent block (the
+    /// <c>OnApply</c> closure in <c>ActiveDbFactory</c> throws
+    /// <see cref="OperationCanceledException"/>). <c>CommitChanges</c>
+    /// catches it and returns false; the host must STILL receive
+    /// ApplyFinished so the dialog re-foregrounds. Pins the
+    /// <c>finally</c>-block contract on the user-cancel path.
+    /// </summary>
+    [Fact]
+    public void Apply_UserCancelDuringCommit_StillRaisesApplyFinished()
+    {
+        var xml = TestFixtures.LoadXml("flat-db.xml");
+        var db = new SimaticMLParser().Parse(xml);
+        var configLoader = CreateEmptyConfig();
+        var bulkService = new BulkChangeService(new ChangeLogger(), configLoader);
+        var vm = new BulkChangeViewModel(
+            db, xml, new HierarchyAnalyzer(), bulkService,
+            UsageTracker(), configLoader,
+            onApply: _ => throw new OperationCanceledException(
+                "User declined to compile the inconsistent block."),
+            applyProgress: new RecordingApplyProgress());
+        vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+
+        var finishedCount = 0;
+        vm.ApplyFinished += () => finishedCount++;
+
+        vm.ApplyCommand.Execute(null);
+
+        finishedCount.Should().Be(1,
+            "compile-cancel must still fire ApplyFinished — the dialog stays " +
+            "open and TIA may have stolen foreground during the failed export");
+    }
+
+    /// <summary>
+    /// <c>OnApply</c> threw a non-cancellation exception (e.g. TIA import
+    /// failed). The VM routes this through <c>HandleErrorWithRollback</c>
+    /// inside the catch. The <c>finally</c> must still raise
+    /// ApplyFinished so the dialog isn't left buried behind TIA after
+    /// the error dialog dismisses.
+    /// </summary>
+    [Fact]
+    public void Apply_ImportThrows_StillRaisesApplyFinished()
+    {
+        var xml = TestFixtures.LoadXml("flat-db.xml");
+        var db = new SimaticMLParser().Parse(xml);
+        var configLoader = CreateEmptyConfig();
+        var bulkService = new BulkChangeService(new ChangeLogger(), configLoader);
+        var messageBox = Substitute.For<IMessageBoxService>();
+        // No backup callback wired → the error path goes to the
+        // "no backup available" branch which just sets a status string
+        // (no user prompt), so the test runs without an interactive stub.
+        var vm = new BulkChangeViewModel(
+            db, xml, new HierarchyAnalyzer(), bulkService,
+            UsageTracker(), configLoader,
+            onApply: _ => throw new InvalidOperationException("TIA import failed"),
+            messageBox: messageBox,
+            applyProgress: new RecordingApplyProgress());
+        vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+
+        var finishedCount = 0;
+        vm.ApplyFinished += () => finishedCount++;
+
+        vm.ApplyCommand.Execute(null);
+
+        finishedCount.Should().Be(1,
+            "exception during import must still fire ApplyFinished from the " +
+            "finally block — without it the dialog stays buried behind TIA " +
+            "after the error MessageBox dismisses");
     }
 
     /// <summary>

--- a/src/BlockParam.Tests/ApplyProgressTests.cs
+++ b/src/BlockParam.Tests/ApplyProgressTests.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using BlockParam.Config;
+using BlockParam.Licensing;
+using BlockParam.Services;
+using BlockParam.SimaticML;
+using BlockParam.UI;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Coverage for the Apply progress orchestration introduced in #146. The
+/// production splash lives on its own STA dispatcher thread and is not
+/// exercised here — these tests pin the orchestration contract:
+///
+/// <list type="bullet">
+///   <item><description>Every Apply attempt opens exactly one progress
+///   session (the user always sees an indicator, even when Apply early-
+///   returns post-write).</description></item>
+///   <item><description>The handle is always disposed — no dangling
+///   splash thread after success, cancel, or exception.</description></item>
+///   <item><description>Apply &amp; Close fires <c>ShowSummaryAndClose</c>
+///   so the user sees a "✓ Applied N" line before the host dialog
+///   vanishes (the core trust gap from #146).</description></item>
+///   <item><description>Plain Apply never fires <c>ShowSummaryAndClose</c>
+///   — its dialog stays open and StatusText repaints, so a held summary
+///   would be duplicate noise.</description></item>
+///   <item><description><c>ApplyFinished</c> is raised on every code
+///   path so the host dialog can re-foreground above TIA.</description></item>
+/// </list>
+/// </summary>
+public class ApplyProgressTests : IDisposable
+{
+    private readonly List<string> _tempDirs = new();
+
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirs)
+        {
+            try { System.IO.Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Recording fake — captures Begin/Report/ShowSummaryAndClose/Dispose
+    /// calls so tests can assert the orchestration shape without spinning
+    /// up a real WPF splash.
+    /// </summary>
+    private sealed class RecordingApplyProgress : IApplyProgressService
+    {
+        public List<RecordingHandle> Handles { get; } = new();
+
+        public IApplyProgressHandle Begin(string initialStatus)
+        {
+            var h = new RecordingHandle(initialStatus);
+            Handles.Add(h);
+            return h;
+        }
+
+        public sealed class RecordingHandle : IApplyProgressHandle
+        {
+            public string InitialStatus { get; }
+            public List<string> Reports { get; } = new();
+            public string? Summary { get; private set; }
+            public int SummaryHoldMs { get; private set; }
+            public int DisposeCount { get; private set; }
+            public bool Closed => DisposeCount > 0 || Summary != null;
+
+            public RecordingHandle(string initialStatus)
+            {
+                InitialStatus = initialStatus;
+            }
+
+            public void Report(string status) => Reports.Add(status);
+
+            public void ShowSummaryAndClose(string summary, int holdMs)
+            {
+                Summary = summary;
+                SummaryHoldMs = holdMs;
+            }
+
+            public void Dispose() => DisposeCount++;
+        }
+    }
+
+    private ConfigLoader CreateEmptyConfig()
+    {
+        var tempDir = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(),
+            $"test_apply_progress_{Guid.NewGuid():N}");
+        System.IO.Directory.CreateDirectory(tempDir);
+        _tempDirs.Add(tempDir);
+        var configPath = System.IO.Path.Combine(tempDir, "config.json");
+        System.IO.File.WriteAllText(configPath, @"{ ""rules"": [] }");
+        return new ConfigLoader(configPath);
+    }
+
+    private static IUsageTracker UsageTracker(int used = 0, int limit = 200)
+    {
+        var t = Substitute.For<IUsageTracker>();
+        t.GetStatus().Returns(new UsageStatus(used, limit));
+        t.RecordUsage(Arg.Any<int>()).Returns(true);
+        return t;
+    }
+
+    private (BulkChangeViewModel vm, RecordingApplyProgress progress) MakeVm(
+        IUsageTracker? usageTracker = null)
+    {
+        var xml = TestFixtures.LoadXml("flat-db.xml");
+        var db = new SimaticMLParser().Parse(xml);
+        var analyzer = new HierarchyAnalyzer();
+        var configLoader = CreateEmptyConfig();
+        var bulkService = new BulkChangeService(new ChangeLogger(), configLoader);
+        var progress = new RecordingApplyProgress();
+        var vm = new BulkChangeViewModel(
+            db, xml, analyzer, bulkService,
+            usageTracker ?? UsageTracker(),
+            configLoader,
+            onApply: _ => { /* no-op — we are not testing the import side */ },
+            applyProgress: progress);
+        return (vm, progress);
+    }
+
+    /// <summary>
+    /// Apply opens exactly one progress session and disposes it. The user
+    /// always sees a "Working…" indicator, regardless of how many edits.
+    /// </summary>
+    [Fact]
+    public void Apply_OpensAndClosesOneProgressSession()
+    {
+        var (vm, progress) = MakeVm();
+        vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+
+        vm.ApplyCommand.Execute(null);
+
+        progress.Handles.Should().HaveCount(1, "plain Apply opens one session");
+        progress.Handles[0].DisposeCount.Should().BeGreaterOrEqualTo(1,
+            "the session must be closed so the splash thread tears down");
+        progress.Handles[0].Summary.Should().BeNull(
+            "plain Apply never holds a summary — dialog stays open and " +
+            "StatusText repaints; a held splash would be duplicate noise");
+    }
+
+    /// <summary>
+    /// Apply &amp; Close holds a "✓ Applied N" summary on the splash before
+    /// closing. This is the core trust-gap fix from #146: without it the
+    /// host dialog vanishes the same tick and the user has no confirmation
+    /// anything happened.
+    /// </summary>
+    [Fact]
+    public void ApplyAndClose_HoldsSummaryOnSplashBeforeClose()
+    {
+        var (vm, progress) = MakeVm();
+        vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+
+        var closeFiredAtSummary = false;
+        vm.RequestClose += () =>
+        {
+            // Capture whether a summary was set by the time the close
+            // signal arrived — guards against a future refactor that
+            // re-orders close before the summary call.
+            closeFiredAtSummary = progress.Handles[0].Summary != null;
+        };
+
+        vm.ApplyAndCloseCommand.Execute(null);
+
+        progress.Handles.Should().HaveCount(1);
+        progress.Handles[0].Summary.Should().NotBeNullOrEmpty(
+            "Apply &amp; Close must surface a summary on the splash");
+        progress.Handles[0].SummaryHoldMs.Should().BeGreaterThan(0,
+            "the hold must be non-zero so the user actually sees it");
+        closeFiredAtSummary.Should().BeTrue(
+            "RequestClose must fire AFTER the summary is set — otherwise " +
+            "the dialog vanishes and the splash's summary becomes invisible");
+    }
+
+    /// <summary>
+    /// ApplyFinished is raised on every Apply outcome so the dialog code-
+    /// behind can re-foreground above TIA. Verifies the success path; the
+    /// guarantee comes from the <c>finally</c> block so failure paths
+    /// fire too (covered by inspection — the finally is unconditional).
+    /// </summary>
+    [Fact]
+    public void Apply_RaisesApplyFinished()
+    {
+        var (vm, _) = MakeVm();
+        vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+
+        var finishedCount = 0;
+        vm.ApplyFinished += () => finishedCount++;
+
+        vm.ApplyCommand.Execute(null);
+
+        finishedCount.Should().Be(1,
+            "every Apply attempt must raise ApplyFinished so the host can " +
+            "re-foreground the dialog above TIA (#146 H3)");
+    }
+
+    /// <summary>
+    /// Over-quota Apply early-returns BEFORE the progress session opens
+    /// (no work happens), so the splash never appears. This matches the
+    /// existing over-quota guard at <c>ExecuteApplyCore</c> — surfacing a
+    /// splash just to flash and close would be jarring.
+    /// </summary>
+    [Fact]
+    public void Apply_OverQuota_DoesNotOpenProgressSession()
+    {
+        // 200/200 used → RemainingToday == 0; even one pending edit is over-cap.
+        var (vm, progress) = MakeVm(usageTracker: UsageTracker(used: 200, limit: 200));
+        vm.Tree.RootMembers.Single(m => m.Name == "Enable").EditableStartValue = "false";
+
+        vm.ApplyCommand.Execute(null);
+
+        progress.Handles.Should().BeEmpty(
+            "the over-quota guard early-returns before the import phase " +
+            "— no splash should flash on the user");
+    }
+
+    /// <summary>
+    /// The NoOp service hands out a handle whose Report / ShowSummary /
+    /// Dispose never throw. This is the default for tests and DevLauncher
+    /// where the real WPF splash would spin up unwanted dispatcher
+    /// threads on every Apply.
+    /// </summary>
+    [Fact]
+    public void NoOpService_IsSafelyCallable()
+    {
+        IApplyProgressService svc = new NoOpApplyProgressService();
+        var handle = svc.Begin("starting");
+        handle.Report("step 1");
+        handle.ShowSummaryAndClose("done", holdMs: 50);
+        handle.Dispose();
+        // Reach this line without exception → contract satisfied.
+    }
+}

--- a/src/BlockParam/AddIn/BulkChangeContextMenu.cs
+++ b/src/BlockParam/AddIn/BulkChangeContextMenu.cs
@@ -376,7 +376,13 @@ public class BulkChangeContextMenu : ContextMenuAddIn
                     : null,
                 onInvalidateUdtSession: plcSoftware != null
                     ? new Action(() => _udtValidationGate.Invalidate(scope))
-                    : null);
+                    : null,
+                // #146: Apply-time progress splash. Lives on its own STA
+                // dispatcher so it keeps painting while TIA's UI thread is
+                // blocked in Openness `Blocks.Import`. The default in the VM
+                // is a NoOp so headless tests / DevLauncher don't spin up
+                // real windows; only the in-process Add-In wires the WPF impl.
+                applyProgress: new BlockParam.Services.WpfApplyProgressService());
 
             licenseService.StartHeartbeat();
 

--- a/src/BlockParam/BlockParam.csproj
+++ b/src/BlockParam/BlockParam.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>BlockParam</RootNamespace>
     <AssemblyName>BlockParam</AssemblyName>
-    <Version>1.0.14</Version>
+    <Version>0.146.0</Version>
     <Authors>Sawascwoolf</Authors>
     <Description>TIA Portal Add-In for editing Data Block start values and parameters — single and in bulk</Description>
     <ApplicationIcon>Resources\BlockParam_logo.ico</ApplicationIcon>

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -386,8 +386,7 @@ Beim Schließen des Dialogs werden sie verworfen. Trotzdem schließen?</value><c
   <data name="Splash_Counter" xml:space="preserve"><value>({0} von {1})</value></data>
   <!-- Apply-Fortschritts-Splash (#146) -->
   <data name="Apply_Progress_Title" xml:space="preserve"><value>Änderungen werden übernommen</value></data>
-  <data name="Apply_Progress_Working" xml:space="preserve"><value>Änderungen werden in {0} geschrieben…</value><comment>{0} = DB-Name</comment></data>
-  <data name="Apply_Progress_WorkingMultiDb" xml:space="preserve"><value>Änderungen werden in {0} DBs geschrieben…</value><comment>{0} = Anzahl aktiver DBs</comment></data>
-  <data name="Apply_Progress_Summary" xml:space="preserve"><value>✓ {0} Änderung(en) in {1} übernommen</value><comment>{0} = Anzahl, {1} = DB-Name</comment></data>
-  <data name="Apply_Progress_SummaryMultiDb" xml:space="preserve"><value>✓ {0} Änderung(en) in {1} DBs übernommen</value><comment>{0} = Anzahl, {1} = DB-Anzahl</comment></data>
+  <data name="Apply_Progress_Working" xml:space="preserve"><value>Änderungen werden in {0} geschrieben…</value><comment>{0} = DB-Name. Multi-DB-Batch-Kontext läuft über Splash_Counter via SetCounter, nicht mehr über eine separate "in N DBs"-Zeile.</comment></data>
+  <data name="Apply_Progress_Summary" xml:space="preserve"><value>✓ {0} Änderung(en) in {1} übernommen</value><comment>{0} = Anzahl, {1} = DB-Name. Führendes Zeichen ist U+2713 CHECK MARK — beim Übersetzen Byte-für-Byte erhalten.</comment></data>
+  <data name="Apply_Progress_SummaryMultiDb" xml:space="preserve"><value>✓ {0} Änderung(en) in {1} DBs übernommen</value><comment>{0} = Anzahl, {1} = DB-Anzahl. Führendes Zeichen ist U+2713 CHECK MARK — beim Übersetzen Byte-für-Byte erhalten.</comment></data>
 </root>

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -384,4 +384,10 @@ Beim Schließen des Dialogs werden sie verworfen. Trotzdem schließen?</value><c
   <data name="Splash_ParsingDb" xml:space="preserve"><value>{0} wird analysiert…</value></data>
   <data name="Splash_LoadingConfig" xml:space="preserve"><value>Konfiguration wird geladen…</value></data>
   <data name="Splash_Counter" xml:space="preserve"><value>({0} von {1})</value></data>
+  <!-- Apply-Fortschritts-Splash (#146) -->
+  <data name="Apply_Progress_Title" xml:space="preserve"><value>Änderungen werden übernommen</value></data>
+  <data name="Apply_Progress_Working" xml:space="preserve"><value>Änderungen werden in {0} geschrieben…</value><comment>{0} = DB-Name</comment></data>
+  <data name="Apply_Progress_WorkingMultiDb" xml:space="preserve"><value>Änderungen werden in {0} DBs geschrieben…</value><comment>{0} = Anzahl aktiver DBs</comment></data>
+  <data name="Apply_Progress_Summary" xml:space="preserve"><value>✓ {0} Änderung(en) in {1} übernommen</value><comment>{0} = Anzahl, {1} = DB-Name</comment></data>
+  <data name="Apply_Progress_SummaryMultiDb" xml:space="preserve"><value>✓ {0} Änderung(en) in {1} DBs übernommen</value><comment>{0} = Anzahl, {1} = DB-Anzahl</comment></data>
 </root>

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -1036,19 +1036,15 @@ Continue?</value>
   </data>
   <data name="Apply_Progress_Working" xml:space="preserve">
     <value>Applying changes to {0}…</value>
-    <comment>{0} = DB name</comment>
-  </data>
-  <data name="Apply_Progress_WorkingMultiDb" xml:space="preserve">
-    <value>Applying changes to {0} DBs…</value>
-    <comment>{0} = active DB count</comment>
+    <comment>{0} = DB name. Used for single-DB Apply and for each per-DB step of multi-DB Apply; the multi-DB batch counter rides on Splash_Counter via SetCounter.</comment>
   </data>
   <data name="Apply_Progress_Summary" xml:space="preserve">
     <value>✓ Applied {0} change(s) to {1}</value>
-    <comment>{0} = change count, {1} = DB name. Held briefly on the splash before Apply &amp; Close dismisses the host dialog.</comment>
+    <comment>{0} = change count, {1} = DB name. Held briefly on the splash before Apply &amp; Close dismisses the host dialog. Leading glyph is U+2713 CHECK MARK — preserve byte-for-byte when translating.</comment>
   </data>
   <data name="Apply_Progress_SummaryMultiDb" xml:space="preserve">
     <value>✓ Applied {0} change(s) across {1} DBs</value>
-    <comment>{0} = total change count, {1} = DB count</comment>
+    <comment>{0} = total change count, {1} = DB count. Leading glyph is U+2713 CHECK MARK — preserve byte-for-byte when translating.</comment>
   </data>
   <data name="Splash_Preparing" xml:space="preserve">
     <value>Preparing…</value>

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -1028,6 +1028,28 @@ Continue?</value>
   <data name="Splash_Title" xml:space="preserve">
     <value>Bulk Change</value>
   </data>
+  <!-- Apply-time progress splash (#146). Shown by ApplyProgressService while
+       the synchronous Openness import blocks TIA's dispatcher; lives on its
+       own STA thread so the indeterminate marquee keeps animating. -->
+  <data name="Apply_Progress_Title" xml:space="preserve">
+    <value>Applying changes</value>
+  </data>
+  <data name="Apply_Progress_Working" xml:space="preserve">
+    <value>Applying changes to {0}…</value>
+    <comment>{0} = DB name</comment>
+  </data>
+  <data name="Apply_Progress_WorkingMultiDb" xml:space="preserve">
+    <value>Applying changes to {0} DBs…</value>
+    <comment>{0} = active DB count</comment>
+  </data>
+  <data name="Apply_Progress_Summary" xml:space="preserve">
+    <value>✓ Applied {0} change(s) to {1}</value>
+    <comment>{0} = change count, {1} = DB name. Held briefly on the splash before Apply &amp; Close dismisses the host dialog.</comment>
+  </data>
+  <data name="Apply_Progress_SummaryMultiDb" xml:space="preserve">
+    <value>✓ Applied {0} change(s) across {1} DBs</value>
+    <comment>{0} = total change count, {1} = DB count</comment>
+  </data>
   <data name="Splash_Preparing" xml:space="preserve">
     <value>Preparing…</value>
   </data>

--- a/src/BlockParam/Services/ApplyProgressService.cs
+++ b/src/BlockParam/Services/ApplyProgressService.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Threading;
+using BlockParam.Localization;
+using BlockParam.UI;
+
+namespace BlockParam.Services;
+
+/// <summary>
+/// Apply-time progress feedback (#146). The TIA Openness import is
+/// synchronous and bound to the TIA process thread — we cannot move it off
+/// the dispatcher. Instead, the splash runs on its OWN STA dispatcher (same
+/// mechanism as the open-time splash, #125), so the indeterminate
+/// progress + "Applying…" status stay painted even while TIA's UI thread
+/// is frozen inside <c>Blocks.Import</c>.
+///
+/// <para>The splash is also <c>Topmost</c>, which addresses the second
+/// half of #146: TIA's main window activates during import and would
+/// otherwise bury the ownerless BulkChangeDialog. The splash sits above
+/// TIA the entire time; after dispose, the dialog itself re-foregrounds
+/// via a brief Topmost flip (see <see cref="BulkChangeDialog"/>).</para>
+///
+/// <para>Tests/DevLauncher inject <see cref="NoOpApplyProgressService"/>;
+/// production wires <see cref="WpfApplyProgressService"/> from
+/// <c>BulkChangeContextMenu</c>.</para>
+/// </summary>
+public interface IApplyProgressService
+{
+    /// <summary>
+    /// Begins an Apply progress session. Caller must dispose the returned
+    /// handle (e.g. via <c>using</c>) — that dismisses the splash.
+    /// </summary>
+    IApplyProgressHandle Begin(string initialStatus);
+}
+
+/// <summary>
+/// Live handle to one Apply progress session. Disposing closes the splash.
+/// </summary>
+public interface IApplyProgressHandle : IDisposable
+{
+    /// <summary>Updates the primary status line ("Applying changes to DB_X…").</summary>
+    void Report(string status);
+
+    /// <summary>
+    /// Shows a success summary on the splash and blocks the caller for
+    /// <paramref name="holdMs"/> milliseconds so the user actually sees it
+    /// before the splash (and typically the host dialog) closes. The splash
+    /// continues to paint during the hold because it lives on its own
+    /// dispatcher.
+    /// </summary>
+    void ShowSummaryAndClose(string summary, int holdMs);
+}
+
+/// <summary>
+/// Production implementation backed by <see cref="LoadingSplashController"/>
+/// (the same cross-thread splash used at dialog open, #125). Every
+/// <see cref="Begin"/> call spawns a fresh STA dispatcher thread; dispose
+/// tears it back down. The cost (~few ms) is bounded — Apply is a rare,
+/// user-initiated gesture.
+/// </summary>
+public sealed class WpfApplyProgressService : IApplyProgressService
+{
+    public IApplyProgressHandle Begin(string initialStatus)
+    {
+        var splash = new LoadingSplashController(Res.Get("Apply_Progress_Title"));
+        splash.Show();
+        splash.Report(initialStatus);
+        return new WpfApplyProgressHandle(splash);
+    }
+
+    private sealed class WpfApplyProgressHandle : IApplyProgressHandle
+    {
+        private readonly LoadingSplashController _splash;
+        private int _disposed;
+
+        public WpfApplyProgressHandle(LoadingSplashController splash)
+        {
+            _splash = splash;
+        }
+
+        public void Report(string status)
+        {
+            if (Volatile.Read(ref _disposed) != 0) return;
+            _splash.Report(status);
+        }
+
+        public void ShowSummaryAndClose(string summary, int holdMs)
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+            _splash.Report(summary);
+            if (holdMs > 0)
+            {
+                // Thread.Sleep on the TIA dispatcher is OK here: the splash
+                // paints on its own thread, the host dialog is about to
+                // close (or already in a stable post-Apply state), and the
+                // hold is short enough to be perceived as confirmation
+                // rather than a hang.
+                Thread.Sleep(holdMs);
+            }
+            _splash.Close();
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+            _splash.Close();
+        }
+    }
+}
+
+/// <summary>
+/// No-op fallback used by unit tests and DevLauncher so Apply paths don't
+/// spin up an STA dispatcher window during headless runs.
+/// </summary>
+public sealed class NoOpApplyProgressService : IApplyProgressService
+{
+    public IApplyProgressHandle Begin(string initialStatus) => NoOpHandle.Instance;
+
+    private sealed class NoOpHandle : IApplyProgressHandle
+    {
+        public static readonly NoOpHandle Instance = new();
+        public void Report(string status) { }
+        public void ShowSummaryAndClose(string summary, int holdMs) { }
+        public void Dispose() { }
+    }
+}

--- a/src/BlockParam/Services/ApplyProgressService.cs
+++ b/src/BlockParam/Services/ApplyProgressService.cs
@@ -41,6 +41,15 @@ public interface IApplyProgressHandle : IDisposable
     void Report(string status);
 
     /// <summary>
+    /// Sets the secondary "(N of M)" counter line, or clears it with an
+    /// empty string. Used by multi-DB Apply to keep batch context ("DB 2
+    /// of 5") visible while <see cref="Report"/> cycles the primary line
+    /// through per-DB names — without this the multi-DB context flashed
+    /// for one tick and was gone (#146 review nit #4).
+    /// </summary>
+    void SetCounter(string counter);
+
+    /// <summary>
     /// Shows a success summary on the splash and blocks the caller for
     /// <paramref name="holdMs"/> milliseconds so the user actually sees it
     /// before the splash (and typically the host dialog) closes. The splash
@@ -83,6 +92,12 @@ public sealed class WpfApplyProgressService : IApplyProgressService
             _splash.Report(status);
         }
 
+        public void SetCounter(string counter)
+        {
+            if (Volatile.Read(ref _disposed) != 0) return;
+            _splash.SetCounter(counter);
+        }
+
         public void ShowSummaryAndClose(string summary, int holdMs)
         {
             if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
@@ -119,6 +134,7 @@ public sealed class NoOpApplyProgressService : IApplyProgressService
     {
         public static readonly NoOpHandle Instance = new();
         public void Report(string status) { }
+        public void SetCounter(string counter) { }
         public void ShowSummaryAndClose(string summary, int holdMs) { }
         public void Dispose() { }
     }

--- a/src/BlockParam/UI/BulkChangeDialog.xaml.cs
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml.cs
@@ -42,16 +42,42 @@ public partial class BulkChangeDialog : Window
         viewModel.RequestClose += () => Close();
         viewModel.FlatListRefreshed += RehydrateManualSelection;
         viewModel.Inspector.PropertyChanged += OnInspectorPropertyChanged;
-        Closed += (_, _) => viewModel.Dispose();
+        // #146 H3: after each Apply, briefly flip Topmost so the dialog
+        // re-foregrounds above TIA. TIA activates its main window during
+        // Openness Import and would otherwise leave this (ownerless,
+        // not-Topmost) dialog buried behind it once the splash dismisses.
+        // Same dance as the Loaded handler below; raised on every Apply
+        // outcome so failures don't strand the user behind TIA either.
+        viewModel.ApplyFinished += BringDialogToForeground;
+        Closed += (_, _) =>
+        {
+            // Detach so a late-firing ApplyFinished (e.g. from a slow
+            // failure path) can't touch a disposed window.
+            viewModel.ApplyFinished -= BringDialogToForeground;
+            viewModel.Dispose();
+        };
 
         // Briefly set Topmost to appear above TIA Portal, then release
         // so other windows (non-TIA) can go in front.
-        Loaded += (_, _) =>
+        Loaded += (_, _) => BringDialogToForeground();
+    }
+
+    /// <summary>
+    /// Topmost flip to pull the dialog above TIA's main window. Cheap and
+    /// idempotent; called from <c>Loaded</c> and after every Apply (#146).
+    /// </summary>
+    private void BringDialogToForeground()
+    {
+        // Dispatcher hop guards against the rare case where the VM raises
+        // ApplyFinished while the close handler has already detached but the
+        // window is still alive — and keeps the flip cheap when Apply &amp;
+        // Close is about to fire RequestClose right after.
+        Dispatcher.BeginInvoke(new Action(() =>
         {
             Topmost = true;
             Activate();
             Topmost = false;
-        };
+        }), System.Windows.Threading.DispatcherPriority.Background);
     }
 
     private void OnInspectorPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/src/BlockParam/UI/BulkChangeDialog.xaml.cs
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml.cs
@@ -65,19 +65,19 @@ public partial class BulkChangeDialog : Window
     /// <summary>
     /// Topmost flip to pull the dialog above TIA's main window. Cheap and
     /// idempotent; called from <c>Loaded</c> and after every Apply (#146).
+    /// Runs synchronously: <c>ApplyFinished</c> is raised from the VM's
+    /// <c>finally</c> block BEFORE <c>RequestClose</c> fires on the same
+    /// dispatcher tick, so the close-then-flip race only existed when the
+    /// flip was deferred via <c>Dispatcher.BeginInvoke</c>. Sync also matches
+    /// the pre-#146 <c>Loaded</c> behaviour — deferring it had momentarily
+    /// left the just-opened dialog non-Topmost, exactly the window where
+    /// TIA's main HWND could bury it on first open.
     /// </summary>
     private void BringDialogToForeground()
     {
-        // Dispatcher hop guards against the rare case where the VM raises
-        // ApplyFinished while the close handler has already detached but the
-        // window is still alive — and keeps the flip cheap when Apply &amp;
-        // Close is about to fire RequestClose right after.
-        Dispatcher.BeginInvoke(new Action(() =>
-        {
-            Topmost = true;
-            Activate();
-            Topmost = false;
-        }), System.Windows.Threading.DispatcherPriority.Background);
+        Topmost = true;
+        Activate();
+        Topmost = false;
     }
 
     private void OnInspectorPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -72,6 +72,19 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     private readonly SimaticMLWriter _writer = new();
     private readonly MemberSearchService _searchService = new();
     private readonly IMessageBoxService _messageBox;
+    // Apply-time progress feedback (#146). Wrapped around every Openness
+    // import so TIA's blocked dispatcher doesn't manifest as a "(Not
+    // Responding)" main window with no Add-In feedback. Default is the
+    // NoOp impl so headless tests / DevLauncher don't spin up an STA
+    // dispatcher window; production wires WpfApplyProgressService from
+    // BulkChangeContextMenu.
+    private readonly IApplyProgressService _applyProgress;
+    // How long the "✓ Applied N values" summary stays on the splash before
+    // Apply &amp; Close fires RequestClose. The splash keeps painting on its
+    // own dispatcher during the hold, so this is purely a perceived-
+    // confirmation pause — without it the dialog vanishes the same tick
+    // and the user has no idea whether anything happened.
+    private const int ApplySummaryHoldMs = 900;
 
     /// <summary>
     /// Exposes the message-box service so headless capture tooling (e.g.
@@ -181,9 +194,13 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         Func<DataBlockSummary, ActiveDb?>? buildActiveDbForSummary = null,
         Action? onRefreshDataBlocks = null,
         Action? onInvalidateTagTableSession = null,
-        Action? onInvalidateUdtSession = null)
+        Action? onInvalidateUdtSession = null,
+        IApplyProgressService? applyProgress = null)
     {
         _dispatcher = Dispatcher.CurrentDispatcher;
+        // Default to NoOp so headless tests and DevLauncher don't accidentally
+        // spin up the cross-thread splash on every Apply (#146).
+        _applyProgress = applyProgress ?? new NoOpApplyProgressService();
         _projectLanguages = projectLanguages is { Count: > 0 } ? projectLanguages : new[] { "en-GB" };
         _commentLanguagePolicy = new CommentLanguagePolicy(editingLanguage, referenceLanguage, _projectLanguages);
 
@@ -425,6 +442,16 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     public SearchFilterViewModel Filter { get; }
 
     public event Action? RequestClose;
+
+    /// <summary>
+    /// Raised on the dispatcher thread once each Apply attempt finishes —
+    /// success, user-cancel, or exception. The dialog code-behind subscribes
+    /// to re-foreground the host window via a brief Topmost flip (#146): TIA
+    /// activates its main window during Openness <c>Import</c>, and without
+    /// this nudge the (ownerless, not-Topmost) dialog stays buried behind
+    /// TIA after the splash dismisses.
+    /// </summary>
+    public event Action? ApplyFinished;
 
     /// <summary>True if Apply was used but changes not yet committed to TIA.</summary>
     public bool HasPendingChanges
@@ -2288,8 +2315,12 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
     /// <summary>
     /// Applies ALL pending changes (bulk-staged + inline edits) to XML.
+    /// Plain Apply: dialog stays open, no summary hold needed (StatusText
+    /// repaints once the dispatcher unblocks).
     /// </summary>
-    private void ExecuteApply()
+    private void ExecuteApply() => ExecuteApplyCore(showSummary: false);
+
+    private void ExecuteApplyCore(bool showSummary)
     {
         // Multi-DB Apply (#58): when more than one DB is active, iterate
         // every active DB, write each one's pending edits into its own xml,
@@ -2299,7 +2330,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         // is one TIA undo step (matches issue #58 decision).
         if (ActiveSet.State.Dbs.Count > 1)
         {
-            ExecuteApplyMultiDb();
+            ExecuteApplyMultiDb(showSummary);
             return;
         }
 
@@ -2339,6 +2370,15 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             Log.Warning(backupEx, "Backup failed, continuing without backup");
         }
 
+        // #146: open the cross-thread progress splash BEFORE the blocking
+        // Openness work begins. The splash paints on its own STA dispatcher
+        // so it stays interactive while TIA's UI thread is frozen inside
+        // Blocks.Import — and because it is Topmost, TIA can't bury it
+        // mid-import. ApplyFinished is raised in `finally` so the host
+        // dialog re-foregrounds on every code path (success / cancel /
+        // exception), not just the happy path.
+        using var progress = _applyProgress.Begin(
+            Res.Format("Apply_Progress_Working", _active.Info.Name));
         try
         {
             // #159 H1: one parse + serialize for the whole pending batch
@@ -2435,11 +2475,31 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             // RefreshTree/PatchTreeAfterApply clear PendingValue, but computed
             // properties only refresh their bindings when PropertyChanged is raised.
             RefreshPendingAndPreview();
+
+            // #146: Apply &amp; Close fires RequestClose the same tick this method
+            // returns. Without a held summary, the dialog vanishes and the user
+            // has no visible confirmation that N values landed. Pin the splash
+            // on a success line for a brief beat before disposing — the splash
+            // keeps painting on its own thread during the hold.
+            if (showSummary)
+            {
+                progress.ShowSummaryAndClose(
+                    Res.Format("Apply_Progress_Summary", totalChanged, _active.Info.Name),
+                    ApplySummaryHoldMs);
+            }
         }
         catch (Exception ex)
         {
             Log.Error(ex, "Apply threw exception");
             HandleErrorWithRollback(ex, backupPath);
+        }
+        finally
+        {
+            // Re-foreground the host dialog (#146 H3): TIA activates its main
+            // window during Openness Import and would otherwise leave the
+            // ownerless dialog buried behind it. Raised on every Apply outcome
+            // so the user is never stranded behind TIA, even on failures.
+            ApplyFinished?.Invoke();
         }
 
         Subscription.UpdateUsageStatus();
@@ -2447,7 +2507,10 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
     private void ExecuteApplyAndClose()
     {
-        ExecuteApply();
+        // Pass showSummary=true: the Apply core holds a "✓ Applied N values"
+        // line on the splash for ApplySummaryHoldMs before disposing, so the
+        // user sees confirmation before the dialog vanishes (#146).
+        ExecuteApplyCore(showSummary: true);
         if (_lastApplySucceeded)
             RequestClose?.Invoke();
     }
@@ -2460,7 +2523,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
     /// Quota is charged once on the sum across all DBs — a single
     /// freemium counter increment (#58 decision: no separate multi-DB cap).
     /// </summary>
-    private void ExecuteApplyMultiDb()
+    private void ExecuteApplyMultiDb(bool showSummary)
     {
         _lastApplySucceeded = false;
 
@@ -2510,6 +2573,11 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             Log.Warning(backupEx, "Backup failed, continuing without backup");
         }
 
+        // #146: cross-thread progress splash for multi-DB Apply — mirrors
+        // single-DB. Use the MultiDb status string so the user knows the
+        // batch spans more than one DB.
+        using var progress = _applyProgress.Begin(
+            Res.Format("Apply_Progress_WorkingMultiDb", perDb.Count));
         try
         {
             int totalChanged = 0;
@@ -2550,6 +2618,10 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             string? cancelledOnDb = null;
             foreach (var (db, edits) in perDb)
             {
+                // Per-DB status line so the user sees forward progress on
+                // long multi-DB Applies (#146). Pre-localized on this thread;
+                // the splash dispatcher just renders.
+                progress.Report(Res.Format("Apply_Progress_Working", db.Info.Name));
                 try
                 {
                     db.OnApply?.Invoke(db.Xml);
@@ -2649,11 +2721,26 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             }
             RefreshTree(_active.Xml);
             RefreshPendingAndPreview();
+
+            // #146: matches the single-DB Apply &amp; Close summary hold so
+            // the user sees confirmation before the dialog vanishes.
+            if (showSummary)
+            {
+                progress.ShowSummaryAndClose(
+                    Res.Format("Apply_Progress_SummaryMultiDb", totalChanged, perDb.Count),
+                    ApplySummaryHoldMs);
+            }
         }
         catch (Exception ex)
         {
             Log.Error(ex, "Multi-DB Apply threw");
             HandleErrorWithRollback(ex, backupPath);
+        }
+        finally
+        {
+            // Re-foreground the host dialog (#146 H3) on every multi-DB
+            // Apply outcome — success, partial-commit, cancel, or exception.
+            ApplyFinished?.Invoke();
         }
 
         Subscription.UpdateUsageStatus();

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -2573,11 +2573,18 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             Log.Warning(backupEx, "Backup failed, continuing without backup");
         }
 
-        // #146: cross-thread progress splash for multi-DB Apply — mirrors
-        // single-DB. Use the MultiDb status string so the user knows the
-        // batch spans more than one DB.
+        // #146: cross-thread progress splash for multi-DB Apply. Initial
+        // status names the FIRST DB about to be written — the prior
+        // "Applying to N DBs" line was overwritten one tick later by the
+        // per-DB Report in Phase 2 (review nit #4), so it flashed and
+        // vanished. Batch context now lives on the persistent counter
+        // line ("DB 1 of 5") via SetCounter, mirroring the open-time
+        // splash's per-DB counter (#125).
+        var firstDbName = perDb.Count > 0 ? perDb[0].db.Info.Name : _active.Info.Name;
         using var progress = _applyProgress.Begin(
-            Res.Format("Apply_Progress_WorkingMultiDb", perDb.Count));
+            Res.Format("Apply_Progress_Working", firstDbName));
+        if (perDb.Count > 1)
+            progress.SetCounter(Res.Format("Splash_Counter", 1, perDb.Count));
         try
         {
             int totalChanged = 0;
@@ -2616,12 +2623,15 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
             int committedChanges = 0;
             int committedDbs = 0;
             string? cancelledOnDb = null;
-            foreach (var (db, edits) in perDb)
+            for (int i = 0; i < perDb.Count; i++)
             {
-                // Per-DB status line so the user sees forward progress on
-                // long multi-DB Applies (#146). Pre-localized on this thread;
-                // the splash dispatcher just renders.
+                var (db, edits) = perDb[i];
+                // Per-DB status line + counter so the user sees forward
+                // progress on long multi-DB Applies (#146). Pre-localized
+                // on this thread; the splash dispatcher just renders.
                 progress.Report(Res.Format("Apply_Progress_Working", db.Info.Name));
+                if (perDb.Count > 1)
+                    progress.SetCounter(Res.Format("Splash_Counter", i + 1, perDb.Count));
                 try
                 {
                     db.OnApply?.Invoke(db.Xml);

--- a/src/BlockParam/addin-publisher-v20.xml
+++ b/src/BlockParam/addin-publisher-v20.xml
@@ -6,7 +6,7 @@
   <Product>
     <Name>BlockParam</Name>
     <Id>BlockParam</Id>
-    <Version>1.0.14</Version>
+    <Version>0.146.0</Version>
   </Product>
   <FeatureAssembly>
     <AssemblyInfo>

--- a/src/BlockParam/addin-publisher-v21.xml
+++ b/src/BlockParam/addin-publisher-v21.xml
@@ -6,7 +6,7 @@
   <Product>
     <Name>BlockParam</Name>
     <Id>BlockParam</Id>
-    <Version>1.0.14</Version>
+    <Version>0.146.0</Version>
   </Product>
   <FeatureAssembly>
     <AssemblyInfo>


### PR DESCRIPTION
## Summary

- Wraps the synchronous Openness Apply with a cross-thread splash (reusing the #125 `LoadingSplashController` STA-dispatcher pattern), so TIA going to "(Not Responding)" no longer manifests as an Add-In with zero feedback.
- Re-foregrounds the dialog above TIA after each Apply via a new `ApplyFinished` event + Topmost-flip in the dialog code-behind — fixes the ownerless-dialog-buried-behind-TIA hypothesis.
- Apply & Close pins a "✓ Applied N values" line on the splash for 900 ms before firing `RequestClose`, so the user sees confirmation before the dialog vanishes (the follow-up trust-gap noted in the issue's comment thread).

## Why it works without violating the Openness HARD CONSTRAINT

TIA Openness is single-threaded; the import has to stay on the TIA dispatcher. The fix gives the user a *visible* affordance from a **different** UI thread — the splash dispatcher — so the marquee + status line keep painting while TIA's main thread is frozen inside `Blocks.Import`. Same mechanism the open-time splash has used since #125; this PR just extends it to the Apply phase.

## Where the orchestration lives (CLAUDE.md guardrails)

Per the `BulkChangeViewModel` (#80) hotspot rule, the new logic is a focused `Services/ApplyProgressService.cs` (~110 LOC) with `IApplyProgressService` + `IApplyProgressHandle`, a `WpfApplyProgressService` for production, and a `NoOpApplyProgressService` default so headless tests / DevLauncher don't spin up STA dispatcher windows. The VM grows by ~50 LOC of wiring (event raise + `using var progress = ...`), not by re-implementing the splash.

All new user-facing strings go through `Strings.resx` / `Strings.de.resx`. No new `readonly struct` fields — partial-trust IL (`PEVerify /IL /UNIQUE`) stays clean.

## Gates

- `dotnet test` → **1160/1160 pass** (5 new in `ApplyProgressTests.cs`).
- `PEVerify /IL /UNIQUE BlockParam.dll` → *All Classes and Methods Verified.*
- `PartialTrustSandboxTests` → 2/2 pass.
- V20 Release build: clean (existing CS8601 warning only, unrelated to this PR).

## Test plan

- [ ] Open a DB with several pending edits → Apply → confirm splash appears immediately, TIA can go "(Not Responding)" without losing the visible "Applying changes to <DB>…" marquee.
- [ ] After Apply returns, dialog re-foregrounds above TIA (Topmost flip).
- [ ] Apply & Close → confirm "✓ Applied N values to <DB>" lingers ~900 ms before the dialog disappears.
- [ ] Multi-DB Apply: each DB's name appears in turn on the splash status line during Phase 2.
- [ ] Failure path (e.g. decline compile prompt on inconsistent block): splash dismisses, dialog still re-foregrounds, no stuck splash thread.
- [ ] Inspect `%APPDATA%\BlockParam\logs\bulkchange-v0.146.0.0-*.log` for "Applying…" log lines and confirm no exceptions on Apply.

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)