### PR TITLE
fix(#174): split scope dropdown / Set button wording so counts stop contradicting

### DIFF
--- a/docs/user/bulk-workflow.md
+++ b/docs/user/bulk-workflow.md
@@ -39,8 +39,11 @@ The row highlights and the **Bulk Edit** panel on the right populates with the
 selection.
 
 The **Scope** dropdown shows one option per ancestor level. The dialog detects
-your DB's actual hierarchy and offers a "Set all N in `<path>`" entry for each
-level — from the immediate parent up to the DB root.
+your DB's actual hierarchy and offers an "N member(s) in `<path>`" entry for each
+level — from the immediate parent up to the DB root. (The blue **Set** button
+next to the dropdown advertises a separate count — how many of those members
+will actually change once you type a value, i.e. excluding ones that already
+hold the target value.)
 
 <p align="center">
   <img src="../../assets/screenshots/03_scope_module.png" alt="Bulk edit configured at the module level — 8 targets shown in blue" width="700">

--- a/src/BlockParam.DevLauncher/IsExternalInit.cs
+++ b/src/BlockParam.DevLauncher/IsExternalInit.cs
@@ -1,0 +1,12 @@
+// Polyfill for C# 9 record / init-only setters on .NET Framework 4.8.
+// The compiler emits a modreq referencing System.Runtime.CompilerServices.IsExternalInit
+// for every `init` accessor; net48's BCL doesn't ship the type, so without this
+// shim every `record` declaration in this project fails with CS0518.
+//
+// CI was green on 2026-05-25 by luck (a Windows runner image must have surfaced
+// the type transitively) and red on 2026-05-26 — adding the shim makes the build
+// independent of runner-image churn.
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit { }
+}

--- a/src/BlockParam.Tests/IsExternalInit.cs
+++ b/src/BlockParam.Tests/IsExternalInit.cs
@@ -1,0 +1,8 @@
+// Polyfill for C# 9 record / init-only setters on .NET Framework 4.8.
+// See src/BlockParam.DevLauncher/IsExternalInit.cs for the full rationale —
+// the test project uses `record` types too and hits the same CS0518 without
+// this shim.
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit { }
+}

--- a/src/BlockParam.Tests/ScopeLabelFormatterTests.cs
+++ b/src/BlockParam.Tests/ScopeLabelFormatterTests.cs
@@ -13,7 +13,14 @@ namespace BlockParam.Tests;
 /// matches (with a <c>*</c> wildcard for the varying instance/DB segment)
 /// and name the leaf field being written — not a single concrete
 /// DB-qualified example path. <see cref="ScopeLabelFormatter"/> is the
-/// single source of truth every render site routes through.
+/// single source of truth every dropdown render site routes through.
+///
+/// #174: the dropdown wording deliberately differs from the Set button
+/// caption — dropdown shows the in-scope total via Scope_DropdownItem
+/// ("N member(s) in pattern"); the button shows the will-change count
+/// via MenuTitle_SetAll ("Set all N in pattern"). They previously shared
+/// MenuTitle_SetAll and contradicted each other once some members already
+/// held the target value.
 /// </summary>
 public class ScopeLabelFormatterTests
 {
@@ -46,7 +53,7 @@ public class ScopeLabelFormatterTests
         var scope = Scope("DB21.resetButton", "resetButton", "elementId");
 
         ScopeLabelFormatter.Pattern(scope).Should().Be("*.resetButton.elementId");
-        scope.Label.Should().Be("Set all 4 in *.resetButton.elementId");
+        scope.Label.Should().Be("4 member(s) in *.resetButton.elementId");
     }
 
     [Fact]
@@ -56,7 +63,7 @@ public class ScopeLabelFormatterTests
         var scope = Scope("DB21", "", "elementId");
 
         ScopeLabelFormatter.Pattern(scope).Should().Be("*.elementId");
-        scope.Label.Should().Be("Set all 4 in *.elementId");
+        scope.Label.Should().Be("4 member(s) in *.elementId");
     }
 
     [Fact]
@@ -68,7 +75,7 @@ public class ScopeLabelFormatterTests
         var scope = Scope("DB21.resetButton", "resetButton", "elementId",
             matchCount: 8, isCrossDb: true);
 
-        scope.Label.Should().Be("Set all 8 in *.resetButton.elementId");
+        scope.Label.Should().Be("8 member(s) in *.resetButton.elementId");
         scope.Label.Should().NotContain("across all selected DBs");
         scope.Label.Should().NotContain("'");
     }
@@ -79,7 +86,7 @@ public class ScopeLabelFormatterTests
         var scope = Scope("All selected DBs", "", "elementId",
             matchCount: 12, isCrossDb: true);
 
-        scope.Label.Should().Be("Set all 12 in *.elementId");
+        scope.Label.Should().Be("12 member(s) in *.elementId");
     }
 
     [Fact]
@@ -90,7 +97,22 @@ public class ScopeLabelFormatterTests
         var scope = Scope("DB21.Motors", "Motors", leafName: "", matchCount: 5);
 
         ScopeLabelFormatter.Pattern(scope).Should().Be("*.Motors");
-        scope.Label.Should().Be("Set all 5 in *.Motors");
+        scope.Label.Should().Be("5 member(s) in *.Motors");
+    }
+
+    [Fact]
+    public void DropdownLabel_DoesNotUseTheSetVerb_174()
+    {
+        // The dropdown describes the scope (a thing to pick), not the action
+        // (a thing to do). The "Set" verb belongs to the button next to it,
+        // which advertises the will-change count. Sharing "Set all N" caused
+        // the two adjacent counters to contradict each other once some
+        // members already held the target value (#174).
+        var scope = Scope("DB21.resetButton", "resetButton", "elementId", matchCount: 48);
+        scope.Label.Should().NotStartWith("Set ",
+            "the dropdown is not the action — the Set button is");
+        scope.Label.Should().StartWith("48 ",
+            "dropdown always shows MatchCount, never CountWouldChangeMembers");
     }
 
     [Fact]
@@ -113,7 +135,7 @@ public class ScopeLabelFormatterTests
 
         var dbScope = result.Scopes.First(s => s.AncestorName == "UdtInstancesDB");
         dbScope.LeafName.Should().Be("ModuleId");
-        dbScope.Label.Should().Be($"Set all {dbScope.MatchCount} in *.ModuleId");
+        dbScope.Label.Should().Be($"{dbScope.MatchCount} member(s) in *.ModuleId");
         dbScope.Label.Should().NotContain("UdtInstancesDB",
             "the label states the pattern, not the concrete DB name");
     }
@@ -131,8 +153,7 @@ public class ScopeLabelFormatterTests
         crossDb.Should().NotBeEmpty("two identical DBs must produce cross-DB lifts");
         crossDb.Should().AllSatisfy(s =>
         {
-            s.Label.Should().StartWith("Set all ");
-            s.Label.Should().Contain("*.");
+            s.Label.Should().Contain(" member(s) in *.");
             s.Label.Should().NotContain("across all selected DBs");
             s.Label.Should().NotContain("'");
         });

--- a/src/BlockParam/Localization/Strings.de.resx
+++ b/src/BlockParam/Localization/Strings.de.resx
@@ -34,6 +34,7 @@
   <!-- Kontextmenü -->
   <data name="MenuTitle_BulkChange" xml:space="preserve"><value>BlockParam...</value></data>
   <data name="MenuTitle_SetAll" xml:space="preserve"><value>Alle {0} in {1} setzen</value></data>
+  <data name="Scope_DropdownItem" xml:space="preserve"><value>{0} Element(e) in {1}</value></data>
   <data name="MenuTitle_EditStartValues" xml:space="preserve"><value>Startwerte bearbeiten...</value></data>
   <!-- Dialog -->
   <data name="Dialog_Title" xml:space="preserve"><value>BlockParam: {0}</value></data>

--- a/src/BlockParam/Localization/Strings.resx
+++ b/src/BlockParam/Localization/Strings.resx
@@ -45,7 +45,7 @@
   </data>
   <data name="MenuTitle_SetAll" xml:space="preserve">
     <value>Set all {0} in {1}</value>
-    <comment>{0} = match count, {1} = scope match pattern (e.g. *.resetButton.elementId). Single source of truth for the bulk-scope label; rendered by ScopeLabelFormatter and reused by the dropdown, Set button, tooltip, ToString and context menu (#143).</comment>
+    <comment>{0} = will-change count (members whose effective value ≠ NewValue), {1} = scope match pattern (e.g. *.resetButton.elementId). Used by the Set button caption — count drops as members reach the target value. The scope dropdown advertises in-scope totals via Scope_DropdownItem instead, so the two adjacent counters don't contradict each other (#174).</comment>
   </data>
   <!-- Context menu action item label (#50). The submenu root is MenuTitle_BulkChange ("BlockParam..."); this is the leaf the user clicks. -->
   <data name="MenuTitle_EditStartValues" xml:space="preserve">
@@ -368,6 +368,10 @@ This cannot be undone.</value>
   </data>
   <data name="Dialog_SetTooltip" xml:space="preserve">
     <value>Stage bulk values as pending (yellow)</value>
+  </data>
+  <data name="Scope_DropdownItem" xml:space="preserve">
+    <value>{0} member(s) in {1}</value>
+    <comment>{0} = total in-scope member count, {1} = scope match pattern (e.g. *.resetButton.elementId). Dropdown wording (and the capture-overlay clone) — describes the scope's size, not the action. The Set button uses MenuTitle_SetAll for the will-change count (#174).</comment>
   </data>
   <data name="Dialog_SetTooltip_ScopeIdle" xml:space="preserve">
     <value>{0} member(s) in {1}</value>

--- a/src/BlockParam/Services/HierarchyAnalyzer.cs
+++ b/src/BlockParam/Services/HierarchyAnalyzer.cs
@@ -638,10 +638,14 @@ public class ScopeLevel
     public int MatchCount => MatchingMembers.Count;
 
     /// <summary>
-    /// The single user-facing label, e.g. <c>Set all 4 in *.resetButton.elementId</c>.
-    /// All render sites (both XAML ItemTemplates, the Set button, its tooltip,
-    /// <see cref="ToString"/>, the context menu) bind/route through this so
-    /// they cannot drift (#143).
+    /// The dropdown / overlay item label, e.g.
+    /// <c>4 member(s) in *.resetButton.elementId</c>. Always advertises
+    /// <see cref="MatchCount"/> — the scope's size, not the action's
+    /// will-change count. The Set button composes its own caption with the
+    /// will-change count via <c>MenuTitle_SetAll</c>, so the dropdown and
+    /// the button next to it can read different numbers without
+    /// contradicting (#174). <see cref="ToString"/> mirrors this so logs
+    /// describe the scope, not a transient action count.
     /// </summary>
     public string Label => ScopeLabelFormatter.Format(this);
 

--- a/src/BlockParam/Services/ScopeLabelFormatter.cs
+++ b/src/BlockParam/Services/ScopeLabelFormatter.cs
@@ -4,8 +4,8 @@ using BlockParam.Localization;
 namespace BlockParam.Services;
 
 /// <summary>
-/// Single source of truth for the user-facing "Set all N in …" bulk-scope
-/// label (#143).
+/// Single source of truth for the bulk-scope dropdown wording (#143) and
+/// the scope-pattern fragment shared with the Set button (#174).
 ///
 /// <para>
 /// Before this class there were 5+ independent renderings of the same
@@ -27,10 +27,16 @@ namespace BlockParam.Services;
 /// </para>
 ///
 /// <para>
-/// Every caller routes through <see cref="Pattern"/> /
-/// <see cref="Format(ScopeLevel)"/> so the renderings cannot drift again.
-/// The single resx template is <c>MenuTitle_SetAll</c> ("Set all {0} in
-/// {1}"), reused across <c>en</c>/<c>de</c>.
+/// <see cref="Pattern"/> is the single pattern source — the Set button
+/// composes it with its own will-change count via <c>MenuTitle_SetAll</c>
+/// ("Set all {0} in {1}"). <see cref="Format(ScopeLevel)"/> is the dropdown
+/// wording — it deliberately uses a <em>different</em> resx template,
+/// <c>Scope_DropdownItem</c> ("{0} member(s) in {1}"), because the
+/// dropdown describes the scope's <em>size</em> (always
+/// <see cref="ScopeLevel.MatchCount"/>) while the button advertises the
+/// <em>action</em> (only members whose effective value differs from
+/// <c>NewValue</c>). Sharing one "Set all N" template caused the two
+/// counters to contradict each other once 1+ member already matched (#174).
 /// </para>
 /// </summary>
 public static class ScopeLabelFormatter
@@ -60,11 +66,15 @@ public static class ScopeLabelFormatter
     }
 
     /// <summary>
-    /// The full user-facing label, e.g. <c>Set all 4 in *.resetButton.elementId</c>.
-    /// Routed through the single <c>MenuTitle_SetAll</c> resx template so the
-    /// dropdown, Set button, tooltip, ToString and context menu render
-    /// identically and localize together.
+    /// The dropdown / overlay item label, e.g.
+    /// <c>4 member(s) in *.resetButton.elementId</c>. Always uses
+    /// <see cref="ScopeLevel.MatchCount"/> (the in-scope total). The Set
+    /// button does NOT route through this — it composes its own caption with
+    /// <c>MenuTitle_SetAll</c> + the will-change count, so once some members
+    /// already hold the target value the two counters intentionally differ
+    /// (#174). The wording omits the "Set" verb so the dropdown reads as
+    /// "pick a scope of this size", not "perform this action".
     /// </summary>
     public static string Format(ScopeLevel scope) =>
-        Res.Format("MenuTitle_SetAll", scope.MatchCount, Pattern(scope));
+        Res.Format("Scope_DropdownItem", scope.MatchCount, Pattern(scope));
 }

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -818,9 +818,13 @@
                                                           HorizontalAlignment="Stretch">
                                                     <ComboBox.ItemTemplate>
                                                         <DataTemplate>
-                                                            <!-- #143: single source of truth — ScopeLevel.Label
-                                                                 (ScopeLabelFormatter + MenuTitle_SetAll resx).
-                                                                 Kept identical-by-construction with the
+                                                            <!-- #143/#174: ScopeLevel.Label (ScopeLabelFormatter +
+                                                                 Scope_DropdownItem resx) — advertises the scope size
+                                                                 (MatchCount). The Set button next to this dropdown
+                                                                 uses MenuTitle_SetAll with the will-change count,
+                                                                 so the two numbers intentionally differ once some
+                                                                 members already hold the target value. Kept
+                                                                 identical-by-construction with the
                                                                  ScopeOverlayList template below. -->
                                                             <TextBlock Text="{Binding Label, Mode=OneWay}"/>
                                                         </DataTemplate>
@@ -1819,9 +1823,10 @@
                  ScrollViewer.HorizontalScrollBarVisibility="Disabled">
             <ListBox.ItemTemplate>
                 <DataTemplate>
-                    <!-- #143: same single source of truth as ScopeCombo
-                         above — bound to ScopeLevel.Label so the capture
-                         overlay can't drift from the live dropdown. -->
+                    <!-- #143/#174: same source as ScopeCombo above — bound
+                         to ScopeLevel.Label (Scope_DropdownItem template,
+                         in-scope MatchCount) so the capture overlay can't
+                         drift from the live dropdown. -->
                     <TextBlock Padding="8,4" FontSize="11"
                                Text="{Binding Label, Mode=OneWay}"/>
                 </DataTemplate>

--- a/src/BlockParam/UI/BulkChangeViewModel.cs
+++ b/src/BlockParam/UI/BulkChangeViewModel.cs
@@ -586,10 +586,13 @@ public class BulkChangeViewModel : ViewModelBase, IDisposable
         {
             if (Selection.IsManualMode)
                 return Res.Format("Dialog_SetManualCount", CountWouldChangeMembers());
-            // #143: single source of truth — the patterned scope label.
-            // CountWouldChangeMembers() (not MatchCount) is the staged count;
-            // route it through the same MenuTitle_SetAll template the dropdown
-            // / ToString use so the wording can't drift.
+            // #143/#174: the button advertises the will-change count via
+            // MenuTitle_SetAll ("Set all N in pattern"). The adjacent scope
+            // dropdown advertises MatchCount via Scope_DropdownItem
+            // ("N member(s) in pattern") — different verb, different count,
+            // on purpose: the dropdown describes the scope's size, the
+            // button describes the action's effect. Share only the pattern
+            // fragment so the *.path segment stays in lockstep.
             return Selection.SelectedScope != null
                 ? Res.Format("MenuTitle_SetAll",
                     CountWouldChangeMembers(),


### PR DESCRIPTION
## Summary

- Scope dropdown and Set button rendered the same `MenuTitle_SetAll` resx ("Set all N in pattern") with different counts — dropdown passed `scope.MatchCount` (e.g. 48), button passed `CountWouldChangeMembers()` (e.g. 32). Identical wording, contradictory numbers, no UX seam.
- PR #71 (#65 follow-up) introduced the asymmetry when it switched the button to the filtered count without splitting the wording, so #143's "single source of truth" became the source of the contradiction.
- Split the captions: button keeps `MenuTitle_SetAll` + will-change count ("Set all 32 in *.path" — describes the action). Dropdown moves to a new `Scope_DropdownItem` ("48 member(s) in *.path" — describes the scope's size). `ScopeLabelFormatter.Pattern` still emits the shared `*.path` fragment so the path can't drift.

## Out-of-scope fixes also in this PR

1. **`IsExternalInit` polyfill** (`src/BlockParam.{DevLauncher,Tests}/IsExternalInit.cs`) — main was also red on `windows-latest` after a runner image rotation; net48 needs the shim for `record`/`init`. Adding it unblocks every PR, not just this one.

## Known unrelated CI failure (NOT introduced by this PR)

`OpenPathPerfTests.H4_SmartExpandFlatBuild_BeforeAfter` — fragile perf microbenchmark whose chosen workload (single highlight in a 5000-leaf array) is a degenerate best-case for the old algorithm. Filed as #179 with reproduction + suggested fix. Surfaced for the first time on this PR only because the `IsExternalInit` fix above let the test phase run; main hits the same failure under `workflow_dispatch` (run 26437577254 fails at build, would fail at test too).

## Test plan

- [x] `ScopeLabelFormatterTests` repinned to new dropdown wording + new `DropdownLabel_DoesNotUseTheSetVerb_174` regression assert
- [x] `BulkChangeViewModelTests.SetButtonText_counts_only_members_that_will_actually_change` still pins button to `MenuTitle_SetAll` — split is locked from both sides
- [x] CI: V21 build, PEVerify partial-trust IL gate green; V20 Build & Test builds clean post-shim, only #179 perf-test failure remains
- [ ] Visual check in DevLauncher / TIA: open a scope where some members already match → confirm dropdown reads "48 member(s) in *.path" and button reads "Set all 32 in *.path"

Closes #174