### PR TITLE
refactor(#171): extract TemporalFormatParser from TiaDataTypeValidator

### DIFF
--- a/src/BlockParam.Tests/TemporalFormatParserTests.cs
+++ b/src/BlockParam.Tests/TemporalFormatParserTests.cs
@@ -26,9 +26,9 @@ public class TemporalFormatParserTests
     [InlineData("LTime_Of_Day", TemporalDataType.LTimeOfDay)]
     [InlineData("LTimeOfDay", TemporalDataType.LTimeOfDay)]
     [InlineData("LTod", TemporalDataType.LTimeOfDay)]
-    [InlineData("Date_And_Time", TemporalDataType.DateTime)]
-    [InlineData("DateTime", TemporalDataType.DateTime)]
-    [InlineData("DT", TemporalDataType.DateTime)]
+    [InlineData("Date_And_Time", TemporalDataType.DateAndTime)]
+    [InlineData("DateTime", TemporalDataType.DateAndTime)]
+    [InlineData("DT", TemporalDataType.DateAndTime)]
     [InlineData("LDate_And_Time", TemporalDataType.LDateTime)]
     [InlineData("LDateTime", TemporalDataType.LDateTime)]
     [InlineData("LDT", TemporalDataType.LDateTime)]
@@ -58,6 +58,9 @@ public class TemporalFormatParserTests
     [InlineData("T#2h30m", 2 * 3_600_000.0 + 30 * 60_000.0)]
     [InlineData("T#1d2h3m4s5ms", 86_400_000.0 + 2 * 3_600_000.0 + 3 * 60_000.0 + 4_000.0 + 5.0)]
     [InlineData("T#-500ms", -500.0)]
+    [InlineData("T#0s", 0.0)]                  // zero-edge
+    [InlineData("T#1d", 86_400_000.0)]         // isolates the day multiplier
+    [InlineData("T#1ns", 0.000_001)]           // smallest sub-ms unit
     public void TryParse_Time_AcceptedForms(string literal, double expectedMs)
     {
         TemporalFormatParser.TryParse(literal, TemporalDataType.Time, out var v).Should().BeTrue();
@@ -206,16 +209,16 @@ public class TemporalFormatParserTests
     [Fact]
     public void TryParse_DateTime_AcceptedForms()
     {
-        TemporalFormatParser.TryParse("DT#2024-01-15-12:30:00", TemporalDataType.DateTime, out var v).Should().BeTrue();
+        TemporalFormatParser.TryParse("DT#2024-01-15-12:30:00", TemporalDataType.DateAndTime, out var v).Should().BeTrue();
         v.NumericValue.Should().BeGreaterThan(0);
-        v.Kind.Should().Be(TemporalDataType.DateTime);
+        v.Kind.Should().Be(TemporalDataType.DateAndTime);
     }
 
     [Fact]
     public void TryParse_DateTime_RangeEdge_HourBoundary()
     {
-        TemporalFormatParser.TryParse("DT#2024-01-15-23:59:59", TemporalDataType.DateTime, out _).Should().BeTrue();
-        TemporalFormatParser.TryParse("DT#2024-01-15-24:00:00", TemporalDataType.DateTime, out _).Should().BeFalse();
+        TemporalFormatParser.TryParse("DT#2024-01-15-23:59:59", TemporalDataType.DateAndTime, out _).Should().BeTrue();
+        TemporalFormatParser.TryParse("DT#2024-01-15-24:00:00", TemporalDataType.DateAndTime, out _).Should().BeFalse();
     }
 
     [Theory]
@@ -224,7 +227,7 @@ public class TemporalFormatParserTests
     [InlineData("DT#nope")]
     public void TryParse_DateTime_RejectsMalformed(string literal)
     {
-        TemporalFormatParser.TryParse(literal, TemporalDataType.DateTime, out _).Should().BeFalse();
+        TemporalFormatParser.TryParse(literal, TemporalDataType.DateAndTime, out _).Should().BeFalse();
     }
 
     // --- LDateTime ---

--- a/src/BlockParam.Tests/TemporalFormatParserTests.cs
+++ b/src/BlockParam.Tests/TemporalFormatParserTests.cs
@@ -1,0 +1,306 @@
+using FluentAssertions;
+using BlockParam.Services;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Covers the six TIA temporal datatype families consolidated under
+/// <see cref="TemporalFormatParser"/> by issue #171. Each datatype has
+/// at least: a canonical accepted form, the prefix variants the type-key
+/// map recognizes, a malformed input, and a range-edge case.
+/// </summary>
+public class TemporalFormatParserTests
+{
+    // --- TryResolveType / IsTemporalType: key aliases ---
+
+    [Theory]
+    [InlineData("Time", TemporalDataType.Time)]
+    [InlineData("LTime", TemporalDataType.LTime)]
+    [InlineData("S5Time", TemporalDataType.S5Time)]
+    [InlineData("Date", TemporalDataType.Date)]
+    [InlineData("LDate", TemporalDataType.LDate)]
+    [InlineData("Time_Of_Day", TemporalDataType.TimeOfDay)]
+    [InlineData("TimeOfDay", TemporalDataType.TimeOfDay)]
+    [InlineData("Tod", TemporalDataType.TimeOfDay)]
+    [InlineData("LTime_Of_Day", TemporalDataType.LTimeOfDay)]
+    [InlineData("LTimeOfDay", TemporalDataType.LTimeOfDay)]
+    [InlineData("LTod", TemporalDataType.LTimeOfDay)]
+    [InlineData("Date_And_Time", TemporalDataType.DateTime)]
+    [InlineData("DateTime", TemporalDataType.DateTime)]
+    [InlineData("DT", TemporalDataType.DateTime)]
+    [InlineData("LDate_And_Time", TemporalDataType.LDateTime)]
+    [InlineData("LDateTime", TemporalDataType.LDateTime)]
+    [InlineData("LDT", TemporalDataType.LDateTime)]
+    public void TryResolveType_RecognizesAllAliases(string key, TemporalDataType expected)
+    {
+        TemporalFormatParser.TryResolveType(key, out var resolved).Should().BeTrue();
+        resolved.Should().Be(expected);
+        TemporalFormatParser.IsTemporalType(key).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("Int")]
+    [InlineData("UDT_Foo")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void TryResolveType_RejectsNonTemporal(string? key)
+    {
+        TemporalFormatParser.TryResolveType(key, out _).Should().BeFalse();
+        TemporalFormatParser.IsTemporalType(key).Should().BeFalse();
+    }
+
+    // --- Time ---
+
+    [Theory]
+    [InlineData("T#500ms", 500.0)]
+    [InlineData("T#1s", 1_000.0)]
+    [InlineData("T#2h30m", 2 * 3_600_000.0 + 30 * 60_000.0)]
+    [InlineData("T#1d2h3m4s5ms", 86_400_000.0 + 2 * 3_600_000.0 + 3 * 60_000.0 + 4_000.0 + 5.0)]
+    [InlineData("T#-500ms", -500.0)]
+    public void TryParse_Time_AcceptedForms(string literal, double expectedMs)
+    {
+        TemporalFormatParser.TryParse(literal, TemporalDataType.Time, out var v).Should().BeTrue();
+        v.NumericValue.Should().Be(expectedMs);
+        v.Kind.Should().Be(TemporalDataType.Time);
+    }
+
+    [Theory]
+    [InlineData("500ms")]                  // missing prefix
+    [InlineData("T#")]                     // empty body
+    [InlineData("T#abc")]                  // junk
+    [InlineData("T#1x")]                   // unknown unit
+    [InlineData("LT#500ms")]               // wrong prefix for Time
+    public void TryParse_Time_RejectsMalformed(string literal)
+    {
+        TemporalFormatParser.TryParse(literal, TemporalDataType.Time, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryParse_Time_AcceptsS5TPrefix()
+    {
+        TemporalFormatParser.TryParse("S5T#2s", TemporalDataType.Time, out var v).Should().BeTrue();
+        v.NumericValue.Should().Be(2_000.0);
+    }
+
+    // --- LTime (only LT# accepted) ---
+
+    [Fact]
+    public void TryParse_LTime_AcceptsLTPrefix()
+    {
+        TemporalFormatParser.TryParse("LT#1us", TemporalDataType.LTime, out var v).Should().BeTrue();
+        v.NumericValue.Should().BeApproximately(0.001, 1e-9);
+    }
+
+    [Theory]
+    [InlineData("T#500ms")]   // T# isn't valid for LTime
+    [InlineData("LT#")]
+    [InlineData("LT#xyz")]
+    public void TryParse_LTime_RejectsMalformed(string literal)
+    {
+        TemporalFormatParser.TryParse(literal, TemporalDataType.LTime, out _).Should().BeFalse();
+    }
+
+    // --- S5Time ---
+
+    [Fact]
+    public void TryParse_S5Time_AcceptsBothS5TAndT()
+    {
+        // S5Time accepts both T# and S5T# (mirrors the validator's behaviour).
+        TemporalFormatParser.TryParse("S5T#500ms", TemporalDataType.S5Time, out var v1).Should().BeTrue();
+        v1.NumericValue.Should().Be(500.0);
+
+        TemporalFormatParser.TryParse("T#2s", TemporalDataType.S5Time, out var v2).Should().BeTrue();
+        v2.NumericValue.Should().Be(2_000.0);
+    }
+
+    [Fact]
+    public void TryParse_S5Time_RejectsMalformed()
+    {
+        TemporalFormatParser.TryParse("S5T#nope", TemporalDataType.S5Time, out _).Should().BeFalse();
+    }
+
+    // --- Date ---
+
+    [Theory]
+    [InlineData("D#2024-01-15")]
+    [InlineData("D#1990-01-01")]
+    public void TryParse_Date_AcceptedForms(string literal)
+    {
+        TemporalFormatParser.TryParse(literal, TemporalDataType.Date, out var v).Should().BeTrue();
+        v.NumericValue.Should().BeGreaterThan(0); // ticks
+    }
+
+    [Fact]
+    public void TryParse_Date_RangeEdge_MonthDayBoundary()
+    {
+        TemporalFormatParser.TryParse("D#2024-12-31", TemporalDataType.Date, out _).Should().BeTrue();
+        TemporalFormatParser.TryParse("D#2024-13-01", TemporalDataType.Date, out _).Should().BeFalse();
+        TemporalFormatParser.TryParse("D#2024-00-15", TemporalDataType.Date, out _).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("2024-01-15")]    // missing prefix
+    [InlineData("D#24-01-15")]    // 2-digit year
+    [InlineData("D#nope")]
+    [InlineData("D#")]
+    public void TryParse_Date_RejectsMalformed(string literal)
+    {
+        TemporalFormatParser.TryParse(literal, TemporalDataType.Date, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryParse_LDate_UsesDHashPrefix()
+    {
+        // LDate shares D# with Date (per the existing validator mapping).
+        TemporalFormatParser.TryParse("D#2024-06-01", TemporalDataType.LDate, out var v).Should().BeTrue();
+        v.Kind.Should().Be(TemporalDataType.LDate);
+    }
+
+    // --- TimeOfDay ---
+
+    [Theory]
+    [InlineData("TOD#00:00:00", 0.0)]
+    [InlineData("TOD#12:30:00", (12 * 3600.0 + 30 * 60.0) * 1000.0)]
+    [InlineData("TOD#23:59:59", (23 * 3600.0 + 59 * 60.0 + 59.0) * 1000.0)]
+    public void TryParse_TimeOfDay_AcceptedForms(string literal, double expectedMs)
+    {
+        TemporalFormatParser.TryParse(literal, TemporalDataType.TimeOfDay, out var v).Should().BeTrue();
+        v.NumericValue.Should().BeApproximately(expectedMs, 1e-6);
+    }
+
+    [Theory]
+    [InlineData("12:30:00")]          // missing prefix
+    [InlineData("TOD#24:00:00")]      // out-of-range hour rejected by TimeSpan parser
+    [InlineData("TOD#12:60:00")]      // out-of-range minute
+    [InlineData("TOD#nope")]
+    public void TryParse_TimeOfDay_RejectsMalformed(string literal)
+    {
+        TemporalFormatParser.TryParse(literal, TemporalDataType.TimeOfDay, out _).Should().BeFalse();
+    }
+
+    // --- LTimeOfDay ---
+
+    [Fact]
+    public void TryParse_LTimeOfDay_AcceptsFractionalAndPlain()
+    {
+        TemporalFormatParser.TryParse("LTOD#12:30:00.123", TemporalDataType.LTimeOfDay, out var v1).Should().BeTrue();
+        v1.NumericValue.Should().BeApproximately((12 * 3600.0 + 30 * 60.0) * 1000.0 + 123.0, 1e-6);
+
+        // The LTOD# body validator also accepts the plain TOD-body form.
+        TemporalFormatParser.TryParse("LTOD#12:30:00", TemporalDataType.LTimeOfDay, out var v2).Should().BeTrue();
+        v2.NumericValue.Should().BeApproximately((12 * 3600.0 + 30 * 60.0) * 1000.0, 1e-6);
+    }
+
+    [Theory]
+    [InlineData("TOD#12:30:00")]      // wrong prefix
+    [InlineData("LTOD#24:00:00")]     // out-of-range hour
+    [InlineData("LTOD#nope")]
+    public void TryParse_LTimeOfDay_RejectsMalformed(string literal)
+    {
+        TemporalFormatParser.TryParse(literal, TemporalDataType.LTimeOfDay, out _).Should().BeFalse();
+    }
+
+    // --- DateTime ---
+
+    [Fact]
+    public void TryParse_DateTime_AcceptedForms()
+    {
+        TemporalFormatParser.TryParse("DT#2024-01-15-12:30:00", TemporalDataType.DateTime, out var v).Should().BeTrue();
+        v.NumericValue.Should().BeGreaterThan(0);
+        v.Kind.Should().Be(TemporalDataType.DateTime);
+    }
+
+    [Fact]
+    public void TryParse_DateTime_RangeEdge_HourBoundary()
+    {
+        TemporalFormatParser.TryParse("DT#2024-01-15-23:59:59", TemporalDataType.DateTime, out _).Should().BeTrue();
+        TemporalFormatParser.TryParse("DT#2024-01-15-24:00:00", TemporalDataType.DateTime, out _).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("2024-01-15-12:30:00")]    // missing prefix
+    [InlineData("DT#2024-01-15 12:30:00")] // space separator (TIA uses dash)
+    [InlineData("DT#nope")]
+    public void TryParse_DateTime_RejectsMalformed(string literal)
+    {
+        TemporalFormatParser.TryParse(literal, TemporalDataType.DateTime, out _).Should().BeFalse();
+    }
+
+    // --- LDateTime ---
+
+    [Fact]
+    public void TryParse_LDateTime_AcceptsFractionalAndPlain()
+    {
+        TemporalFormatParser.TryParse("LDT#2024-01-15-12:30:00.1234567", TemporalDataType.LDateTime, out var v1).Should().BeTrue();
+        v1.NumericValue.Should().BeGreaterThan(0);
+
+        TemporalFormatParser.TryParse("LDT#2024-01-15-12:30:00", TemporalDataType.LDateTime, out var v2).Should().BeTrue();
+        v2.NumericValue.Should().BeGreaterThan(0);
+    }
+
+    [Theory]
+    [InlineData("DT#2024-01-15-12:30:00")]   // wrong prefix
+    [InlineData("LDT#2024-01-15-24:00:00")]  // hour overflow
+    public void TryParse_LDateTime_RejectsMalformed(string literal)
+    {
+        TemporalFormatParser.TryParse(literal, TemporalDataType.LDateTime, out _).Should().BeFalse();
+    }
+
+    // --- Body-only validation paths used by the validator ---
+
+    [Theory]
+    [InlineData("500ms", true)]
+    [InlineData("2h30m", true)]
+    [InlineData("-1s", true)]
+    [InlineData("", false)]
+    [InlineData("-", false)]
+    [InlineData("abc", false)]
+    public void IsValidTimeBody_Matches(string body, bool expected)
+        => TemporalFormatParser.IsValidTimeBody(body).Should().Be(expected);
+
+    [Theory]
+    [InlineData("2024-01-15", true)]
+    [InlineData("24-01-15", false)]
+    [InlineData("nope", false)]
+    public void IsValidDateBody_Matches(string body, bool expected)
+        => TemporalFormatParser.IsValidDateBody(body).Should().Be(expected);
+
+    [Theory]
+    [InlineData("12:30:00", true)]
+    [InlineData("12:30:00.123", false)]  // plain TOD body rejects fractional
+    [InlineData("nope", false)]
+    public void IsValidTimeOfDayBody_Matches(string body, bool expected)
+        => TemporalFormatParser.IsValidTimeOfDayBody(body).Should().Be(expected);
+
+    [Theory]
+    [InlineData("12:30:00", true)]
+    [InlineData("12:30:00.123", true)]
+    [InlineData("nope", false)]
+    public void IsValidLTimeOfDayBody_AcceptsBoth(string body, bool expected)
+        => TemporalFormatParser.IsValidLTimeOfDayBody(body).Should().Be(expected);
+
+    [Theory]
+    [InlineData("2024-01-15-12:30:00", true)]
+    [InlineData("2024-01-15-12:30:00.123", false)]
+    [InlineData("nope", false)]
+    public void IsValidDateTimeBody_Matches(string body, bool expected)
+        => TemporalFormatParser.IsValidDateTimeBody(body).Should().Be(expected);
+
+    [Theory]
+    [InlineData("2024-01-15-12:30:00", true)]
+    [InlineData("2024-01-15-12:30:00.1234567", true)]
+    [InlineData("nope", false)]
+    public void IsValidLDateTimeBody_AcceptsBoth(string body, bool expected)
+        => TemporalFormatParser.IsValidLDateTimeBody(body).Should().Be(expected);
+
+    // --- Empty / null literal handling ---
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void TryParse_EmptyLiteral_ReturnsFalse(string? literal)
+    {
+        TemporalFormatParser.TryParse(literal, TemporalDataType.Time, out _).Should().BeFalse();
+    }
+}

--- a/src/BlockParam/Services/TemporalFormatParser.cs
+++ b/src/BlockParam/Services/TemporalFormatParser.cs
@@ -18,7 +18,7 @@ public enum TemporalDataType
     LDate,
     TimeOfDay,
     LTimeOfDay,
-    DateTime,
+    DateAndTime,
     LDateTime,
 }
 
@@ -88,9 +88,9 @@ public static class TemporalFormatParser
             ["LTime_Of_Day"] = TemporalDataType.LTimeOfDay,
             ["LTimeOfDay"] = TemporalDataType.LTimeOfDay,
             ["LTod"] = TemporalDataType.LTimeOfDay,
-            ["Date_And_Time"] = TemporalDataType.DateTime,
-            ["DateTime"] = TemporalDataType.DateTime,
-            ["DT"] = TemporalDataType.DateTime,
+            ["Date_And_Time"] = TemporalDataType.DateAndTime,
+            ["DateTime"] = TemporalDataType.DateAndTime,
+            ["DT"] = TemporalDataType.DateAndTime,
             ["LDate_And_Time"] = TemporalDataType.LDateTime,
             ["LDateTime"] = TemporalDataType.LDateTime,
             ["LDT"] = TemporalDataType.LDateTime,
@@ -167,7 +167,7 @@ public static class TemporalFormatParser
                 }
                 return false;
 
-            case TemporalDataType.DateTime:
+            case TemporalDataType.DateAndTime:
                 if (TryParseDateTimeLiteral(v, "DT#", out var dt))
                 {
                     parsed = new TemporalValue(expected, dt);
@@ -190,29 +190,26 @@ public static class TemporalFormatParser
 
     /// <summary>Body of a T# / LT# / S5T# literal (the part after the prefix).</summary>
     public static bool IsValidTimeBody(string body)
-        => body != null && body.Length > 0
+        => body.Length > 0
            && body.Replace("-", "").Length > 0
            && TimeComponentsRegex.IsMatch(body);
 
     /// <summary>Body of a D# literal (<c>YYYY-MM-DD</c>).</summary>
-    public static bool IsValidDateBody(string body)
-        => body != null && DateRegex.IsMatch(body);
+    public static bool IsValidDateBody(string body) => DateRegex.IsMatch(body);
 
     /// <summary>Body of a TOD# literal (<c>HH:MM:SS</c>, no fractional seconds).</summary>
-    public static bool IsValidTimeOfDayBody(string body)
-        => body != null && TimeOfDayRegex.IsMatch(body);
+    public static bool IsValidTimeOfDayBody(string body) => TimeOfDayRegex.IsMatch(body);
 
     /// <summary>Body of an LTOD# literal — accepts the TOD# form too (fractional seconds optional).</summary>
     public static bool IsValidLTimeOfDayBody(string body)
-        => body != null && (LTimeOfDayRegex.IsMatch(body) || TimeOfDayRegex.IsMatch(body));
+        => LTimeOfDayRegex.IsMatch(body) || TimeOfDayRegex.IsMatch(body);
 
     /// <summary>Body of a DT# literal (<c>YYYY-MM-DD-HH:MM:SS</c>).</summary>
-    public static bool IsValidDateTimeBody(string body)
-        => body != null && DateTimeRegex.IsMatch(body);
+    public static bool IsValidDateTimeBody(string body) => DateTimeRegex.IsMatch(body);
 
     /// <summary>Body of an LDT# literal — accepts the DT# form too (fractional seconds optional).</summary>
     public static bool IsValidLDateTimeBody(string body)
-        => body != null && (LDateTimeRegex.IsMatch(body) || DateTimeRegex.IsMatch(body));
+        => LDateTimeRegex.IsMatch(body) || DateTimeRegex.IsMatch(body);
 
     // --- Internal numeric parsers ---
 

--- a/src/BlockParam/Services/TemporalFormatParser.cs
+++ b/src/BlockParam/Services/TemporalFormatParser.cs
@@ -1,0 +1,308 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace BlockParam.Services;
+
+/// <summary>
+/// The TIA temporal datatype families this parser recognizes.
+/// String keys (including the underscored and short aliases like
+/// <c>Time_Of_Day</c>, <c>Tod</c>, <c>DT</c>) map onto these via
+/// <see cref="TemporalFormatParser.TryResolveType"/>.
+/// </summary>
+public enum TemporalDataType
+{
+    Time,
+    LTime,
+    S5Time,
+    Date,
+    LDate,
+    TimeOfDay,
+    LTimeOfDay,
+    DateTime,
+    LDateTime,
+}
+
+/// <summary>
+/// Normalized numeric value parsed from a TIA temporal literal.
+/// Time / LTime / S5Time / TimeOfDay / LTimeOfDay yield milliseconds;
+/// Date / LDate / DateTime / LDateTime yield <see cref="System.DateTime.Ticks"/>.
+/// </summary>
+public readonly struct TemporalValue
+{
+    public TemporalDataType Kind { get; }
+    public double NumericValue { get; }
+
+    public TemporalValue(TemporalDataType kind, double numericValue)
+    {
+        Kind = kind;
+        NumericValue = numericValue;
+    }
+}
+
+/// <summary>
+/// Owns the regex grammar + range-aware parsing for TIA's six temporal
+/// literal families (T#, LT#, S5T#, D#, TOD#/LTOD#, DT#/LDT#). Extracted
+/// from <see cref="TiaDataTypeValidator"/> (issue #171) so the regexes
+/// and their downstream validation live together with a single test
+/// fixture for the whole family.
+/// </summary>
+/// <remarks>
+/// Partial-trust safe: uses only the same <c>static readonly Regex</c> +
+/// <see cref="RegexOptions.Compiled"/> pattern already proven under TIA's
+/// Add-In Loader sandbox (cf. <c>MultiSelectLog.cs</c>). No readonly-struct
+/// field access — <see cref="TemporalValue"/> is only constructed and
+/// returned via <c>out</c>, never stored as a readonly field.
+/// </remarks>
+public static class TemporalFormatParser
+{
+    private static readonly Regex TimeComponentsRegex = new(
+        @"^-?(\d+d)?(\d+h)?(\d+m(?!s))?(\d+s)?(\d+ms)?(\d+us)?(\d+ns)?$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static readonly Regex DateRegex = new(
+        @"^\d{4}-\d{2}-\d{2}$", RegexOptions.Compiled);
+
+    private static readonly Regex TimeOfDayRegex = new(
+        @"^\d{1,2}:\d{2}:\d{2}$", RegexOptions.Compiled);
+
+    private static readonly Regex LTimeOfDayRegex = new(
+        @"^\d{1,2}:\d{2}:\d{2}\.\d{1,9}$", RegexOptions.Compiled);
+
+    private static readonly Regex DateTimeRegex = new(
+        @"^\d{4}-\d{2}-\d{2}-\d{1,2}:\d{2}:\d{2}$", RegexOptions.Compiled);
+
+    private static readonly Regex LDateTimeRegex = new(
+        @"^\d{4}-\d{2}-\d{2}-\d{1,2}:\d{2}:\d{2}\.\d{1,9}$", RegexOptions.Compiled);
+
+    private static readonly Dictionary<string, TemporalDataType> TypeKeys =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Time"] = TemporalDataType.Time,
+            ["LTime"] = TemporalDataType.LTime,
+            ["S5Time"] = TemporalDataType.S5Time,
+            ["Date"] = TemporalDataType.Date,
+            ["LDate"] = TemporalDataType.LDate,
+            ["Time_Of_Day"] = TemporalDataType.TimeOfDay,
+            ["TimeOfDay"] = TemporalDataType.TimeOfDay,
+            ["Tod"] = TemporalDataType.TimeOfDay,
+            ["LTime_Of_Day"] = TemporalDataType.LTimeOfDay,
+            ["LTimeOfDay"] = TemporalDataType.LTimeOfDay,
+            ["LTod"] = TemporalDataType.LTimeOfDay,
+            ["Date_And_Time"] = TemporalDataType.DateTime,
+            ["DateTime"] = TemporalDataType.DateTime,
+            ["DT"] = TemporalDataType.DateTime,
+            ["LDate_And_Time"] = TemporalDataType.LDateTime,
+            ["LDateTime"] = TemporalDataType.LDateTime,
+            ["LDT"] = TemporalDataType.LDateTime,
+        };
+
+    /// <summary>True when <paramref name="typeKey"/> names any TIA temporal family.</summary>
+    public static bool IsTemporalType(string? typeKey)
+        => !string.IsNullOrEmpty(typeKey) && TypeKeys.ContainsKey(typeKey!);
+
+    /// <summary>Maps a TIA type-key string (including underscore / short aliases) onto the enum.</summary>
+    public static bool TryResolveType(string? typeKey, out TemporalDataType type)
+    {
+        if (string.IsNullOrEmpty(typeKey))
+        {
+            type = default;
+            return false;
+        }
+        return TypeKeys.TryGetValue(typeKey!, out type);
+    }
+
+    /// <summary>
+    /// Parses a TIA temporal literal (e.g. <c>T#2h30m</c>, <c>D#2024-01-15</c>,
+    /// <c>TOD#12:30:00</c>, <c>DT#2024-01-15-12:30:00</c>) according to the
+    /// expected datatype, normalizing into <see cref="TemporalValue"/>.
+    /// </summary>
+    public static bool TryParse(string? literal, TemporalDataType expected, out TemporalValue parsed)
+    {
+        parsed = default;
+        if (string.IsNullOrEmpty(literal)) return false;
+        var v = literal!.Trim();
+
+        switch (expected)
+        {
+            case TemporalDataType.Time:
+            case TemporalDataType.S5Time:
+                if (TryParseTimeLiteral(v, "T#", out var t)
+                    || TryParseTimeLiteral(v, "S5T#", out t))
+                {
+                    parsed = new TemporalValue(expected, t);
+                    return true;
+                }
+                return false;
+
+            case TemporalDataType.LTime:
+                if (TryParseTimeLiteral(v, "LT#", out var lt))
+                {
+                    parsed = new TemporalValue(expected, lt);
+                    return true;
+                }
+                return false;
+
+            case TemporalDataType.Date:
+            case TemporalDataType.LDate:
+                if (TryParseDateLiteral(v, "D#", out var d))
+                {
+                    parsed = new TemporalValue(expected, d);
+                    return true;
+                }
+                return false;
+
+            case TemporalDataType.TimeOfDay:
+                if (TryParseTimeOfDayLiteral(v, "TOD#", out var tod))
+                {
+                    parsed = new TemporalValue(expected, tod);
+                    return true;
+                }
+                return false;
+
+            case TemporalDataType.LTimeOfDay:
+                if (TryParseTimeOfDayLiteral(v, "LTOD#", out var ltod))
+                {
+                    parsed = new TemporalValue(expected, ltod);
+                    return true;
+                }
+                return false;
+
+            case TemporalDataType.DateTime:
+                if (TryParseDateTimeLiteral(v, "DT#", out var dt))
+                {
+                    parsed = new TemporalValue(expected, dt);
+                    return true;
+                }
+                return false;
+
+            case TemporalDataType.LDateTime:
+                if (TryParseDateTimeLiteral(v, "LDT#", out var ldt))
+                {
+                    parsed = new TemporalValue(expected, ldt);
+                    return true;
+                }
+                return false;
+        }
+        return false;
+    }
+
+    // --- Format-only validators (used by TiaDataTypeValidator's Validate paths) ---
+
+    /// <summary>Body of a T# / LT# / S5T# literal (the part after the prefix).</summary>
+    public static bool IsValidTimeBody(string body)
+        => body != null && body.Length > 0
+           && body.Replace("-", "").Length > 0
+           && TimeComponentsRegex.IsMatch(body);
+
+    /// <summary>Body of a D# literal (<c>YYYY-MM-DD</c>).</summary>
+    public static bool IsValidDateBody(string body)
+        => body != null && DateRegex.IsMatch(body);
+
+    /// <summary>Body of a TOD# literal (<c>HH:MM:SS</c>, no fractional seconds).</summary>
+    public static bool IsValidTimeOfDayBody(string body)
+        => body != null && TimeOfDayRegex.IsMatch(body);
+
+    /// <summary>Body of an LTOD# literal — accepts the TOD# form too (fractional seconds optional).</summary>
+    public static bool IsValidLTimeOfDayBody(string body)
+        => body != null && (LTimeOfDayRegex.IsMatch(body) || TimeOfDayRegex.IsMatch(body));
+
+    /// <summary>Body of a DT# literal (<c>YYYY-MM-DD-HH:MM:SS</c>).</summary>
+    public static bool IsValidDateTimeBody(string body)
+        => body != null && DateTimeRegex.IsMatch(body);
+
+    /// <summary>Body of an LDT# literal — accepts the DT# form too (fractional seconds optional).</summary>
+    public static bool IsValidLDateTimeBody(string body)
+        => body != null && (LDateTimeRegex.IsMatch(body) || DateTimeRegex.IsMatch(body));
+
+    // --- Internal numeric parsers ---
+
+    private static bool TryParseTimeLiteral(string value, string prefix, out double ms)
+    {
+        ms = 0;
+        if (!value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var body = value.Substring(prefix.Length);
+        if (!IsValidTimeBody(body))
+            return false;
+
+        var match = TimeComponentsRegex.Match(body);
+        bool negative = body.StartsWith("-");
+        double total = 0;
+
+        if (match.Groups[1].Success) total += ParseDigits(match.Groups[1].Value) * 86_400_000.0;
+        if (match.Groups[2].Success) total += ParseDigits(match.Groups[2].Value) * 3_600_000.0;
+        if (match.Groups[3].Success) total += ParseDigits(match.Groups[3].Value) * 60_000.0;
+        if (match.Groups[4].Success) total += ParseDigits(match.Groups[4].Value) * 1_000.0;
+        if (match.Groups[5].Success) total += ParseDigitsMultiSuffix(match.Groups[5].Value, "ms");
+        if (match.Groups[6].Success) total += ParseDigitsMultiSuffix(match.Groups[6].Value, "us") * 0.001;
+        if (match.Groups[7].Success) total += ParseDigitsMultiSuffix(match.Groups[7].Value, "ns") * 0.000001;
+
+        ms = negative ? -total : total;
+        return true;
+    }
+
+    private static long ParseDigits(string component)
+    {
+        var digits = component.Substring(0, component.Length - 1);
+        return long.TryParse(digits, NumberStyles.None, CultureInfo.InvariantCulture, out var val) ? val : 0;
+    }
+
+    private static long ParseDigitsMultiSuffix(string component, string suffix)
+    {
+        var digits = component.Substring(0, component.Length - suffix.Length);
+        return long.TryParse(digits, NumberStyles.None, CultureInfo.InvariantCulture, out var val) ? val : 0;
+    }
+
+    private static bool TryParseDateLiteral(string value, string prefix, out double ticks)
+    {
+        ticks = 0;
+        if (!value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var body = value.Substring(prefix.Length);
+        if (System.DateTime.TryParseExact(body, "yyyy-MM-dd",
+            CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
+        {
+            ticks = date.Ticks;
+            return true;
+        }
+        return false;
+    }
+
+    private static bool TryParseTimeOfDayLiteral(string value, string prefix, out double ms)
+    {
+        ms = 0;
+        if (!value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var body = value.Substring(prefix.Length);
+        if (TimeSpan.TryParseExact(body, new[] { @"h\:mm\:ss", @"hh\:mm\:ss",
+            @"h\:mm\:ss\.FFFFFFF", @"hh\:mm\:ss\.FFFFFFF" },
+            CultureInfo.InvariantCulture, out var tod))
+        {
+            ms = tod.TotalMilliseconds;
+            return true;
+        }
+        return false;
+    }
+
+    private static bool TryParseDateTimeLiteral(string value, string prefix, out double ticks)
+    {
+        ticks = 0;
+        if (!value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var body = value.Substring(prefix.Length);
+        // TIA uses a dash between date and time: 2024-01-15-12:30:00
+        if (System.DateTime.TryParseExact(body,
+            new[] { "yyyy-MM-dd-H:mm:ss", "yyyy-MM-dd-HH:mm:ss",
+                    "yyyy-MM-dd-H:mm:ss.FFFFFFF", "yyyy-MM-dd-HH:mm:ss.FFFFFFF" },
+            CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt))
+        {
+            ticks = dt.Ticks;
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/BlockParam/Services/TiaDataTypeValidator.cs
+++ b/src/BlockParam/Services/TiaDataTypeValidator.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using System.Text.RegularExpressions;
 using BlockParam.Localization;
 
 namespace BlockParam.Services;
@@ -55,29 +54,6 @@ public static class TiaDataTypeValidator
             ["LDT"] = v => ValidateLDateTime(v, "LDT#", "LDT"),
         };
 
-    // Regex for time components: optional negative, then one or more groups of digits+unit
-    private static readonly Regex TimeComponentsRegex = new(
-        @"^-?(\d+d)?(\d+h)?(\d+m(?!s))?(\d+s)?(\d+ms)?(\d+us)?(\d+ns)?$",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
-    // Regex for date: YYYY-MM-DD
-    private static readonly Regex DateRegex = new(
-        @"^\d{4}-\d{2}-\d{2}$", RegexOptions.Compiled);
-
-    // Regex for time of day: HH:MM:SS (optional .mmm fractional)
-    private static readonly Regex TimeOfDayRegex = new(
-        @"^\d{1,2}:\d{2}:\d{2}$", RegexOptions.Compiled);
-
-    private static readonly Regex LTimeOfDayRegex = new(
-        @"^\d{1,2}:\d{2}:\d{2}\.\d{1,9}$", RegexOptions.Compiled);
-
-    // Regex for datetime: YYYY-MM-DD-HH:MM:SS
-    private static readonly Regex DateTimeRegex = new(
-        @"^\d{4}-\d{2}-\d{2}-\d{1,2}:\d{2}:\d{2}$", RegexOptions.Compiled);
-
-    private static readonly Regex LDateTimeRegex = new(
-        @"^\d{4}-\d{2}-\d{2}-\d{1,2}:\d{2}:\d{2}\.\d{1,9}$", RegexOptions.Compiled);
-
     /// <summary>
     /// Validates a value against the TIA literal format for the given data type.
     /// Returns null if valid, or an error message with format example if invalid.
@@ -109,9 +85,16 @@ public static class TiaDataTypeValidator
 
         var key = datatype?.Trim('"') ?? "";
 
-        // Temporal types: parse to milliseconds or ticks
-        if (TemporalTypes.Contains(key))
-            return TryParseTemporalValue(value, key, out result);
+        // Temporal types: delegate to the shared parser (#171)
+        if (TemporalFormatParser.TryResolveType(key, out var temporalType))
+        {
+            if (TemporalFormatParser.TryParse(value, temporalType, out var temporal))
+            {
+                result = temporal.NumericValue;
+                return true;
+            }
+            return false;
+        }
 
         // Try base-prefixed parsing first (16#, 8#, 2#)
         if (TryParseBasePrefixed(value, out var prefixedValue))
@@ -133,16 +116,6 @@ public static class TiaDataTypeValidator
         "Real", "LReal"
     };
 
-    private static readonly HashSet<string> TemporalTypes = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "Time", "LTime", "S5Time",
-        "Date", "LDate",
-        "Time_Of_Day", "TimeOfDay", "Tod",
-        "LTime_Of_Day", "LTimeOfDay", "LTod",
-        "Date_And_Time", "DateTime", "DT",
-        "LDate_And_Time", "LDateTime", "LDT"
-    };
-
     /// <summary>
     /// Returns whether the given data type supports Min/Max constraints.
     /// Includes numeric types and temporal types (Time, Date, etc.).
@@ -152,7 +125,7 @@ public static class TiaDataTypeValidator
     {
         if (string.IsNullOrEmpty(datatype)) return true;
         var key = datatype!.Trim('"');
-        return NumericTypes.Contains(key) || TemporalTypes.Contains(key);
+        return NumericTypes.Contains(key) || TemporalFormatParser.IsTemporalType(key);
     }
 
     /// <summary>
@@ -205,156 +178,6 @@ public static class TiaDataTypeValidator
             }
         }
 
-        return false;
-    }
-
-    // --- Temporal parsing for Min/Max ---
-
-    /// <summary>
-    /// Routes temporal value parsing to the correct method based on type.
-    /// All temporal types are normalized to milliseconds for comparison.
-    /// </summary>
-    private static bool TryParseTemporalValue(string value, string typeKey, out double result)
-    {
-        result = 0;
-        var v = value.Trim();
-
-        // Time / LTime / S5Time → parse T#/LT#/S5T# to milliseconds
-        if (typeKey.Equals("Time", StringComparison.OrdinalIgnoreCase)
-            || typeKey.Equals("S5Time", StringComparison.OrdinalIgnoreCase))
-            return TryParseTimeLiteral(v, "T#", out result)
-                || TryParseTimeLiteral(v, "S5T#", out result);
-
-        if (typeKey.Equals("LTime", StringComparison.OrdinalIgnoreCase))
-            return TryParseTimeLiteral(v, "LT#", out result);
-
-        // Date / LDate → parse D#YYYY-MM-DD to ticks
-        if (typeKey.Equals("Date", StringComparison.OrdinalIgnoreCase)
-            || typeKey.Equals("LDate", StringComparison.OrdinalIgnoreCase))
-            return TryParseDateLiteral(v, "D#", out result);
-
-        // TimeOfDay variants → parse TOD#HH:MM:SS to milliseconds
-        if (typeKey.Equals("Time_Of_Day", StringComparison.OrdinalIgnoreCase)
-            || typeKey.Equals("TimeOfDay", StringComparison.OrdinalIgnoreCase)
-            || typeKey.Equals("Tod", StringComparison.OrdinalIgnoreCase))
-            return TryParseTimeOfDayLiteral(v, "TOD#", out result);
-
-        if (typeKey.Equals("LTime_Of_Day", StringComparison.OrdinalIgnoreCase)
-            || typeKey.Equals("LTimeOfDay", StringComparison.OrdinalIgnoreCase)
-            || typeKey.Equals("LTod", StringComparison.OrdinalIgnoreCase))
-            return TryParseTimeOfDayLiteral(v, "LTOD#", out result);
-
-        // DateTime variants → parse DT#/LDT# to ticks
-        if (typeKey.Equals("Date_And_Time", StringComparison.OrdinalIgnoreCase)
-            || typeKey.Equals("DateTime", StringComparison.OrdinalIgnoreCase)
-            || typeKey.Equals("DT", StringComparison.OrdinalIgnoreCase))
-            return TryParseDateTimeLiteral(v, "DT#", out result);
-
-        if (typeKey.Equals("LDate_And_Time", StringComparison.OrdinalIgnoreCase)
-            || typeKey.Equals("LDateTime", StringComparison.OrdinalIgnoreCase)
-            || typeKey.Equals("LDT", StringComparison.OrdinalIgnoreCase))
-            return TryParseDateTimeLiteral(v, "LDT#", out result);
-
-        return false;
-    }
-
-    /// <summary>
-    /// Parses T#2h30m15s500ms into total milliseconds.
-    /// Supports components: d, h, m, s, ms, us, ns. Optional leading minus.
-    /// </summary>
-    private static bool TryParseTimeLiteral(string value, string prefix, out double ms)
-    {
-        ms = 0;
-        if (!value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        var body = value.Substring(prefix.Length);
-        var match = TimeComponentsRegex.Match(body);
-        if (!match.Success || body.Length == 0 || body.Replace("-", "").Length == 0)
-            return false;
-
-        bool negative = body.StartsWith("-");
-        double total = 0;
-
-        if (match.Groups[1].Success) total += ParseDigits(match.Groups[1].Value, 'd') * 86_400_000.0;
-        if (match.Groups[2].Success) total += ParseDigits(match.Groups[2].Value, 'h') * 3_600_000.0;
-        if (match.Groups[3].Success) total += ParseDigits(match.Groups[3].Value, 'm') * 60_000.0;
-        if (match.Groups[4].Success) total += ParseDigits(match.Groups[4].Value, 's') * 1_000.0;
-        if (match.Groups[5].Success) total += ParseDigitsMultiSuffix(match.Groups[5].Value, "ms");
-        if (match.Groups[6].Success) total += ParseDigitsMultiSuffix(match.Groups[6].Value, "us") * 0.001;
-        if (match.Groups[7].Success) total += ParseDigitsMultiSuffix(match.Groups[7].Value, "ns") * 0.000001;
-
-        ms = negative ? -total : total;
-        return true;
-    }
-
-    /// <summary>Extracts digits from a time component like "30m" → 30.</summary>
-    private static long ParseDigits(string component, char suffix)
-    {
-        var digits = component.Substring(0, component.Length - 1);
-        return long.TryParse(digits, NumberStyles.None, CultureInfo.InvariantCulture, out var val) ? val : 0;
-    }
-
-    /// <summary>Extracts digits from a multi-char suffix component like "500ms" → 500.</summary>
-    private static long ParseDigitsMultiSuffix(string component, string suffix)
-    {
-        var digits = component.Substring(0, component.Length - suffix.Length);
-        return long.TryParse(digits, NumberStyles.None, CultureInfo.InvariantCulture, out var val) ? val : 0;
-    }
-
-    /// <summary>Parses D#2024-01-15 into ticks for comparison.</summary>
-    private static bool TryParseDateLiteral(string value, string prefix, out double result)
-    {
-        result = 0;
-        if (!value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        var body = value.Substring(prefix.Length);
-        if (System.DateTime.TryParseExact(body, "yyyy-MM-dd",
-            CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
-        {
-            result = date.Ticks;
-            return true;
-        }
-        return false;
-    }
-
-    /// <summary>Parses TOD#12:30:00 or LTOD#12:30:00.123 into milliseconds.</summary>
-    private static bool TryParseTimeOfDayLiteral(string value, string prefix, out double result)
-    {
-        result = 0;
-        if (!value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        var body = value.Substring(prefix.Length);
-        if (TimeSpan.TryParseExact(body, new[] { @"h\:mm\:ss", @"hh\:mm\:ss",
-            @"h\:mm\:ss\.FFFFFFF", @"hh\:mm\:ss\.FFFFFFF" },
-            CultureInfo.InvariantCulture, out var tod))
-        {
-            result = tod.TotalMilliseconds;
-            return true;
-        }
-        return false;
-    }
-
-    /// <summary>Parses DT#2024-01-15-12:30:00 or LDT# with fractional seconds into ticks.</summary>
-    private static bool TryParseDateTimeLiteral(string value, string prefix, out double result)
-    {
-        result = 0;
-        if (!value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        var body = value.Substring(prefix.Length);
-        // TIA uses dash between date and time: 2024-01-15-12:30:00
-        // Try multiple formats to cover with/without fractional seconds
-        if (System.DateTime.TryParseExact(body,
-            new[] { "yyyy-MM-dd-H:mm:ss", "yyyy-MM-dd-HH:mm:ss",
-                    "yyyy-MM-dd-H:mm:ss.FFFFFFF", "yyyy-MM-dd-HH:mm:ss.FFFFFFF" },
-            CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt))
-        {
-            result = dt.Ticks;
-            return true;
-        }
         return false;
     }
 
@@ -459,8 +282,7 @@ public static class TiaDataTypeValidator
         if (v.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
         {
             var body = v.Substring(prefix.Length);
-            if (TimeComponentsRegex.IsMatch(body) && body.Length > 0
-                && body.Replace("-", "").Length > 0)
+            if (TemporalFormatParser.IsValidTimeBody(body))
                 return null;
         }
 
@@ -474,7 +296,7 @@ public static class TiaDataTypeValidator
         if (v.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
         {
             var body = v.Substring(prefix.Length);
-            if (DateRegex.IsMatch(body))
+            if (TemporalFormatParser.IsValidDateBody(body))
                 return null;
         }
 
@@ -488,7 +310,7 @@ public static class TiaDataTypeValidator
         if (v.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
         {
             var body = v.Substring(prefix.Length);
-            if (TimeOfDayRegex.IsMatch(body))
+            if (TemporalFormatParser.IsValidTimeOfDayBody(body))
                 return null;
         }
 
@@ -502,8 +324,7 @@ public static class TiaDataTypeValidator
         if (v.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
         {
             var body = v.Substring(prefix.Length);
-            // Accept both with and without fractional seconds
-            if (LTimeOfDayRegex.IsMatch(body) || TimeOfDayRegex.IsMatch(body))
+            if (TemporalFormatParser.IsValidLTimeOfDayBody(body))
                 return null;
         }
 
@@ -517,7 +338,7 @@ public static class TiaDataTypeValidator
         if (v.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
         {
             var body = v.Substring(prefix.Length);
-            if (DateTimeRegex.IsMatch(body))
+            if (TemporalFormatParser.IsValidDateTimeBody(body))
                 return null;
         }
 
@@ -531,18 +352,13 @@ public static class TiaDataTypeValidator
         if (v.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
         {
             var body = v.Substring(prefix.Length);
-            // Accept both with and without fractional seconds
-            if (LDateTimeRegex.IsMatch(body) || DateTimeRegex.IsMatch(body))
+            if (TemporalFormatParser.IsValidLDateTimeBody(body))
                 return null;
         }
 
         return Res.Get("TypeValidation_DateTime");
     }
 
-    /// <summary>
-    /// Determines if a value is likely a constant name (starts with a letter,
-    /// no known literal prefix). Constants are passed through without validation.
-    /// </summary>
     /// <summary>
     /// Checks if a value is a known constant name from loaded tag tables.
     /// Known constants bypass format validation since they resolve at TIA runtime.


### PR DESCRIPTION
## Summary

Consolidates the six hand-rolled temporal regexes that were sitting back-to-back at `TiaDataTypeValidator.cs:59-78` into a dedicated `TemporalFormatParser`, so the regexes and the parsing/validation logic that consumes them live together — and the whole temporal family is covered by one test fixture.

- **New** `src/BlockParam/Services/TemporalFormatParser.cs` — owns the 6 compiled regexes, a `TemporalDataType` enum, a `TemporalValue` struct, and a `TryParse(literal, expected, out TemporalValue)` façade. Body-level `IsValidXxxBody` helpers are exposed for `TiaDataTypeValidator`'s format-validation paths.
- **`TiaDataTypeValidator.cs`** drops **557 → 372 LOC** (−185, well above the ≥80-LOC criterion). All `Regex` fields removed; `TryParseNumericValue`, `SupportsMinMax`, and the temporal `ValidateXxx` methods now delegate to the new parser. Public API surface is unchanged so every existing caller (`ValueConstraint`, `RuleViewModel`, `BulkChangeService`, `MemberValidator`) stays green without modification.
- **New** `src/BlockParam.Tests/TemporalFormatParserTests.cs` — covers each of the 6 datatypes with a canonical accepted form, all prefix/short aliases (`Time_Of_Day` / `TimeOfDay` / `Tod`, `DT` / `DateTime` / `Date_And_Time`, etc.), malformed inputs, and range-edge cases (`D#2024-12-31` vs `D#2024-13-01`, `DT#…-23:59:59` vs `…-24:00:00`).

## Partial-trust safety

The new file uses the same `static readonly Regex` + `RegexOptions.Compiled` pattern already proven under TIA's Add-In Loader sandbox (cf. `MultiSelectLog.cs`). `TemporalValue` is a `readonly struct` that's only constructed and returned via `out` — never stored as a readonly field — so it doesn't trigger the `ldflda`-on-readonly-struct-field IL pattern from PR #131. The `peverify` job on this branch run was green.

## Test plan

- [x] V20 build + xUnit suite green
- [x] V21 build green
- [x] PEVerify (partial-trust IL gate) green — no new unverifiable IL
- [x] Existing `TiaDataTypeValidator` callers untouched (no API surface change)
- [x] New `TemporalFormatParserTests` cover the 6 datatypes' accepted/rejected forms + range edges per acceptance criteria

CI: [run #310](https://github.com/Sawascwoolf/BlockParam/actions/runs/26354314129) — all three required jobs green on `2e9efda`.

Closes #171

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKNAJ6kQEc8TdwaXn9ru6t)_