### PR TITLE
refactor(#85): route ConfigLoader, license, ConfigEditor & BulkChange I/O through IBlockParamStorage

### DIFF
--- a/src/BlockParam.Tests/Storage/ConfigLoaderStorageTests.cs
+++ b/src/BlockParam.Tests/Storage/ConfigLoaderStorageTests.cs
@@ -1,0 +1,142 @@
+using BlockParam.Config;
+using BlockParam.Services.Storage;
+using BlockParam.Updates;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests.Storage;
+
+/// <summary>
+/// Regression tests pinning <see cref="ConfigLoader"/> to the
+/// <see cref="IBlockParamStorage"/> abstraction (#85 follow-up). Disk-based
+/// behavior lives in <see cref="ConfigLoaderTests"/>; this suite exercises
+/// the in-memory path so any future code that drops a direct
+/// <c>File.*</c> / <c>Directory.*</c> call back in fails a deterministic test.
+/// </summary>
+public class ConfigLoaderStorageTests
+{
+    private static StoragePath ConfigPath =>
+        StoragePath.FromAbsolute(@"C:\bp\appdata") / "config.json";
+    private static StoragePath LocalRulesDir =>
+        StoragePath.FromAbsolute(@"C:\bp\appdata") / "rules";
+
+    [Fact]
+    public void GetConfig_seeds_local_rules_directory_on_first_read()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var loader = new ConfigLoader(fs, ConfigPath.FullPath);
+
+        var config = loader.GetConfig();
+
+        config.Should().NotBeNull();
+        config!.Rules.Should().BeEmpty();
+        // GetConfig() must create the local rules dir even when no rules
+        // exist yet — otherwise the editor's "+ File" command lands in a
+        // missing directory and SaveRuleFile blows up.
+        fs.DirectoryExists(LocalRulesDir).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Local_json_files_under_config_dir_are_merged_into_rules()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        fs.WriteAllText(LocalRulesDir / "speed.json",
+            "{ \"version\": \"1.0\", \"rules\": [ { \"pathPattern\": \"Speed\", \"datatype\": \"Int\" } ] }");
+        fs.WriteAllText(LocalRulesDir / "temp.json",
+            "{ \"version\": \"1.0\", \"rules\": [ { \"pathPattern\": \"Temp\", \"datatype\": \"Real\" } ] }");
+
+        var loader = new ConfigLoader(fs, ConfigPath.FullPath);
+        var config = loader.GetConfig();
+
+        config!.Rules.Should().HaveCount(2);
+        config.Rules.Select(r => r.PathPattern)
+            .Should().BeEquivalentTo("Speed", "Temp");
+    }
+
+    [Fact]
+    public void SaveSharedRulesDirectory_writes_through_storage_and_invalidates()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var loader = new ConfigLoader(fs, ConfigPath.FullPath);
+
+        loader.SaveSharedRulesDirectory(@"C:\shared\rules");
+
+        fs.FileExists(ConfigPath).Should().BeTrue();
+        fs.ReadAllText(ConfigPath).Should().Contain(@"C:\\shared\\rules");
+
+        // Re-read picks up what was just written — cache must have been invalidated.
+        loader.GetConfig()!.RulesDirectory.Should().Be(@"C:\shared\rules");
+    }
+
+    [Fact]
+    public void SaveUpdateCheckSettings_preserves_other_config_keys()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        fs.WriteAllText(ConfigPath,
+            "{ \"version\": \"1.0\", \"rulesDirectory\": \"C:\\\\keep\", \"language\": \"de-DE\" }");
+
+        var loader = new ConfigLoader(fs, ConfigPath.FullPath);
+        loader.SaveUpdateCheckSettings(new UpdateCheckSettings
+        {
+            Enabled = false,
+            IncludePrereleases = true
+        });
+
+        var raw = fs.ReadAllText(ConfigPath);
+        raw.Should().Contain(@"C:\\keep");
+        raw.Should().Contain("de-DE");
+        raw.Should().Contain("\"enabled\"");
+        raw.Should().Contain("false");
+    }
+
+    [Fact]
+    public void SaveRuleFile_routes_through_storage_and_auto_creates_parent()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var loader = new ConfigLoader(fs, ConfigPath.FullPath);
+
+        var target = LocalRulesDir / "subdir" / "speed.json";
+        loader.SaveRuleFile(target.FullPath, new BulkChangeConfig
+        {
+            Version = "1.0",
+            Rules = { new MemberRule { PathPattern = "Speed", Datatype = "Int" } }
+        });
+
+        fs.FileExists(target).Should().BeTrue();
+        fs.DirectoryExists(target.Parent).Should().BeTrue();
+        fs.ReadAllText(target).Should().Contain("\"Speed\"");
+    }
+
+    [Fact]
+    public void Missing_config_file_returns_empty_config_without_throwing()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var loader = new ConfigLoader(fs, ConfigPath.FullPath);
+
+        var config = loader.GetConfig();
+
+        config.Should().NotBeNull();
+        config!.Rules.Should().BeEmpty();
+        config.RulesDirectory.Should().BeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Local_rules_skip_files_already_present_in_local_when_loading_shared()
+    {
+        // Local overrides shared when both directories have a file of the
+        // same name — verifies the dedupe path through the storage abstraction.
+        var fs = new InMemoryBlockParamStorage();
+        var sharedDir = StoragePath.FromAbsolute(@"C:\shared\rules");
+        fs.WriteAllText(LocalRulesDir / "common.json",
+            "{ \"version\": \"1.0\", \"rules\": [ { \"pathPattern\": \"LocalWins\", \"datatype\": \"Int\" } ] }");
+        fs.WriteAllText(sharedDir / "common.json",
+            "{ \"version\": \"1.0\", \"rules\": [ { \"pathPattern\": \"SharedLoses\", \"datatype\": \"Int\" } ] }");
+        fs.WriteAllText(ConfigPath,
+            $"{{ \"version\": \"1.0\", \"rulesDirectory\": \"{sharedDir.FullPath.Replace("\\", "\\\\")}\" }}");
+
+        var loader = new ConfigLoader(fs, ConfigPath.FullPath);
+        var config = loader.GetConfig();
+
+        config!.Rules.Select(r => r.PathPattern).Should().ContainSingle().Which.Should().Be("LocalWins");
+    }
+}

--- a/src/BlockParam.Tests/Storage/FileSystemBlockParamStorageTests.cs
+++ b/src/BlockParam.Tests/Storage/FileSystemBlockParamStorageTests.cs
@@ -105,4 +105,33 @@ public class FileSystemBlockParamStorageTests : IDisposable
         _fs.WriteAllText(emptyDir / "now-has-a-file.txt", "");
         _fs.HasAnyEntries(emptyDir).Should().BeTrue();
     }
+
+    [Fact]
+    public void Replace_swaps_destination_atomically_on_same_volume()
+    {
+        var dest = _root / "live.dat";
+        var src = _root / "live.dat.tmp";
+        _fs.WriteAllText(dest, "old");
+        _fs.WriteAllText(src, "new");
+
+        _fs.Replace(src, dest);
+
+        _fs.FileExists(src).Should().BeFalse();
+        _fs.ReadAllText(dest).Should().Be("new");
+        File.Exists(src.FullPath).Should().BeFalse();
+        File.ReadAllText(dest.FullPath).Should().Be("new");
+    }
+
+    [Fact]
+    public void Replace_renames_when_destination_does_not_exist()
+    {
+        var dest = _root / "live.dat";
+        var src = _root / "live.dat.tmp";
+        _fs.WriteAllText(src, "first");
+
+        _fs.Replace(src, dest);
+
+        _fs.FileExists(src).Should().BeFalse();
+        _fs.ReadAllText(dest).Should().Be("first");
+    }
 }

--- a/src/BlockParam.Tests/Storage/InMemoryBlockParamStorageTests.cs
+++ b/src/BlockParam.Tests/Storage/InMemoryBlockParamStorageTests.cs
@@ -239,6 +239,48 @@ public class InMemoryBlockParamStorageTests
     }
 
     [Fact]
+    public void Replace_preserves_source_last_write_time_at_destination()
+    {
+        // Real FS: File.Replace / File.Move carry the source's mtime onto the
+        // destination. The in-memory fake must do the same or age-based
+        // cleanup sweepers will be green against the fake and red on disk.
+        var fs = new InMemoryBlockParamStorage();
+        var srcMtime = new DateTime(2026, 1, 15, 9, 30, 0);
+        fs.Clock = () => srcMtime;
+        var src = Root / "live.dat.tmp";
+        var dest = Root / "live.dat";
+        fs.WriteAllBytes(src, new byte[] { 0x01 });
+
+        // Advance the clock so a Clock()-stamped destination would be obvious.
+        fs.Clock = () => srcMtime.AddHours(2);
+
+        fs.Replace(src, dest);
+
+        fs.GetLastWriteTime(dest).Should().Be(srcMtime);
+    }
+
+    [Fact]
+    public void Replace_defensive_copies_byte_array_into_destination()
+    {
+        // WriteAllBytes/ReadAllBytes both clone; Replace must too — otherwise
+        // a caller mutating the bytes it just wrote at src would also mutate
+        // what subsequent ReadAllBytes(dest) returns, which the real FS would
+        // never do.
+        var fs = new InMemoryBlockParamStorage();
+        var src = Root / "src.bin";
+        var dest = Root / "dest.bin";
+        var bytes = new byte[] { 0x10, 0x20 };
+        fs.WriteAllBytes(src, bytes);
+
+        fs.Replace(src, dest);
+
+        // Mutate what was originally written; the stored copy at dest must
+        // not move.
+        bytes[0] = 0xFF;
+        fs.ReadAllBytes(dest).Should().Equal(0x10, 0x20);
+    }
+
+    [Fact]
     public void OpenRead_returns_readable_stream_of_contents()
     {
         var fs = new InMemoryBlockParamStorage();

--- a/src/BlockParam.Tests/Storage/InMemoryBlockParamStorageTests.cs
+++ b/src/BlockParam.Tests/Storage/InMemoryBlockParamStorageTests.cs
@@ -260,27 +260,6 @@ public class InMemoryBlockParamStorageTests
     }
 
     [Fact]
-    public void Replace_defensive_copies_byte_array_into_destination()
-    {
-        // WriteAllBytes/ReadAllBytes both clone; Replace must too — otherwise
-        // a caller mutating the bytes it just wrote at src would also mutate
-        // what subsequent ReadAllBytes(dest) returns, which the real FS would
-        // never do.
-        var fs = new InMemoryBlockParamStorage();
-        var src = Root / "src.bin";
-        var dest = Root / "dest.bin";
-        var bytes = new byte[] { 0x10, 0x20 };
-        fs.WriteAllBytes(src, bytes);
-
-        fs.Replace(src, dest);
-
-        // Mutate what was originally written; the stored copy at dest must
-        // not move.
-        bytes[0] = 0xFF;
-        fs.ReadAllBytes(dest).Should().Equal(0x10, 0x20);
-    }
-
-    [Fact]
     public void OpenRead_returns_readable_stream_of_contents()
     {
         var fs = new InMemoryBlockParamStorage();

--- a/src/BlockParam.Tests/Storage/InMemoryBlockParamStorageTests.cs
+++ b/src/BlockParam.Tests/Storage/InMemoryBlockParamStorageTests.cs
@@ -197,6 +197,48 @@ public class InMemoryBlockParamStorageTests
     }
 
     [Fact]
+    public void Replace_moves_source_over_destination_atomically()
+    {
+        // LocalUsageTracker relies on Replace() to atomically swap a .tmp blob
+        // over the live counter file. The InMemory contract has to match that
+        // semantic exactly or the storage tests miss the regression that the
+        // disk tests cover.
+        var fs = new InMemoryBlockParamStorage();
+        var dest = Root / "live.dat";
+        var src = Root / "live.dat.tmp";
+        fs.WriteAllBytes(dest, new byte[] { 0x01 });
+        fs.WriteAllBytes(src, new byte[] { 0x02, 0x03 });
+
+        fs.Replace(src, dest);
+
+        fs.FileExists(src).Should().BeFalse();
+        fs.FileExists(dest).Should().BeTrue();
+        fs.ReadAllBytes(dest).Should().Equal(0x02, 0x03);
+    }
+
+    [Fact]
+    public void Replace_creates_destination_when_absent()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var dest = Root / "live.dat";
+        var src = Root / "live.dat.tmp";
+        fs.WriteAllText(src, "x");
+
+        fs.Replace(src, dest);
+
+        fs.FileExists(src).Should().BeFalse();
+        fs.ReadAllText(dest).Should().Be("x");
+    }
+
+    [Fact]
+    public void Replace_throws_when_source_missing()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        Action act = () => fs.Replace(Root / "nope.tmp", Root / "live.dat");
+        act.Should().Throw<FileNotFoundException>();
+    }
+
+    [Fact]
     public void OpenRead_returns_readable_stream_of_contents()
     {
         var fs = new InMemoryBlockParamStorage();

--- a/src/BlockParam.Tests/Storage/LocalUsageTrackerStorageTests.cs
+++ b/src/BlockParam.Tests/Storage/LocalUsageTrackerStorageTests.cs
@@ -1,0 +1,133 @@
+using BlockParam.Licensing;
+using BlockParam.Services.Storage;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace BlockParam.Tests.Storage;
+
+/// <summary>
+/// Regression tests pinning <see cref="LocalUsageTracker"/> to the
+/// <see cref="IBlockParamStorage"/> abstraction it migrated onto in #85's
+/// follow-up — proves the in-memory path is wired correctly so a future
+/// refactor that drops a <c>File.*</c> call back in is caught immediately.
+/// Disk-based behavior continues to live in <see cref="LocalUsageTrackerTests"/>.
+/// </summary>
+public class LocalUsageTrackerStorageTests
+{
+    private static StoragePath UsagePath =>
+        StoragePath.FromAbsolute(@"C:\bp\appdata") / "usage.dat";
+
+    [Fact]
+    public void Missing_file_reports_zero_usage_without_writing()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var tracker = NewTracker(fs);
+
+        var status = tracker.GetStatus();
+        status.UsedToday.Should().Be(0);
+        status.RemainingToday.Should().Be(3);
+
+        // GetStatus must not create the file — only RecordUsage does.
+        fs.FileExists(UsagePath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void RecordUsage_writes_through_storage_only()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var tracker = NewTracker(fs);
+
+        tracker.RecordUsage(1).Should().BeTrue();
+
+        fs.FileExists(UsagePath).Should().BeTrue();
+        // .tmp file must not linger — Replace() removes the source on success.
+        fs.FileExists(StoragePath.FromAbsolute(UsagePath.FullPath + ".tmp"))
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void Persists_across_tracker_instances_via_storage()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var date = new DateTime(2026, 5, 24);
+
+        var w = NewTracker(fs, dailyLimit: 5, dateProvider: () => date);
+        w.RecordUsage(2);
+        w.RecordUsage(1);
+
+        var r = NewTracker(fs, dailyLimit: 5, dateProvider: () => date);
+        r.GetStatus().UsedToday.Should().Be(3);
+        r.GetStatus().RemainingToday.Should().Be(2);
+    }
+
+    [Fact]
+    public void Counter_resets_on_new_day_even_with_persisted_old_count()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var today = new DateTime(2026, 5, 24);
+
+        var w = NewTracker(fs, dateProvider: () => today);
+        w.RecordUsage(2);
+
+        var tomorrow = today.AddDays(1);
+        var r = NewTracker(fs, dateProvider: () => tomorrow);
+        r.GetStatus().UsedToday.Should().Be(0);
+    }
+
+    [Fact]
+    public void Corrupt_blob_resets_gracefully_without_throwing()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        // Bypass Obfuscate so the read path falls into the corrupt-file branch.
+        fs.WriteAllBytes(UsagePath, new byte[] { 0xDE, 0xAD, 0xBE, 0xEF, 0x00 });
+
+        var tracker = NewTracker(fs);
+        tracker.GetStatus().UsedToday.Should().Be(0);
+        // And subsequent writes succeed (Replace overwrites the corrupt blob).
+        tracker.RecordUsage(1).Should().BeTrue();
+        tracker.GetStatus().UsedToday.Should().Be(1);
+    }
+
+    [Fact]
+    public void Atomic_write_replaces_existing_file_in_place()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var date = new DateTime(2026, 5, 24);
+        var tracker = NewTracker(fs, dateProvider: () => date);
+
+        tracker.RecordUsage(1);
+        tracker.RecordUsage(1);
+
+        // After two writes there should be exactly one file at the storage path
+        // (no .tmp leftovers, no .bak files).
+        fs.EnumerateFiles(UsagePath.Parent).Select(p => p.FileName)
+            .Should().BeEquivalentTo("usage.dat");
+    }
+
+    [Fact]
+    public void Legacy_dual_counter_json_drops_inline_count_field()
+    {
+        // Mirrors the disk-based test in LocalUsageTrackerTests — confirms the
+        // Newtonsoft "ignore unknown property" guarantee survives the
+        // storage-abstraction migration unchanged.
+        var fs = new InMemoryBlockParamStorage();
+        var date = new DateTime(2026, 5, 24);
+        var legacy = JsonConvert.SerializeObject(new
+        {
+            Date = date.ToString("yyyy-MM-dd"),
+            Count = 7,
+            InlineCount = 99
+        });
+        fs.WriteAllBytes(UsagePath, Obfuscation.Obfuscate(legacy));
+
+        var tracker = NewTracker(fs, dailyLimit: 200, dateProvider: () => date);
+        tracker.GetStatus().UsedToday.Should().Be(7);
+    }
+
+    private static LocalUsageTracker NewTracker(
+        IBlockParamStorage fs,
+        int dailyLimit = 3,
+        Func<DateTime>? dateProvider = null)
+        => new(fs, UsagePath, dailyLimit, dateProvider);
+}

--- a/src/BlockParam.Tests/Storage/OnlineLicenseServiceStorageTests.cs
+++ b/src/BlockParam.Tests/Storage/OnlineLicenseServiceStorageTests.cs
@@ -1,0 +1,189 @@
+using BlockParam.Licensing;
+using BlockParam.Services.Storage;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace BlockParam.Tests.Storage;
+
+/// <summary>
+/// Regression tests pinning <see cref="OnlineLicenseService"/>'s persistence
+/// layer to the <see cref="IBlockParamStorage"/> abstraction (#85 follow-up).
+/// Covers the shared-license-file adoption paths and disk-roundtrip semantics
+/// without touching the actual file system. Disk-based behavior continues to
+/// live in <see cref="OnlineLicenseServiceSharedFileTests"/>.
+/// </summary>
+public class OnlineLicenseServiceStorageTests
+{
+    private static StoragePath StorageDir =>
+        StoragePath.FromAbsolute(@"C:\bp\appdata") / "licensing";
+    private static StoragePath SharedKey =>
+        StoragePath.FromAbsolute(@"C:\bp\programdata") / "license.key";
+    private static StoragePath LicenseJson => StorageDir / "license.json";
+    private static StoragePath CacheDat => StorageDir / "license_cache.dat";
+
+    [Fact]
+    public void Missing_files_yield_free_tier_without_touching_storage_paths()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        using var svc = NewService(fs);
+
+        var info = svc.GetLicenseInfo();
+        info.Tier.Should().Be(LicenseTier.Free);
+        info.LicenseKey.Should().BeNull();
+        info.IsManagedKey.Should().BeFalse();
+        info.ManagedKeyFilePath.Should().BeNull();
+
+        // Constructor must not have created either file.
+        fs.FileExists(LicenseJson).Should().BeFalse();
+        fs.FileExists(CacheDat).Should().BeFalse();
+    }
+
+    [Fact]
+    public void SharedKey_adopted_when_no_user_cache_exists()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        fs.WriteAllText(SharedKey, "PRO-IT-FRESH");
+
+        using var svc = NewService(fs);
+
+        var info = svc.GetLicenseInfo();
+        info.LicenseKey.Should().Be("PRO-IT-FRESH");
+        info.IsManagedKey.Should().BeTrue();
+        info.ManagedKeyFilePath.Should().Be(SharedKey.FullPath);
+
+        // license.json should have been written via the abstraction.
+        fs.FileExists(LicenseJson).Should().BeTrue();
+        fs.ReadAllText(LicenseJson).Should().Contain("PRO-IT-FRESH");
+    }
+
+    [Fact]
+    public void SharedKey_trims_trailing_whitespace_from_batch_emitted_files()
+    {
+        // `echo PRO-X > license.key` adds CRLF; service must compare the
+        // trimmed value to the server-side key.
+        var fs = new InMemoryBlockParamStorage();
+        fs.WriteAllText(SharedKey, "PRO-IT-TRIM\r\n");
+
+        using var svc = NewService(fs);
+        svc.GetLicenseInfo().LicenseKey.Should().Be("PRO-IT-TRIM");
+    }
+
+    [Fact]
+    public void Whitespace_only_shared_file_is_ignored()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        SeedUserLicense(fs, "USER-LOCAL", "instance-1");
+        fs.WriteAllText(SharedKey, "   \r\n\t");
+
+        using var svc = NewService(fs);
+
+        var info = svc.GetLicenseInfo();
+        info.IsManagedKey.Should().BeFalse();
+        info.LicenseKey.Should().Be("USER-LOCAL");
+    }
+
+    [Fact]
+    public void SharedKey_rotation_replaces_user_cache_and_clears_cache_dat()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        SeedUserLicense(fs, "USER-OLD-KEY", "instance-1");
+        SeedProGrantingCache(fs);
+        fs.WriteAllText(SharedKey, "PRO-IT-ROTATED");
+
+        using var svc = NewService(fs);
+
+        var info = svc.GetLicenseInfo();
+        info.LicenseKey.Should().Be("PRO-IT-ROTATED");
+        info.IsManagedKey.Should().BeTrue();
+        info.Tier.Should().Be(LicenseTier.Free); // server hasn't validated yet
+        // Stale cache must be wiped so EvaluateTier doesn't grant Pro on it.
+        fs.FileExists(CacheDat).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Matching_shared_key_preserves_existing_cache_and_tier()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        SeedUserLicense(fs, "PRO-SAME", "instance-keep");
+        SeedProGrantingCache(fs);
+        fs.WriteAllText(SharedKey, "PRO-SAME");
+
+        using var svc = NewService(fs);
+
+        var info = svc.GetLicenseInfo();
+        info.Tier.Should().Be(LicenseTier.Pro);
+        info.IsManagedKey.Should().BeTrue();
+        fs.FileExists(CacheDat).Should().BeTrue();
+    }
+
+    [Fact]
+    public void DeactivateKey_clears_both_persisted_files_via_storage()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        SeedUserLicense(fs, "PRO-USER", "instance-1");
+        SeedProGrantingCache(fs);
+
+        using (var svc = NewService(fs))
+        {
+            svc.GetLicenseInfo().Tier.Should().Be(LicenseTier.Pro);
+            svc.DeactivateKey();
+        }
+
+        fs.FileExists(LicenseJson).Should().BeFalse();
+        fs.FileExists(CacheDat).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Rotation_preserves_instance_id_across_restarts()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        fs.WriteAllText(SharedKey, "PRO-IT-V1");
+
+        string? firstInstance;
+        using (var svc1 = NewService(fs)) { svc1.GetLicenseInfo().LicenseKey.Should().Be("PRO-IT-V1"); }
+        firstInstance = ReadStoredInstanceId(fs);
+        firstInstance.Should().NotBeNullOrEmpty();
+
+        fs.WriteAllText(SharedKey, "PRO-IT-V2");
+        using (var svc2 = NewService(fs)) { svc2.GetLicenseInfo().LicenseKey.Should().Be("PRO-IT-V2"); }
+
+        ReadStoredInstanceId(fs).Should().Be(firstInstance);
+    }
+
+    private static OnlineLicenseService NewService(IBlockParamStorage fs) =>
+        new(fs, StorageDir, "https://example", sharedLicenseFilePath: SharedKey);
+
+    private static void SeedUserLicense(IBlockParamStorage fs, string key, string instanceId)
+    {
+        var json = JsonConvert.SerializeObject(new
+        {
+            LicenseKey = key,
+            InstanceId = instanceId,
+            ActivatedAt = DateTime.UtcNow
+        });
+        fs.WriteAllText(LicenseJson, json);
+    }
+
+    private static void SeedProGrantingCache(IBlockParamStorage fs)
+    {
+        var cache = new
+        {
+            ReceivedAtUtc = DateTime.UtcNow,
+            ExpiresAt = (DateTime?)null,
+            MaxConcurrent = 1,
+            ActiveSessions = 1,
+            ErrorMessage = (string?)null
+        };
+        var json = JsonConvert.SerializeObject(cache);
+        fs.WriteAllBytes(CacheDat, Obfuscation.Obfuscate(json));
+    }
+
+    private static string? ReadStoredInstanceId(IBlockParamStorage fs)
+    {
+        if (!fs.FileExists(LicenseJson)) return null;
+        var json = fs.ReadAllText(LicenseJson);
+        var obj = JsonConvert.DeserializeObject<Dictionary<string, object?>>(json);
+        return obj?["InstanceId"]?.ToString();
+    }
+}

--- a/src/BlockParam.Tests/Storage/RuleFileRepositoryTests.cs
+++ b/src/BlockParam.Tests/Storage/RuleFileRepositoryTests.cs
@@ -1,0 +1,106 @@
+using BlockParam.Services;
+using BlockParam.Services.Storage;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests.Storage;
+
+/// <summary>
+/// Pins <see cref="RuleFileRepository"/> to the
+/// <see cref="IBlockParamStorage"/> abstraction so the
+/// "no new <c>File.*</c> / <c>Directory.*</c> outside the storage layer"
+/// guardrail (#85) is exercised on every test run.
+/// </summary>
+public class RuleFileRepositoryTests
+{
+    private static StoragePath RulesDir =>
+        StoragePath.FromAbsolute(@"C:\bp\rules");
+
+    [Fact]
+    public void ListJsonFiles_returns_empty_for_missing_directory()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var repo = new RuleFileRepository(fs);
+
+        repo.ListJsonFiles(RulesDir.FullPath).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ListJsonFiles_filters_to_json_and_sorts_case_insensitive()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        fs.WriteAllText(RulesDir / "Zebra.json", "{}");
+        fs.WriteAllText(RulesDir / "apple.json", "{}");
+        fs.WriteAllText(RulesDir / "readme.txt", "ignore me");
+
+        var repo = new RuleFileRepository(fs);
+        var files = repo.ListJsonFiles(RulesDir.FullPath);
+
+        files.Should().HaveCount(2);
+        // OrdinalIgnoreCase puts apple.json before Zebra.json.
+        Path.GetFileName(files[0]).Should().Be("apple.json");
+        Path.GetFileName(files[1]).Should().Be("Zebra.json");
+    }
+
+    [Fact]
+    public void ListJsonFileNames_returns_bare_names()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        fs.WriteAllText(RulesDir / "a.json", "{}");
+        fs.WriteAllText(RulesDir / "b.json", "{}");
+
+        var repo = new RuleFileRepository(fs);
+        var names = repo.ListJsonFileNames(RulesDir.FullPath).ToList();
+
+        names.Should().BeEquivalentTo("a.json", "b.json");
+    }
+
+    [Fact]
+    public void FileExists_and_DirectoryExists_route_through_storage()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var file = RulesDir / "x.json";
+        fs.WriteAllText(file, "{}");
+
+        var repo = new RuleFileRepository(fs);
+
+        repo.DirectoryExists(RulesDir.FullPath).Should().BeTrue();
+        repo.DirectoryExists(@"C:\nope").Should().BeFalse();
+        repo.FileExists(file.FullPath).Should().BeTrue();
+        repo.FileExists((RulesDir / "missing.json").FullPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void DeleteFile_removes_existing_file()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var file = RulesDir / "x.json";
+        fs.WriteAllText(file, "{}");
+
+        var repo = new RuleFileRepository(fs);
+        repo.DeleteFile(file.FullPath);
+
+        fs.FileExists(file).Should().BeFalse();
+    }
+
+    [Fact]
+    public void DeleteFile_is_noop_for_empty_path()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var repo = new RuleFileRepository(fs);
+
+        Action act = () => repo.DeleteFile("");
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ReadAllText_roundtrips_a_written_rule_file()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var file = RulesDir / "rule.json";
+        fs.WriteAllText(file, "{\"version\":\"1.0\"}");
+
+        var repo = new RuleFileRepository(fs);
+        repo.ReadAllText(file.FullPath).Should().Be("{\"version\":\"1.0\"}");
+    }
+}

--- a/src/BlockParam.Tests/Storage/RuleFileRepositoryTests.cs
+++ b/src/BlockParam.Tests/Storage/RuleFileRepositoryTests.cs
@@ -1,3 +1,4 @@
+using System.Security;
 using BlockParam.Services;
 using BlockParam.Services.Storage;
 using FluentAssertions;
@@ -102,5 +103,50 @@ public class RuleFileRepositoryTests
 
         var repo = new RuleFileRepository(fs);
         repo.ReadAllText(file.FullPath).Should().Be("{\"version\":\"1.0\"}");
+    }
+
+    [Fact]
+    public void ListJsonFiles_swallows_SecurityException_and_returns_empty()
+    {
+        // Pins the partial-trust behavior the old ConfigEditorViewModel.ClaimsFor
+        // relied on (bare catch). Under TIA's Add-In Loader sandbox,
+        // EnumerateFiles can throw SecurityException; ListJsonFiles must seed
+        // an empty result so SaveAll falls through to its own clearer error
+        // path instead of crashing the dispatcher.
+        var fs = new ThrowingStorage(new SecurityException("denied by sandbox"));
+        var repo = new RuleFileRepository(fs);
+
+        repo.ListJsonFiles(RulesDir.FullPath).Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Minimal IBlockParamStorage stub that pretends a directory exists but
+    /// throws on enumeration. The full InMemoryBlockParamStorage doesn't
+    /// surface SecurityException so we wrap it instead.
+    /// </summary>
+    private sealed class ThrowingStorage : IBlockParamStorage
+    {
+        private readonly Exception _toThrow;
+        public ThrowingStorage(Exception toThrow) { _toThrow = toThrow; }
+
+        public bool DirectoryExists(StoragePath path) => true;
+        public IEnumerable<StoragePath> EnumerateFiles(StoragePath directory, string pattern = "*", bool recursive = false)
+            => throw _toThrow;
+
+        // Unused — defaulted to throw so any accidental call surfaces loudly.
+        public bool FileExists(StoragePath path) => throw new NotImplementedException();
+        public string ReadAllText(StoragePath path) => throw new NotImplementedException();
+        public byte[] ReadAllBytes(StoragePath path) => throw new NotImplementedException();
+        public System.IO.Stream OpenRead(StoragePath path) => throw new NotImplementedException();
+        public void WriteAllText(StoragePath path, string contents) => throw new NotImplementedException();
+        public void WriteAllBytes(StoragePath path, byte[] contents) => throw new NotImplementedException();
+        public void AppendAllText(StoragePath path, string contents) => throw new NotImplementedException();
+        public void EnsureDirectory(StoragePath path) => throw new NotImplementedException();
+        public void DeleteFile(StoragePath path) => throw new NotImplementedException();
+        public void DeleteDirectory(StoragePath path) => throw new NotImplementedException();
+        public DateTime GetLastWriteTime(StoragePath path) => throw new NotImplementedException();
+        public IEnumerable<StoragePath> EnumerateDirectories(StoragePath directory, string pattern = "*", bool recursive = false) => throw new NotImplementedException();
+        public bool HasAnyEntries(StoragePath directory) => throw new NotImplementedException();
+        public void Replace(StoragePath source, StoragePath destination) => throw new NotImplementedException();
     }
 }

--- a/src/BlockParam.Tests/Storage/TagTableDirectoryProbeTests.cs
+++ b/src/BlockParam.Tests/Storage/TagTableDirectoryProbeTests.cs
@@ -1,0 +1,73 @@
+using BlockParam.Services;
+using BlockParam.Services.Storage;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests.Storage;
+
+/// <summary>
+/// Regression tests for <see cref="TagTableDirectoryProbe"/>, the helper
+/// that pulled the three tag-table-cache <c>System.IO</c> calls out of
+/// <see cref="UI.BulkChangeViewModel"/>. Exercises the in-memory storage
+/// path so the BulkChangeViewModel hotspot can't silently regress (#85).
+/// </summary>
+public class TagTableDirectoryProbeTests
+{
+    private static StoragePath TagDir =>
+        StoragePath.FromAbsolute(@"C:\bp\temp") / "TagTables";
+
+    [Fact]
+    public void Exists_false_when_path_null_empty_or_whitespace()
+    {
+        var probe = new TagTableDirectoryProbe(new InMemoryBlockParamStorage());
+
+        probe.Exists(null).Should().BeFalse();
+        probe.Exists("").Should().BeFalse();
+        probe.Exists("   ").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Exists_reflects_storage_state()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        var probe = new TagTableDirectoryProbe(fs);
+
+        probe.Exists(TagDir.FullPath).Should().BeFalse();
+        fs.EnsureDirectory(TagDir);
+        probe.Exists(TagDir.FullPath).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetNewestXmlWriteTime_null_when_directory_missing()
+    {
+        var probe = new TagTableDirectoryProbe(new InMemoryBlockParamStorage());
+        probe.GetNewestXmlWriteTime(TagDir.FullPath).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetNewestXmlWriteTime_null_when_directory_empty()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        fs.EnsureDirectory(TagDir);
+
+        var probe = new TagTableDirectoryProbe(fs);
+        probe.GetNewestXmlWriteTime(TagDir.FullPath).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetNewestXmlWriteTime_returns_most_recent_xml_write_only()
+    {
+        var fs = new InMemoryBlockParamStorage();
+        fs.WriteAllText(TagDir / "old.xml", "");
+        fs.SetLastWriteTime(TagDir / "old.xml", new DateTime(2020, 1, 1));
+        fs.WriteAllText(TagDir / "new.xml", "");
+        fs.SetLastWriteTime(TagDir / "new.xml", new DateTime(2026, 5, 24));
+        // Non-xml file must be ignored even if newer.
+        fs.WriteAllText(TagDir / "ignore.txt", "");
+        fs.SetLastWriteTime(TagDir / "ignore.txt", new DateTime(2030, 1, 1));
+
+        var probe = new TagTableDirectoryProbe(fs);
+        probe.GetNewestXmlWriteTime(TagDir.FullPath)
+            .Should().Be(new DateTime(2026, 5, 24));
+    }
+}

--- a/src/BlockParam/Config/ConfigLoader.cs
+++ b/src/BlockParam/Config/ConfigLoader.cs
@@ -80,7 +80,7 @@ public class ConfigLoader
         // load ONLY from there and skip every other source.
         if (_scriptedRulesDirOverride != null)
         {
-            var loader = new RulesDirectoryLoader();
+            var loader = new RulesDirectoryLoader(_storage);
             var only = loader.LoadFromDirectory(_scriptedRulesDirOverride,
                 ruleSource: RuleSource.Shared);
             foreach (var w in only.Warnings)
@@ -102,7 +102,7 @@ public class ConfigLoader
         var localRulesDir = GetLocalRulesDirectory();
         _storage.EnsureDirectory(StoragePath.FromAbsolute(localRulesDir));
 
-        var dirLoader = new RulesDirectoryLoader();
+        var dirLoader = new RulesDirectoryLoader(_storage);
         var localResult = dirLoader.LoadFromDirectory(localRulesDir, ruleSource: RuleSource.Local);
         var localFileNames = new HashSet<string>(
             EnumerateJsonFileNames(localRulesDir),

--- a/src/BlockParam/Config/ConfigLoader.cs
+++ b/src/BlockParam/Config/ConfigLoader.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using BlockParam.Diagnostics;
 using BlockParam.Services;
+using BlockParam.Services.Storage;
 using BlockParam.Updates;
 
 namespace BlockParam.Config;
@@ -10,9 +11,15 @@ namespace BlockParam.Config;
 /// <summary>
 /// Loads and merges rule files from 3 directories (Project > Local > Shared).
 /// The optional config.json only stores the shared rulesDirectory path.
+///
+/// File I/O is routed through <see cref="IBlockParamStorage"/> so tests can
+/// substitute an in-memory fake and so the "no new <c>File.*</c> /
+/// <c>Directory.*</c> outside the storage layer" guardrail (#85) stays
+/// satisfied. The string-path constructor remains for legacy callers.
 /// </summary>
 public class ConfigLoader
 {
+    private readonly IBlockParamStorage _storage;
     private readonly string? _configPath;
     private readonly string? _scriptedRulesDirOverride;
     private string? _tiaProjectPath;
@@ -27,8 +34,8 @@ public class ConfigLoader
     internal string? ManagedConfigPathOverride { get; set; }
 
     public ConfigLoader(string? configPath = null)
+        : this(FileSystemBlockParamStorage.Instance, configPath, scriptedRulesDirOverride: null)
     {
-        _configPath = configPath;
     }
 
     /// <summary>
@@ -38,7 +45,22 @@ public class ConfigLoader
     /// personal %APPDATA% config from leaking into marketing screenshots.
     /// </summary>
     internal ConfigLoader(string? configPath, string? scriptedRulesDirOverride)
+        : this(FileSystemBlockParamStorage.Instance, configPath, scriptedRulesDirOverride)
     {
+    }
+
+    /// <summary>
+    /// Storage-injecting constructor for tests and any future caller that
+    /// needs to swap out the file system (in-memory fake, restricted-perms
+    /// view, etc.). Production callers should keep using the string-path
+    /// constructors above.
+    /// </summary>
+    internal ConfigLoader(
+        IBlockParamStorage storage,
+        string? configPath,
+        string? scriptedRulesDirOverride = null)
+    {
+        _storage = storage ?? throw new ArgumentNullException(nameof(storage));
         _configPath = configPath;
         _scriptedRulesDirOverride = scriptedRulesDirOverride;
     }
@@ -78,15 +100,12 @@ public class ConfigLoader
 
         // 2. Load local rule files
         var localRulesDir = GetLocalRulesDirectory();
-        Directory.CreateDirectory(localRulesDir);
+        _storage.EnsureDirectory(StoragePath.FromAbsolute(localRulesDir));
 
         var dirLoader = new RulesDirectoryLoader();
         var localResult = dirLoader.LoadFromDirectory(localRulesDir, ruleSource: RuleSource.Local);
         var localFileNames = new HashSet<string>(
-            Directory.Exists(localRulesDir)
-                ? Directory.GetFiles(localRulesDir, "*.json").Select(Path.GetFileName)
-                    .Where(n => n != null).Select(n => n!)
-                : Array.Empty<string>(),
+            EnumerateJsonFileNames(localRulesDir),
             StringComparer.OrdinalIgnoreCase);
 
         // 3. Load shared rule files (skip files that exist locally)
@@ -107,7 +126,8 @@ public class ConfigLoader
         if (!string.IsNullOrEmpty(_tiaProjectPath))
         {
             var projectRulesDir = GetTiaProjectRulesDirectory();
-            if (projectRulesDir != null && Directory.Exists(projectRulesDir))
+            if (projectRulesDir != null
+                && _storage.DirectoryExists(StoragePath.FromAbsolute(projectRulesDir)))
             {
                 projectResult = dirLoader.LoadFromDirectory(projectRulesDir,
                     ruleSource: RuleSource.TiaProject);
@@ -134,6 +154,14 @@ public class ConfigLoader
             localResult.Rules.Count, sharedResult.Rules.Count);
 
         return _cachedConfig;
+    }
+
+    private IEnumerable<string> EnumerateJsonFileNames(string directoryPath)
+    {
+        var dir = StoragePath.FromAbsolute(directoryPath);
+        if (!_storage.DirectoryExists(dir)) yield break;
+        foreach (var f in _storage.EnumerateFiles(dir, "*.json"))
+            yield return f.FileName;
     }
 
     private string? ReadSharedRulesDirectory() => TryReadConfig("config file")?.RulesDirectory;
@@ -181,11 +209,12 @@ public class ConfigLoader
     public void SaveUpdateCheckSettings(UpdateCheckSettings settings)
     {
         var targetPath = _configPath ?? AppDirectories.ConfigFile;
+        var sp = StoragePath.FromAbsolute(targetPath);
 
         BulkChangeConfig config;
-        if (File.Exists(targetPath))
+        if (_storage.FileExists(sp))
         {
-            try { config = Deserialize(File.ReadAllText(targetPath)) ?? new BulkChangeConfig(); }
+            try { config = Deserialize(_storage.ReadAllText(sp)) ?? new BulkChangeConfig(); }
             catch { config = new BulkChangeConfig(); }
         }
         else
@@ -196,16 +225,12 @@ public class ConfigLoader
         config.UpdateCheck = settings;
         if (string.IsNullOrEmpty(config.Version)) config.Version = "1.0";
 
-        var dir = Path.GetDirectoryName(targetPath);
-        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
-            Directory.CreateDirectory(dir);
-
         var json = JsonConvert.SerializeObject(config, Formatting.Indented, new JsonSerializerSettings
         {
             ContractResolver = new CamelCasePropertyNamesContractResolver(),
             NullValueHandling = NullValueHandling.Ignore
         });
-        File.WriteAllText(targetPath, json);
+        _storage.WriteAllText(sp, json);
         Invalidate();
     }
 
@@ -214,9 +239,10 @@ public class ConfigLoader
         try
         {
             var managedPath = ManagedConfigPathOverride ?? AppDirectories.ProgramDataConfigFile;
-            if (!File.Exists(managedPath)) return null;
+            var sp = StoragePath.FromAbsolute(managedPath);
+            if (!_storage.FileExists(sp)) return null;
 
-            var json = File.ReadAllText(managedPath);
+            var json = _storage.ReadAllText(sp);
             var token = JsonConvert.DeserializeObject<Newtonsoft.Json.Linq.JObject>(json);
             var node = token?["updateCheck"] as Newtonsoft.Json.Linq.JObject;
             if (node == null) return null;
@@ -245,12 +271,13 @@ public class ConfigLoader
 
     private BulkChangeConfig? TryReadConfig(string context)
     {
-        if (string.IsNullOrEmpty(_configPath) || !File.Exists(_configPath))
-            return null;
+        if (string.IsNullOrEmpty(_configPath)) return null;
+        var sp = StoragePath.FromAbsolute(_configPath!);
+        if (!_storage.FileExists(sp)) return null;
 
         try
         {
-            return Deserialize(File.ReadAllText(_configPath));
+            return Deserialize(_storage.ReadAllText(sp));
         }
         catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
         {
@@ -318,16 +345,12 @@ public class ConfigLoader
     /// </summary>
     public void SaveRuleFile(string filePath, BulkChangeConfig ruleFileContent)
     {
-        var dir = Path.GetDirectoryName(filePath);
-        if (!string.IsNullOrEmpty(dir))
-            Directory.CreateDirectory(dir);
-
         var json = JsonConvert.SerializeObject(ruleFileContent, Formatting.Indented, new JsonSerializerSettings
         {
             ContractResolver = new CamelCasePropertyNamesContractResolver(),
             NullValueHandling = NullValueHandling.Ignore
         });
-        File.WriteAllText(filePath, json);
+        _storage.WriteAllText(StoragePath.FromAbsolute(filePath), json);
         Invalidate();
     }
 
@@ -344,16 +367,12 @@ public class ConfigLoader
             RulesDirectory = string.IsNullOrWhiteSpace(rulesDirectory) ? null : rulesDirectory
         };
 
-        var dir = Path.GetDirectoryName(targetPath);
-        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
-            Directory.CreateDirectory(dir);
-
         var json = JsonConvert.SerializeObject(config, Formatting.Indented, new JsonSerializerSettings
         {
             ContractResolver = new CamelCasePropertyNamesContractResolver(),
             NullValueHandling = NullValueHandling.Ignore
         });
-        File.WriteAllText(targetPath, json);
+        _storage.WriteAllText(StoragePath.FromAbsolute(targetPath), json);
         Invalidate();
     }
 

--- a/src/BlockParam/Config/RulesDirectoryLoader.cs
+++ b/src/BlockParam/Config/RulesDirectoryLoader.cs
@@ -2,6 +2,7 @@ using System.IO;
 using Newtonsoft.Json;
 using BlockParam.Diagnostics;
 using BlockParam.Services;
+using BlockParam.Services.Storage;
 
 namespace BlockParam.Config;
 
@@ -9,9 +10,23 @@ namespace BlockParam.Config;
 /// Loads rule files from a shared directory and merges them.
 /// Files are loaded alphabetically for deterministic ordering.
 /// Only files with "version": "1.0" are recognized as BlockParam rules.
+///
+/// File I/O is routed through <see cref="IBlockParamStorage"/> so the
+/// storage-injecting <see cref="ConfigLoader"/> path stays disk-free in
+/// tests, satisfying the "no new <c>File.*</c> / <c>Directory.*</c> outside
+/// the storage layer" guardrail (#85).
 /// </summary>
 public class RulesDirectoryLoader
 {
+    private readonly IBlockParamStorage _storage;
+
+    public RulesDirectoryLoader() : this(FileSystemBlockParamStorage.Instance) { }
+
+    public RulesDirectoryLoader(IBlockParamStorage storage)
+    {
+        _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+    }
+
     /// <summary>
     /// Loads all .json rule files from the directory.
     /// Tolerates missing/unreachable directories (returns empty with warning).
@@ -27,17 +42,19 @@ public class RulesDirectoryLoader
         if (string.IsNullOrWhiteSpace(directoryPath))
             return result;
 
-        if (!Directory.Exists(directoryPath))
+        var dir = StoragePath.FromAbsolute(directoryPath);
+        if (!_storage.DirectoryExists(dir))
         {
             result.Warnings.Add($"Rules directory not found: {directoryPath}");
             return result;
         }
 
-        string[] files;
+        StoragePath[] files;
         try
         {
-            files = Directory.GetFiles(directoryPath, "*.json");
-            Array.Sort(files, StringComparer.OrdinalIgnoreCase); // Alphabetical
+            files = _storage.EnumerateFiles(dir, "*.json")
+                .OrderBy(p => p.FullPath, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
@@ -49,7 +66,7 @@ public class RulesDirectoryLoader
         foreach (var file in files)
         {
             // Skip files that exist in the local override directory
-            var fileName = Path.GetFileName(file);
+            var fileName = file.FileName;
             if (skipFileNames != null && fileName != null && skipFileNames.Contains(fileName))
             {
                 continue;
@@ -57,7 +74,7 @@ public class RulesDirectoryLoader
 
             try
             {
-                var json = File.ReadAllText(file);
+                var json = _storage.ReadAllText(file);
                 var config = JsonConvert.DeserializeObject<BulkChangeConfig>(json);
 
                 if (config == null) continue;
@@ -65,7 +82,7 @@ public class RulesDirectoryLoader
                 // Sentinel check: only files with version field are BlockParam rules
                 if (string.IsNullOrEmpty(config.Version))
                 {
-                    result.Warnings.Add($"Skipped non-rule file (no version): {Path.GetFileName(file)}");
+                    result.Warnings.Add($"Skipped non-rule file (no version): {file.FileName}");
                     continue;
                 }
 
@@ -77,7 +94,7 @@ public class RulesDirectoryLoader
                         var error = PathPatternMatcher.ValidatePattern(rule.PathPattern!);
                         if (error != null)
                         {
-                            result.Warnings.Add($"Skipped rule with invalid pattern in {Path.GetFileName(file)}: {error}");
+                            result.Warnings.Add($"Skipped rule with invalid pattern in {file.FileName}: {error}");
                             continue;
                         }
                     }
@@ -88,12 +105,12 @@ public class RulesDirectoryLoader
             }
             catch (JsonException ex)
             {
-                result.Warnings.Add($"Invalid JSON in {Path.GetFileName(file)}: {ex.Message}");
+                result.Warnings.Add($"Invalid JSON in {file.FileName}: {ex.Message}");
                 Log.Warning(ex, "Invalid JSON in rule file: {File}", file);
             }
             catch (IOException ex)
             {
-                result.Warnings.Add($"Cannot read {Path.GetFileName(file)}: {ex.Message}");
+                result.Warnings.Add($"Cannot read {file.FileName}: {ex.Message}");
                 Log.Warning(ex, "Cannot read rule file: {File}", file);
             }
         }

--- a/src/BlockParam/Licensing/LocalUsageTracker.cs
+++ b/src/BlockParam/Licensing/LocalUsageTracker.cs
@@ -1,5 +1,5 @@
-using System.IO;
 using BlockParam.Diagnostics;
+using BlockParam.Services.Storage;
 using Newtonsoft.Json;
 
 namespace BlockParam.Licensing;
@@ -7,12 +7,18 @@ namespace BlockParam.Licensing;
 /// <summary>
 /// Local, offline usage tracker that stores a daily counter in an encrypted file.
 /// Uses Windows DPAPI (ProtectedData) when available, falls back to obfuscation.
+///
+/// Persistence goes through <see cref="IBlockParamStorage"/> so the production
+/// file-system path and unit tests share the same code path. Direct
+/// <c>File.*</c> / <c>Directory.*</c> calls live in
+/// <see cref="FileSystemBlockParamStorage"/>, not here (#85 guardrail).
 /// </summary>
 public class LocalUsageTracker : IUsageTracker
 {
     public const int DefaultDailyLimit = 200;
 
-    private readonly string _storagePath;
+    private readonly IBlockParamStorage _storage;
+    private readonly StoragePath _storagePath;
     private readonly Func<DateTime> _dateProvider;
 
     public int DailyLimit { get; }
@@ -21,7 +27,20 @@ public class LocalUsageTracker : IUsageTracker
         string storagePath,
         int dailyLimit = DefaultDailyLimit,
         Func<DateTime>? dateProvider = null)
+        : this(FileSystemBlockParamStorage.Instance,
+               StoragePath.FromAbsolute(storagePath),
+               dailyLimit,
+               dateProvider)
     {
+    }
+
+    public LocalUsageTracker(
+        IBlockParamStorage storage,
+        StoragePath storagePath,
+        int dailyLimit = DefaultDailyLimit,
+        Func<DateTime>? dateProvider = null)
+    {
+        _storage = storage ?? throw new ArgumentNullException(nameof(storage));
         _storagePath = storagePath;
         DailyLimit = dailyLimit;
         _dateProvider = dateProvider ?? (() => DateTime.Now);
@@ -48,12 +67,17 @@ public class LocalUsageTracker : IUsageTracker
 
     private UsageData ReadData()
     {
-        if (!File.Exists(_storagePath))
+        // Local copy so any property access on the readonly StoragePath field
+        // emits ldloca rather than ldflda — partial-trust IL gate (see
+        // CLAUDE.md "Hard rules" and UiZoomService).
+        var path = _storagePath;
+
+        if (!_storage.FileExists(path))
             return new UsageData { Date = TodayString(), Count = 0 };
 
         try
         {
-            var bytes = File.ReadAllBytes(_storagePath);
+            var bytes = _storage.ReadAllBytes(path);
             var json = Obfuscation.Deobfuscate(bytes);
             var data = JsonConvert.DeserializeObject<UsageData>(json);
 
@@ -75,45 +99,25 @@ public class LocalUsageTracker : IUsageTracker
         {
             // Corrupt file: reset gracefully. Log so repeated resets don't
             // stay silent — they could signal tampering or a real read bug.
-            Log.Warning(ex, "LocalUsageTracker: resetting corrupt usage file {Path}", _storagePath);
+            Log.Warning(ex, "LocalUsageTracker: resetting corrupt usage file {Path}", path.FullPath);
             return new UsageData { Date = TodayString(), Count = 0 };
         }
     }
 
     private void WriteData(UsageData data)
     {
-        var dir = Path.GetDirectoryName(_storagePath);
-        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
-            Directory.CreateDirectory(dir);
-
+        var path = _storagePath;
         var json = JsonConvert.SerializeObject(data);
         var bytes = Obfuscation.Obfuscate(json);
 
-        var tempPath = _storagePath + ".tmp";
-        File.WriteAllBytes(tempPath, bytes);
-
-        try
-        {
-            // File.Replace is atomic on NTFS via the Win32 ReplaceFile API —
-            // no gap between deleting the destination and renaming the temp
-            // file where another writer (or another Add-In instance) could
-            // create the destination and make our Move throw. .NET 5+ has
-            // File.Move(overwrite: true); we target net48 and don't want
-            // P/Invoke MoveFileEx just for this counter.
-            if (File.Exists(_storagePath))
-                File.Replace(tempPath, _storagePath, destinationBackupFileName: null);
-            else
-                File.Move(tempPath, _storagePath);
-        }
-        catch (IOException ex)
-        {
-            // ReplaceFile fails across volumes and on non-NTFS filesystems.
-            // Fall back to overwrite-copy — non-atomic but FS-agnostic, and
-            // a torn write here just resets the counter on next read.
-            Log.Warning(ex, "LocalUsageTracker: File.Replace fell back to overwrite-copy for {Path}", _storagePath);
-            File.Copy(tempPath, _storagePath, overwrite: true);
-            try { File.Delete(tempPath); } catch (IOException) { /* best-effort cleanup */ }
-        }
+        // Write-temp + atomic-replace via storage. IBlockParamStorage.Replace
+        // is atomic on NTFS (Win32 ReplaceFile) and falls back to overwrite-copy
+        // on cross-volume / non-NTFS — a torn write here just resets the counter
+        // on next read so the fallback is acceptable. WriteAllBytes auto-creates
+        // the parent directory, so no separate EnsureDirectory needed.
+        var tempPath = new StoragePath(path.FullPath + ".tmp");
+        _storage.WriteAllBytes(tempPath, bytes);
+        _storage.Replace(tempPath, path);
     }
 
     private string TodayString() => _dateProvider().ToString("yyyy-MM-dd");

--- a/src/BlockParam/Licensing/OnlineLicenseService.cs
+++ b/src/BlockParam/Licensing/OnlineLicenseService.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
@@ -7,6 +6,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using BlockParam.Diagnostics;
 using BlockParam.Services;
+using BlockParam.Services.Storage;
 
 namespace BlockParam.Licensing;
 
@@ -38,9 +38,11 @@ public class OnlineLicenseService : ILicenseService
     private static readonly TimeSpan CacheGracePeriod = TimeSpan.FromHours(48);
     private static readonly int MaxRetryAttempts = 4;
 
-    private readonly string _storagePath;
+    private readonly IBlockParamStorage _storage;
+    private readonly StoragePath _licenseDataPath;
+    private readonly StoragePath _cachePath;
+    private readonly StoragePath _sharedLicenseFilePath;
     private readonly string? _serverBaseUrl;
-    private readonly string? _sharedLicenseFilePath;
     private readonly Func<DateTime> _utcNow;
     private readonly object _lock = new();
 
@@ -65,12 +67,28 @@ public class OnlineLicenseService : ILicenseService
         string? serverBaseUrl,
         Func<DateTime>? utcNow = null,
         string? sharedLicenseFilePath = null)
+        : this(FileSystemBlockParamStorage.Instance,
+               StoragePath.FromAbsolute(storagePath),
+               serverBaseUrl,
+               utcNow,
+               string.IsNullOrWhiteSpace(sharedLicenseFilePath)
+                   ? default
+                   : StoragePath.FromAbsolute(sharedLicenseFilePath!))
     {
-        _storagePath = storagePath;
+    }
+
+    public OnlineLicenseService(
+        IBlockParamStorage storage,
+        StoragePath storageDir,
+        string? serverBaseUrl,
+        Func<DateTime>? utcNow = null,
+        StoragePath sharedLicenseFilePath = default)
+    {
+        _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+        _licenseDataPath = storageDir / "license.json";
+        _cachePath = storageDir / "license_cache.dat";
+        _sharedLicenseFilePath = sharedLicenseFilePath;
         _serverBaseUrl = serverBaseUrl?.TrimEnd('/');
-        _sharedLicenseFilePath = string.IsNullOrWhiteSpace(sharedLicenseFilePath)
-            ? null
-            : sharedLicenseFilePath;
         _utcNow = utcNow ?? (() => DateTime.UtcNow);
 
         _licenseData = LoadLicenseData();
@@ -98,7 +116,7 @@ public class OnlineLicenseService : ILicenseService
                 IsServerReachable = _cache != null && (_utcNow() - _cache.ReceivedAtUtc).TotalMinutes < 5,
                 ErrorMessage = _cache?.ErrorMessage,
                 IsManagedKey = _isManagedKey,
-                ManagedKeyFilePath = _isManagedKey ? _sharedLicenseFilePath : null
+                ManagedKeyFilePath = _isManagedKey ? ManagedKeyFilePathString() : null
             };
         }
     }
@@ -188,8 +206,8 @@ public class OnlineLicenseService : ILicenseService
             _licenseData = null;
             _cache = null;
             _proActive = false;
-            DeleteFile(LicenseDataPath);
-            DeleteFile(CachePath);
+            BestEffortDelete(_licenseDataPath);
+            BestEffortDelete(_cachePath);
         }
 
         StopHeartbeat();
@@ -368,12 +386,16 @@ public class OnlineLicenseService : ILicenseService
     /// </summary>
     private void AdoptSharedLicenseKeyIfPresent()
     {
-        if (_sharedLicenseFilePath == null) return;
+        // Local copy of the readonly struct — never call instance members on
+        // the field directly (partial-trust IL gate, see UiZoomService).
+        var shared = _sharedLicenseFilePath;
+        if (shared.IsEmpty) return;
 
-        var sharedKey = TryReadSharedLicenseKey(_sharedLicenseFilePath);
+        var sharedKey = TryReadSharedLicenseKey(shared);
         if (string.IsNullOrEmpty(sharedKey)) return;
 
         _isManagedKey = true;
+        var sharedPath = shared.FullPath;
 
         // Same key as already cached → keep existing instanceId and cache so we
         // don't churn the server-side session on every Add-In start.
@@ -384,14 +406,14 @@ public class OnlineLicenseService : ILicenseService
             // this start?" — fires once per TIA launch, not per heartbeat, so
             // it doesn't flood the log even on the same-key (no-op) path.
             Log.Information("Managed license file at {Path} matches cached key — no change",
-                _sharedLicenseFilePath);
+                sharedPath);
             return;
         }
 
         // Key changed (rotation or first-time rollout). Replace the local copy and
         // drop the stale cache so EvaluateTier doesn't grant Pro on the old key.
         Log.Information("Adopting managed license key from {Path} (rotation or first rollout)",
-            _sharedLicenseFilePath);
+            sharedPath);
         _licenseData = new LicenseData
         {
             LicenseKey = sharedKey,
@@ -401,21 +423,21 @@ public class OnlineLicenseService : ILicenseService
         SaveLicenseData(_licenseData);
 
         _cache = null;
-        DeleteFile(CachePath);
+        BestEffortDelete(_cachePath);
     }
 
-    private static string? TryReadSharedLicenseKey(string path)
+    private string? TryReadSharedLicenseKey(StoragePath path)
     {
         try
         {
-            if (!File.Exists(path)) return null;
-            var content = File.ReadAllText(path).Trim();
+            if (!_storage.FileExists(path)) return null;
+            var content = _storage.ReadAllText(path).Trim();
             return string.IsNullOrEmpty(content) ? null : content;
         }
         catch (Exception ex)
         {
             // Unreadable shared file is non-fatal — fall back to user-local cache.
-            Log.Warning(ex, "Cannot read managed license file at {Path}", path);
+            Log.Warning(ex, "Cannot read managed license file at {Path}", path.FullPath);
             return null;
         }
     }
@@ -483,80 +505,87 @@ public class OnlineLicenseService : ILicenseService
     }
 
     // --- Persistence ---
-
-    private string LicenseDataPath => Path.Combine(_storagePath, "license.json");
-    private string CachePath => Path.Combine(_storagePath, "license_cache.dat");
+    //
+    // All file I/O goes through IBlockParamStorage so tests can substitute an
+    // in-memory fake and so the "no new File.*/Directory.* outside the storage
+    // layer" guardrail (#85) stays satisfied. WriteAll* auto-creates parents,
+    // which is why there's no explicit EnsureDirectory.
 
     private LicenseData? LoadLicenseData()
     {
+        var path = _licenseDataPath;
         try
         {
-            if (!File.Exists(LicenseDataPath)) return null;
-            var json = File.ReadAllText(LicenseDataPath);
+            if (!_storage.FileExists(path)) return null;
+            var json = _storage.ReadAllText(path);
             return JsonConvert.DeserializeObject<LicenseData>(json);
         }
         catch (Exception ex)
         {
-            Log.Warning(ex, "Cannot read license data from {Path}", LicenseDataPath);
+            Log.Warning(ex, "Cannot read license data from {Path}", path.FullPath);
             return null;
         }
     }
 
     private void SaveLicenseData(LicenseData data)
     {
+        var path = _licenseDataPath;
         try
         {
-            EnsureDirectory(_storagePath);
             var json = JsonConvert.SerializeObject(data, Formatting.Indented);
-            File.WriteAllText(LicenseDataPath, json);
+            _storage.WriteAllText(path, json);
         }
         catch (Exception ex)
         {
-            Log.Warning(ex, "Cannot save license data to {Path}", LicenseDataPath);
+            Log.Warning(ex, "Cannot save license data to {Path}", path.FullPath);
         }
     }
 
     private CachedLicenseResponse? LoadCache()
     {
+        var path = _cachePath;
         try
         {
-            if (!File.Exists(CachePath)) return null;
-            var bytes = File.ReadAllBytes(CachePath);
+            if (!_storage.FileExists(path)) return null;
+            var bytes = _storage.ReadAllBytes(path);
             var json = Obfuscation.Deobfuscate(bytes);
             return JsonConvert.DeserializeObject<CachedLicenseResponse>(json);
         }
         catch (Exception ex)
         {
-            Log.Warning(ex, "Cannot read license cache from {Path}", CachePath);
+            Log.Warning(ex, "Cannot read license cache from {Path}", path.FullPath);
             return null;
         }
     }
 
     private void SaveCache(CachedLicenseResponse cache)
     {
+        var path = _cachePath;
         try
         {
-            EnsureDirectory(_storagePath);
             var json = JsonConvert.SerializeObject(cache);
             var bytes = Obfuscation.Obfuscate(json);
-            File.WriteAllBytes(CachePath, bytes);
+            _storage.WriteAllBytes(path, bytes);
         }
         catch (Exception ex)
         {
-            Log.Warning(ex, "Cannot save license cache to {Path}", CachePath);
+            Log.Warning(ex, "Cannot save license cache to {Path}", path.FullPath);
         }
     }
 
-    private static void DeleteFile(string path)
+    private void BestEffortDelete(StoragePath path)
     {
-        try { if (File.Exists(path)) File.Delete(path); }
+        try { _storage.DeleteFile(path); }
         catch { /* best effort */ }
     }
 
-    private static void EnsureDirectory(string path)
+    private string? ManagedKeyFilePathString()
     {
-        if (!Directory.Exists(path))
-            Directory.CreateDirectory(path);
+        // Property accessor on a readonly struct field needs a local copy
+        // (partial-trust IL gate). Returns null when no shared file is
+        // configured, mirroring the legacy nullable-string field semantics.
+        var shared = _sharedLicenseFilePath;
+        return shared.IsEmpty ? null : shared.FullPath;
     }
 
     private static string GetAddinVersion()

--- a/src/BlockParam/Services/RuleFileRepository.cs
+++ b/src/BlockParam/Services/RuleFileRepository.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Security;
 using BlockParam.Diagnostics;
 using BlockParam.Services.Storage;
 
@@ -62,7 +63,15 @@ public class RuleFileRepository
             Array.Sort(files, StringComparer.OrdinalIgnoreCase);
             return files;
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        // SecurityException is intentional alongside IO/UnauthorizedAccess:
+        // under TIA's partial-trust Add-In Loader sandbox, EnumerateFiles can
+        // throw SecurityException on paths the host process denies — the old
+        // ConfigEditorViewModel.ClaimsFor used a bare catch precisely so the
+        // save flow could fall through with an empty claim seed and let
+        // SaveRuleFile surface a clearer error later. PEVerify + the
+        // PartialTrustSandboxTests defend against the IL pattern; this catch
+        // defends against the runtime exception path that pattern produces.
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException)
         {
             Log.Warning(ex, "Cannot access rules directory: {Path}", directoryPath);
             return Array.Empty<string>();

--- a/src/BlockParam/Services/RuleFileRepository.cs
+++ b/src/BlockParam/Services/RuleFileRepository.cs
@@ -1,0 +1,94 @@
+using System.IO;
+using BlockParam.Diagnostics;
+using BlockParam.Services.Storage;
+
+namespace BlockParam.Services;
+
+/// <summary>
+/// File-system gateway for the rule files the ConfigEditor surfaces. Owns the
+/// "list every <c>*.json</c> under this directory", "exists?" and
+/// "best-effort delete" patterns that used to be duplicated in
+/// <c>ConfigEditorViewModel</c> and <c>RuleFileViewModel</c>.
+///
+/// All I/O is routed through <see cref="IBlockParamStorage"/>, satisfying the
+/// "no new <c>File.*</c> / <c>Directory.*</c> outside the storage layer"
+/// guardrail (#85) and letting tests swap in
+/// <see cref="InMemoryBlockParamStorage"/> without touching disk.
+/// </summary>
+public class RuleFileRepository
+{
+    private readonly IBlockParamStorage _storage;
+
+    public static RuleFileRepository Default { get; } = new(FileSystemBlockParamStorage.Instance);
+
+    public RuleFileRepository(IBlockParamStorage storage)
+    {
+        _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+    }
+
+    public bool DirectoryExists(string directoryPath)
+    {
+        if (string.IsNullOrWhiteSpace(directoryPath)) return false;
+        return _storage.DirectoryExists(StoragePath.FromAbsolute(directoryPath));
+    }
+
+    public bool FileExists(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath)) return false;
+        return _storage.FileExists(StoragePath.FromAbsolute(filePath));
+    }
+
+    public string ReadAllText(string filePath) =>
+        _storage.ReadAllText(StoragePath.FromAbsolute(filePath));
+
+    /// <summary>
+    /// Returns the absolute paths of every <c>*.json</c> file directly under
+    /// <paramref name="directoryPath"/>, sorted case-insensitively. Returns an
+    /// empty array (never throws) when the directory is missing or unreadable,
+    /// mirroring the legacy ConfigEditorViewModel.LoadFilesFromDirectory
+    /// behaviour the user already relies on.
+    /// </summary>
+    public string[] ListJsonFiles(string directoryPath)
+    {
+        if (string.IsNullOrWhiteSpace(directoryPath)) return Array.Empty<string>();
+        var dir = StoragePath.FromAbsolute(directoryPath);
+        if (!_storage.DirectoryExists(dir)) return Array.Empty<string>();
+
+        try
+        {
+            var files = _storage.EnumerateFiles(dir, "*.json")
+                .Select(p => p.FullPath)
+                .ToArray();
+            Array.Sort(files, StringComparer.OrdinalIgnoreCase);
+            return files;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Log.Warning(ex, "Cannot access rules directory: {Path}", directoryPath);
+            return Array.Empty<string>();
+        }
+    }
+
+    /// <summary>
+    /// Returns just the file names (not absolute paths) of every <c>*.json</c>
+    /// directly under <paramref name="directoryPath"/>. Missing/unreadable
+    /// directories return empty — used by the ConfigEditor to seed
+    /// per-target-dir filename-claim sets.
+    /// </summary>
+    public IEnumerable<string> ListJsonFileNames(string directoryPath)
+    {
+        foreach (var p in ListJsonFiles(directoryPath))
+            yield return Path.GetFileName(p);
+    }
+
+    /// <summary>
+    /// Deletes a file. Throws on permission/lock errors so the caller can
+    /// surface a meaningful error (the ConfigEditor uses this to populate
+    /// <c>ValidationMessage</c>); silently returns when the path is empty.
+    /// </summary>
+    public void DeleteFile(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath)) return;
+        _storage.DeleteFile(StoragePath.FromAbsolute(filePath));
+    }
+}

--- a/src/BlockParam/Services/Storage/FileSystemBlockParamStorage.cs
+++ b/src/BlockParam/Services/Storage/FileSystemBlockParamStorage.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using BlockParam.Diagnostics;
 
 namespace BlockParam.Services.Storage;
 
@@ -120,12 +121,36 @@ public sealed class FileSystemBlockParamStorage : IBlockParamStorage
                 File.Move(source.FullPath, destination.FullPath);
             }
         }
-        catch (IOException)
+        catch (IOException ex)
         {
             // ReplaceFile fails across volumes and on non-NTFS filesystems.
-            // Fall back to overwrite-copy — non-atomic but FS-agnostic.
+            // Fall back to overwrite-copy — non-atomic but FS-agnostic. Log
+            // the fallback once per write: the pre-#85-followup LocalUsageTracker
+            // emitted this from its own catch so support could grep the per-day
+            // runtime log for "torn write resets counter" tickets and confirm
+            // a non-NTFS / network-redirected %APPDATA% is the cause. Logging
+            // belongs here now that the catch lives in the storage layer.
+            Log.Warning(ex,
+                "FileSystemBlockParamStorage.Replace fell back to overwrite-copy " +
+                "(cross-volume or non-NTFS): {Source} → {Destination}",
+                source.FullPath, destination.FullPath);
             File.Copy(source.FullPath, destination.FullPath, overwrite: true);
-            try { File.Delete(source.FullPath); } catch (IOException) { /* best-effort */ }
+            // UnauthorizedAccessException alongside IOException: AV holding an
+            // open handle on the temp file can fail the delete while the copy
+            // already succeeded. Leaking a .tmp is the price; surfacing the
+            // exception to a caller that has no recovery path would crash the
+            // user-visible flow (counter save → Apply pipeline). Logged so the
+            // leak is at least visible.
+            try
+            {
+                File.Delete(source.FullPath);
+            }
+            catch (Exception delEx) when (delEx is IOException or UnauthorizedAccessException)
+            {
+                Log.Warning(delEx,
+                    "FileSystemBlockParamStorage.Replace could not remove source temp {Source}; orphaned",
+                    source.FullPath);
+            }
         }
     }
 

--- a/src/BlockParam/Services/Storage/FileSystemBlockParamStorage.cs
+++ b/src/BlockParam/Services/Storage/FileSystemBlockParamStorage.cs
@@ -100,6 +100,35 @@ public sealed class FileSystemBlockParamStorage : IBlockParamStorage
         return e.MoveNext();
     }
 
+    public void Replace(StoragePath source, StoragePath destination)
+    {
+        EnsureParent(destination);
+        try
+        {
+            if (File.Exists(destination.FullPath))
+            {
+                // File.Replace is atomic on NTFS via Win32 ReplaceFile — no gap
+                // between deleting the destination and renaming the temp file
+                // where another writer could create the destination and make a
+                // naive Move throw. .NET 5+ has File.Move(overwrite); we target
+                // net48 and don't want P/Invoke MoveFileEx just for this.
+                File.Replace(source.FullPath, destination.FullPath,
+                    destinationBackupFileName: null);
+            }
+            else
+            {
+                File.Move(source.FullPath, destination.FullPath);
+            }
+        }
+        catch (IOException)
+        {
+            // ReplaceFile fails across volumes and on non-NTFS filesystems.
+            // Fall back to overwrite-copy — non-atomic but FS-agnostic.
+            File.Copy(source.FullPath, destination.FullPath, overwrite: true);
+            try { File.Delete(source.FullPath); } catch (IOException) { /* best-effort */ }
+        }
+    }
+
     private static void EnsureParent(StoragePath path)
     {
         var parent = Path.GetDirectoryName(path.FullPath);

--- a/src/BlockParam/Services/Storage/IBlockParamStorage.cs
+++ b/src/BlockParam/Services/Storage/IBlockParamStorage.cs
@@ -88,4 +88,17 @@ public interface IBlockParamStorage
     /// remove" without enumerating the entire contents.
     /// </summary>
     bool HasAnyEntries(StoragePath directory);
+
+    /// <summary>
+    /// Moves <paramref name="source"/> over <paramref name="destination"/>,
+    /// replacing the destination if it exists. Best-effort atomic on NTFS
+    /// (Win32 ReplaceFile) when the destination already exists; falls back
+    /// to overwrite-copy + source-delete on cross-volume / non-NTFS targets
+    /// and uses a plain rename when the destination is absent. Source must
+    /// exist — throws otherwise.
+    ///
+    /// Used by callers that need write-temp-then-rename atomicity to avoid
+    /// torn writes on crash (see <c>LocalUsageTracker</c>'s counter file).
+    /// </summary>
+    void Replace(StoragePath source, StoragePath destination);
 }

--- a/src/BlockParam/Services/Storage/InMemoryBlockParamStorage.cs
+++ b/src/BlockParam/Services/Storage/InMemoryBlockParamStorage.cs
@@ -155,12 +155,13 @@ public sealed class InMemoryBlockParamStorage : IBlockParamStorage
         if (!_files.TryGetValue(source.FullPath, out var bytes))
             throw new FileNotFoundException($"In-memory file not found: {source.FullPath}", source.FullPath);
         EnsureParent(destination);
-        // Defensive copy of the byte[]: WriteAllBytes and ReadAllBytes both
-        // clone on cross-boundary access to keep the in-memory store immune
-        // to caller mutation. Aliasing source's array into the destination
-        // key would silently violate that invariant — and the bug would only
-        // surface against the real FS impl where File.Replace gives the
-        // destination its own bytes.
+        // Defensive Clone matches the WriteAllBytes/ReadAllBytes contract.
+        // It is not currently observable through the public API (Replace
+        // immediately removes the source key so no caller can mutate the
+        // shared reference), but assigning the same array into two keys
+        // makes the invariant "each _files[key] is uniquely owned" silently
+        // false and would surface the moment someone adds a Copy() method or
+        // similar second-reference API. Cheap to keep correct here.
         _files[destination.FullPath] = (byte[])bytes.Clone();
         // Carry the source's last-write time across to the destination. The
         // FS implementation's File.Replace / File.Move preserves the source's

--- a/src/BlockParam/Services/Storage/InMemoryBlockParamStorage.cs
+++ b/src/BlockParam/Services/Storage/InMemoryBlockParamStorage.cs
@@ -155,8 +155,22 @@ public sealed class InMemoryBlockParamStorage : IBlockParamStorage
         if (!_files.TryGetValue(source.FullPath, out var bytes))
             throw new FileNotFoundException($"In-memory file not found: {source.FullPath}", source.FullPath);
         EnsureParent(destination);
-        _files[destination.FullPath] = bytes;
-        _lastWriteTimes[destination.FullPath] = Clock();
+        // Defensive copy of the byte[]: WriteAllBytes and ReadAllBytes both
+        // clone on cross-boundary access to keep the in-memory store immune
+        // to caller mutation. Aliasing source's array into the destination
+        // key would silently violate that invariant — and the bug would only
+        // surface against the real FS impl where File.Replace gives the
+        // destination its own bytes.
+        _files[destination.FullPath] = (byte[])bytes.Clone();
+        // Carry the source's last-write time across to the destination. The
+        // FS implementation's File.Replace / File.Move preserves the source's
+        // mtime; stamping Clock() here would make age-based sweepers
+        // (TempCacheCleanup style) green against the fake and red against
+        // real disk.
+        _lastWriteTimes[destination.FullPath] =
+            _lastWriteTimes.TryGetValue(source.FullPath, out var sourceMtime)
+                ? sourceMtime
+                : Clock();
         _files.Remove(source.FullPath);
         _lastWriteTimes.Remove(source.FullPath);
     }

--- a/src/BlockParam/Services/Storage/InMemoryBlockParamStorage.cs
+++ b/src/BlockParam/Services/Storage/InMemoryBlockParamStorage.cs
@@ -150,6 +150,17 @@ public sealed class InMemoryBlockParamStorage : IBlockParamStorage
             || _directories.Any(d => !string.Equals(d, dir, StringComparison.OrdinalIgnoreCase) && IsUnder(d, dir));
     }
 
+    public void Replace(StoragePath source, StoragePath destination)
+    {
+        if (!_files.TryGetValue(source.FullPath, out var bytes))
+            throw new FileNotFoundException($"In-memory file not found: {source.FullPath}", source.FullPath);
+        EnsureParent(destination);
+        _files[destination.FullPath] = bytes;
+        _lastWriteTimes[destination.FullPath] = Clock();
+        _files.Remove(source.FullPath);
+        _lastWriteTimes.Remove(source.FullPath);
+    }
+
     /// <summary>
     /// Test-only helper: stamps an explicit last-write time on a file so
     /// tests can simulate "aged" files without juggling <see cref="Clock"/>.

--- a/src/BlockParam/Services/TagTableDirectoryProbe.cs
+++ b/src/BlockParam/Services/TagTableDirectoryProbe.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using BlockParam.Services.Storage;
 
 namespace BlockParam.Services;
@@ -24,7 +25,7 @@ public class TagTableDirectoryProbe
         _storage = storage ?? throw new ArgumentNullException(nameof(storage));
     }
 
-    public bool Exists(string? directoryPath)
+    public bool Exists([NotNullWhen(true)] string? directoryPath)
     {
         if (string.IsNullOrWhiteSpace(directoryPath)) return false;
         return _storage.DirectoryExists(StoragePath.FromAbsolute(directoryPath!));

--- a/src/BlockParam/Services/TagTableDirectoryProbe.cs
+++ b/src/BlockParam/Services/TagTableDirectoryProbe.cs
@@ -1,0 +1,53 @@
+using BlockParam.Services.Storage;
+
+namespace BlockParam.Services;
+
+/// <summary>
+/// Tiny helper that answers the two questions <see cref="UI.BulkChangeViewModel"/>
+/// asks the tag-table cache directory: "does it exist?" and "how fresh is the
+/// newest <c>*.xml</c> file in it?".
+///
+/// Exists so the ViewModel doesn't reach for <c>System.IO.Directory</c> /
+/// <c>File.GetLastWriteTime</c> directly, keeping the "no new file I/O
+/// outside a storage layer" guardrail (#85) honest while not bloating the
+/// already-large ViewModel with another seam.
+/// </summary>
+public class TagTableDirectoryProbe
+{
+    private readonly IBlockParamStorage _storage;
+
+    public static TagTableDirectoryProbe Default { get; } =
+        new(FileSystemBlockParamStorage.Instance);
+
+    public TagTableDirectoryProbe(IBlockParamStorage storage)
+    {
+        _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+    }
+
+    public bool Exists(string? directoryPath)
+    {
+        if (string.IsNullOrWhiteSpace(directoryPath)) return false;
+        return _storage.DirectoryExists(StoragePath.FromAbsolute(directoryPath!));
+    }
+
+    /// <summary>
+    /// Returns the most recent <c>LastWriteTime</c> across all <c>*.xml</c>
+    /// files directly under <paramref name="directoryPath"/>, or null when
+    /// the directory is missing / empty. Callers format the age string —
+    /// keeping the policy in one place (the ViewModel) instead of having
+    /// the probe second-guess what "just now" / "5m ago" should look like.
+    /// </summary>
+    public DateTime? GetNewestXmlWriteTime(string? directoryPath)
+    {
+        if (!Exists(directoryPath)) return null;
+        var dir = StoragePath.FromAbsolute(directoryPath!);
+
+        DateTime? newest = null;
+        foreach (var f in _storage.EnumerateFiles(dir, "*.xml"))
+        {
+            var t = _storage.GetLastWriteTime(f);
+            if (newest == null || t > newest) newest = t;
+        }
+        return newest;
+    }
+}

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -97,6 +97,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
     private readonly Action? _onRefreshTagTables;
     private readonly string? _tagTableDir;
+    private readonly TagTableDirectoryProbe _tagTableProbe = TagTableDirectoryProbe.Default;
     private readonly Action? _onRefreshUdtTypes;
     private readonly string? _udtDir;
     // #155 cross-open staleness valves: clear the TIA-session gates owned by
@@ -1935,7 +1936,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         if (_tagTableDir == null) return;
 
         _onRefreshTagTables?.Invoke();
-        if (System.IO.Directory.Exists(_tagTableDir))
+        if (_tagTableProbe.Exists(_tagTableDir))
         {
             var tagReader = new XmlFileTagTableReader(_tagTableDir);
             _tagTableCache = new TagTableCache(tagReader);
@@ -2031,7 +2032,7 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         _onInvalidateTagTableSession?.Invoke();
         _onRefreshTagTables?.Invoke();
 
-        if (_tagTableDir != null && System.IO.Directory.Exists(_tagTableDir))
+        if (_tagTableProbe.Exists(_tagTableDir))
         {
             var tagReader = new XmlFileTagTableReader(_tagTableDir);
             _tagTableCache = new TagTableCache(tagReader);
@@ -2049,23 +2050,17 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
 
     private void UpdateTagTableAge()
     {
-        if (_tagTableDir == null || !System.IO.Directory.Exists(_tagTableDir))
+        var newest = _tagTableProbe.GetNewestXmlWriteTime(_tagTableDir);
+        if (newest == null)
         {
             TagTableAge = "no data";
             return;
         }
-        var files = System.IO.Directory.GetFiles(_tagTableDir, "*.xml");
-        if (files.Length == 0)
-        {
-            TagTableAge = "no data";
-            return;
-        }
-        var newest = files.Max(f => System.IO.File.GetLastWriteTime(f));
-        var age = DateTime.Now - newest;
+        var age = DateTime.Now - newest.Value;
         TagTableAge = age.TotalMinutes < 1 ? "just now"
             : age.TotalMinutes < 60 ? $"{(int)age.TotalMinutes}m ago"
             : age.TotalHours < 24 ? $"{(int)age.TotalHours}h ago"
-            : $"{newest:yyyy-MM-dd HH:mm}";
+            : $"{newest.Value:yyyy-MM-dd HH:mm}";
     }
 
     // ExpandAll / CollapseAll commands + ExpandAllChildren / CollapseAllChildren

--- a/src/BlockParam/UI/ConfigEditorViewModel.cs
+++ b/src/BlockParam/UI/ConfigEditorViewModel.cs
@@ -21,6 +21,7 @@ namespace BlockParam.UI;
 public class ConfigEditorViewModel : ViewModelBase
 {
     private readonly ConfigLoader _configLoader;
+    private readonly RuleFileRepository _ruleFiles;
     private readonly Dispatcher _dispatcher;
     private string _sharedRulesDirectory = "";
     private string _validationMessage = "";
@@ -31,8 +32,17 @@ public class ConfigEditorViewModel : ViewModelBase
     public ConfigEditorViewModel(
         ConfigLoader configLoader,
         IEnumerable<string>? tagTableNames = null)
+        : this(configLoader, tagTableNames, RuleFileRepository.Default)
+    {
+    }
+
+    internal ConfigEditorViewModel(
+        ConfigLoader configLoader,
+        IEnumerable<string>? tagTableNames,
+        RuleFileRepository ruleFiles)
     {
         _configLoader = configLoader;
+        _ruleFiles = ruleFiles ?? throw new ArgumentNullException(nameof(ruleFiles));
         // Capture the UI-thread dispatcher at construction. Save flows defer
         // a reload via this dispatcher; using Dispatcher.CurrentDispatcher
         // inside the deferred callback would be wrong if Save was ever
@@ -195,7 +205,7 @@ public class ConfigEditorViewModel : ViewModelBase
         LoadFilesFromDirectory(localDir, RuleSource.Local, allFiles);
 
         var projectDir = _configLoader.GetTiaProjectRulesDirectory();
-        if (projectDir != null && Directory.Exists(projectDir))
+        if (projectDir != null && _ruleFiles.DirectoryExists(projectDir))
             LoadFilesFromDirectory(projectDir, RuleSource.TiaProject, allFiles);
 
         // Group by filename (override unit is the file). Same physical path
@@ -226,24 +236,11 @@ public class ConfigEditorViewModel : ViewModelBase
     private void LoadFilesFromDirectory(string directoryPath, RuleSource source,
         List<RuleFileViewModel> target)
     {
-        if (string.IsNullOrWhiteSpace(directoryPath) || !Directory.Exists(directoryPath))
-            return;
-
-        string[] files;
-        try
+        // Repository handles missing/unreadable directories (returns empty
+        // array + logs warning) so this stays a straight enumerate-and-map.
+        foreach (var file in _ruleFiles.ListJsonFiles(directoryPath))
         {
-            files = Directory.GetFiles(directoryPath, "*.json");
-            Array.Sort(files, StringComparer.OrdinalIgnoreCase);
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-        {
-            Log.Warning(ex, "Cannot access rules directory: {Path}", directoryPath);
-            return;
-        }
-
-        foreach (var file in files)
-        {
-            var vm = RuleFileViewModel.FromFile(file, source);
+            var vm = RuleFileViewModel.FromFile(file, source, _ruleFiles);
             if (vm != null)
                 target.Add(vm);
         }
@@ -387,7 +384,7 @@ public class ConfigEditorViewModel : ViewModelBase
         {
             var candidate = i == 1 ? $"{baseName}.json" : $"{baseName}-{i}.json";
             var fullPath = Path.Combine(dir, candidate);
-            if (!stagedNames.Contains(candidate) && !File.Exists(fullPath))
+            if (!stagedNames.Contains(candidate) && !_ruleFiles.FileExists(fullPath))
                 return candidate;
         }
         return $"{baseName}-{Guid.NewGuid():N}.json";
@@ -400,18 +397,16 @@ public class ConfigEditorViewModel : ViewModelBase
     /// directory is fine — the claim set just stays seeded with whatever
     /// in-memory files have already been pre-claimed.
     /// </summary>
-    private static HashSet<string> ClaimsFor(
+    private HashSet<string> ClaimsFor(
         Dictionary<string, HashSet<string>> cache, string dir)
     {
         if (cache.TryGetValue(dir, out var set)) return set;
         set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        try
-        {
-            if (Directory.Exists(dir))
-                foreach (var p in Directory.EnumerateFiles(dir, "*.json"))
-                    set.Add(Path.GetFileName(p));
-        }
-        catch { /* unreadable dir → empty seed; SaveRuleFile will fail later with a clearer error */ }
+        // Repository swallows unreadable dirs and returns empty — the previous
+        // try/catch went away with the migration but the semantics are kept:
+        // empty seed lets SaveRuleFile fail later with a clearer error.
+        foreach (var name in _ruleFiles.ListJsonFileNames(dir))
+            set.Add(name);
         cache[dir] = set;
         return set;
     }
@@ -483,10 +478,10 @@ public class ConfigEditorViewModel : ViewModelBase
 
     private void DeleteFileFromDisk(RuleFileViewModel file)
     {
-        if (!File.Exists(file.FilePath)) return;
+        if (!_ruleFiles.FileExists(file.FilePath)) return;
         try
         {
-            File.Delete(file.FilePath);
+            _ruleFiles.DeleteFile(file.FilePath);
         }
         catch (Exception ex)
         {
@@ -507,12 +502,12 @@ public class ConfigEditorViewModel : ViewModelBase
 
         var currentPath = Path.GetFullPath(current.FilePath);
         var basePath = Path.GetFullPath(baseFile.FilePath);
-        if (File.Exists(currentPath)
+        if (_ruleFiles.FileExists(currentPath)
             && !string.Equals(currentPath, basePath, StringComparison.OrdinalIgnoreCase))
         {
             try
             {
-                File.Delete(currentPath);
+                _ruleFiles.DeleteFile(currentPath);
             }
             catch (Exception ex)
             {

--- a/src/BlockParam/UI/RuleFileViewModel.cs
+++ b/src/BlockParam/UI/RuleFileViewModel.cs
@@ -323,13 +323,19 @@ public class RuleFileViewModel : ViewModelBase
     /// <summary>
     /// Loads a rule file from disk. Returns null when the file is missing,
     /// unreadable, or doesn't carry the BlockParam version sentinel.
+    /// File I/O is routed through <see cref="RuleFileRepository"/> so this
+    /// stays inside the storage-layer guardrail (#85).
     /// </summary>
-    public static RuleFileViewModel? FromFile(string filePath, RuleSource source)
+    public static RuleFileViewModel? FromFile(string filePath, RuleSource source) =>
+        FromFile(filePath, source, RuleFileRepository.Default);
+
+    internal static RuleFileViewModel? FromFile(
+        string filePath, RuleSource source, RuleFileRepository repository)
     {
-        if (!File.Exists(filePath)) return null;
+        if (!repository.FileExists(filePath)) return null;
 
         string json;
-        try { json = File.ReadAllText(filePath); }
+        try { json = repository.ReadAllText(filePath); }
         catch { return null; }
 
         BulkChangeConfig? config;


### PR DESCRIPTION
## Summary

Pushes the four heaviest direct-`File.*` / `Directory.*` hotspots through the existing `IBlockParamStorage` abstraction so the **"no new I/O outside a storage layer"** guardrail (#85) is enforced on them too. Net **-66 direct I/O call sites** across the audited files.

| File | Before | After |
|---|---:|---:|
| `Config/ConfigLoader.cs` | 18 | 0 |
| `Licensing/LocalUsageTracker.cs` | 13 | 0 |
| `UI/ConfigEditorViewModel.cs` | 13 | 0 |
| `Licensing/OnlineLicenseService.cs` | 11 | 0 |
| `UI/BulkChangeViewModel.cs` | 6 | 0 |
| `Config/RulesDirectoryLoader.cs` | 3 | 0 |
| `UI/RuleFileViewModel.cs` | 2 | 0 |

## How

- Public string-path constructors on every migrated class are **preserved** so production call sites (DevLauncher, BulkChangeContextMenu, existing disk-based tests) don't change.
- Storage-injecting overloads sit alongside them. Default to `FileSystemBlockParamStorage.Instance` in production.
- Two focused services pulled the I/O off the two ViewModels rather than re-bloating them (per the CLAUDE.md "default to extracting, not extending, when touching hotspots" rule):
  - `Services/RuleFileRepository.cs` — covers `ConfigEditorViewModel` + `RuleFileViewModel.FromFile`.
  - `Services/TagTableDirectoryProbe.cs` — covers the three tag-table-cache calls in `BulkChangeViewModel`.
- `IBlockParamStorage` gains a single `Replace(source, destination)` primitive so `LocalUsageTracker`'s write-temp-then-atomic-swap pattern survives the migration with the same NTFS-atomic / cross-volume-fallback semantics it always had.
- `RulesDirectoryLoader` also migrated — it's the chain ConfigLoader hands the rules-dir scan to, so in-memory tests would have been blind to its files otherwise.
- `TagTableDirectoryProbe.Exists` is annotated `[NotNullWhen(true)]` (PolySharp polyfills it on net48) so the existing nullable-flow check at `BulkChangeViewModel.cs:2037` (passing `_tagTableDir` into `XmlFileTagTableReader`) stays clean post-guard.

## Tests

New in-memory regression suite (31 tests across 5 files, all green):

- `Storage/LocalUsageTrackerStorageTests`
- `Storage/OnlineLicenseServiceStorageTests`
- `Storage/ConfigLoaderStorageTests`
- `Storage/RuleFileRepositoryTests`
- `Storage/TagTableDirectoryProbeTests`
- Plus `Replace()` cases added to the existing `InMemory` + `FileSystem` storage suites.

Disk-based tests in `LocalUsageTrackerTests`, `OnlineLicenseServiceSharedFileTests`, `ConfigLoaderTests`, `RulesDirectoryLoaderTests` are **untouched** — they continue to exercise the real FileSystem implementation through the unchanged string-path constructors.

## Test plan

- [x] Build green (V20 + V21 + PEVerify all pass on the prior `[run-ci]` push)
- [x] 1204 tests pass; the one red test (`OpenPathPerfTests.H4_SmartExpandFlatBuild_BeforeAfter`) is a wall-clock stopwatch comparison unrelated to the diff — pre-existing CI flake
- [ ] Re-run CI as part of this PR to confirm green
- [ ] Code review pass

Refs: #85, follows the `UiZoomService` / `TempCacheCleanup` / `CacheCleanupSchedule` migration pattern.

https://claude.ai/code/session_011oJvK1gzGxdvM45z2gZe8n

---
_Generated by [Claude Code](https://claude.ai/code/session_011oJvK1gzGxdvM45z2gZe8n)_