### PR TITLE
fix(workflow-video): rescue marketing video from drift + missing popups

### DIFF
--- a/.claude/skills/recreate-workflow-video/SKILL.md
+++ b/.claude/skills/recreate-workflow-video/SKILL.md
@@ -22,7 +22,11 @@ bash assets/screenshots/workflow/external/render-external.sh
 bash assets/screenshots/scripts/build_workflow_video.sh
 ```
 
-Output: `assets/screenshots/workflow/workflow_inline.mp4`. The stitch script auto-opens it in the default player.
+Outputs:
+- `assets/screenshots/workflow/workflow_inline.mp4` — the marketing video.
+- `assets/screenshots/workflow/_validation_grid.png` — a 4-column row-major contact sheet of every scene in manifest order, captioned with `<idx>. <scene-id>`. Built automatically at the end of `build_workflow_video.sh` from the same frames as the MP4 so the two never go out of sync. Skipped (with a one-line warning) if Python or Pillow isn't installed — install with `python -m pip install Pillow`. Open it to spot-check every scene without scrubbing the video.
+
+The stitch script does NOT auto-open the MP4 by default; set `BLOCKPARAM_AUTO_OPEN=1` to restore the old behavior. The previous default spawned a `cmd //c start` child that kept the shell "running" until the player was closed, which hung headless and agent-driven rebuilds.
 
 ## Why four steps
 

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,13 @@ Thumbs.db
 assets/screenshots/workflow/wf*.png
 assets/screenshots/workflow/mdb*.png
 
+## Workflow validation contact sheet — co-output of build_workflow_video.sh,
+## same regenerable status as the per-scene PNGs above.
+assets/screenshots/workflow/_validation_grid.png
+
+## Python bytecode cache for screenshot helper scripts.
+assets/screenshots/scripts/__pycache__/
+
 ## Pill review composite — regenerated on demand by scripts/review-pill-screenshots.ps1.
 ## The 01-10 canonical scenes are tracked; the stitched composite is not.
 assets/screenshots/pill/composite.png

--- a/assets/fixtures/DB_BatchRecipe.xml
+++ b/assets/fixtures/DB_BatchRecipe.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Document>
+  <Engineering version="V20" />
+  <SW.Blocks.GlobalDB ID="0">
+    <AttributeList>
+      <AutoNumber>true</AutoNumber>
+      <HeaderVersion>0.1</HeaderVersion>
+      <Interface><Sections xmlns="http://www.siemens.com/automation/Openness/SW/Interface/v5" /></Interface>
+      <MemoryLayout>Optimized</MemoryLayout>
+      <Name>DB_BatchRecipe</Name>
+      <Number>8</Number>
+      <ProgrammingLanguage>DB</ProgrammingLanguage>
+    </AttributeList>
+  </SW.Blocks.GlobalDB>
+</Document>

--- a/assets/fixtures/DB_FluidControl.xml
+++ b/assets/fixtures/DB_FluidControl.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Document>
+  <Engineering version="V20" />
+  <SW.Blocks.GlobalDB ID="0">
+    <AttributeList>
+      <AutoNumber>true</AutoNumber>
+      <HeaderVersion>0.1</HeaderVersion>
+      <Interface><Sections xmlns="http://www.siemens.com/automation/Openness/SW/Interface/v5" /></Interface>
+      <MemoryLayout>Optimized</MemoryLayout>
+      <Name>DB_FluidControl</Name>
+      <Number>5</Number>
+      <ProgrammingLanguage>DB</ProgrammingLanguage>
+    </AttributeList>
+  </SW.Blocks.GlobalDB>
+</Document>

--- a/assets/fixtures/DB_PressureLoop.xml
+++ b/assets/fixtures/DB_PressureLoop.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Document>
+  <Engineering version="V20" />
+  <SW.Blocks.GlobalDB ID="0">
+    <AttributeList>
+      <AutoNumber>true</AutoNumber>
+      <HeaderVersion>0.1</HeaderVersion>
+      <Interface><Sections xmlns="http://www.siemens.com/automation/Openness/SW/Interface/v5" /></Interface>
+      <MemoryLayout>Optimized</MemoryLayout>
+      <Name>DB_PressureLoop</Name>
+      <Number>6</Number>
+      <ProgrammingLanguage>DB</ProgrammingLanguage>
+    </AttributeList>
+  </SW.Blocks.GlobalDB>
+</Document>

--- a/assets/fixtures/DB_ProcessPlant_A1.xml
+++ b/assets/fixtures/DB_ProcessPlant_A1.xml
@@ -826,148 +826,148 @@
                       </Member>
                       <Member Name="deadband" Datatype="Real">
                         <Subelement Path="1,2,1,1">
-                          <StartValue>0.50</StartValue>
+                          <StartValue>1.50</StartValue>
                         </Subelement>
                         <Subelement Path="1,2,1,2">
-                          <StartValue>0.75</StartValue>
+                          <StartValue>1.75</StartValue>
                         </Subelement>
                         <Subelement Path="1,2,1,3">
-                          <StartValue>1.00</StartValue>
+                          <StartValue>2.00</StartValue>
                         </Subelement>
                         <Subelement Path="1,2,1,4">
-                          <StartValue>1.25</StartValue>
+                          <StartValue>2.25</StartValue>
                         </Subelement>
                         <Subelement Path="1,2,2,1">
-                          <StartValue>0.50</StartValue>
+                          <StartValue>1.50</StartValue>
                         </Subelement>
                         <Subelement Path="1,2,2,2">
-                          <StartValue>0.75</StartValue>
+                          <StartValue>1.75</StartValue>
                         </Subelement>
                         <Subelement Path="1,2,2,3">
-                          <StartValue>1.00</StartValue>
+                          <StartValue>2.00</StartValue>
                         </Subelement>
                         <Subelement Path="1,2,2,4">
-                          <StartValue>1.25</StartValue>
+                          <StartValue>2.25</StartValue>
                         </Subelement>
                         <Subelement Path="1,2,3,1">
-                          <StartValue>0.50</StartValue>
+                          <StartValue>1.50</StartValue>
                         </Subelement>
                         <Subelement Path="1,2,3,2">
-                          <StartValue>0.75</StartValue>
+                          <StartValue>1.75</StartValue>
                         </Subelement>
                         <Subelement Path="1,2,3,3">
-                          <StartValue>1.00</StartValue>
+                          <StartValue>2.00</StartValue>
                         </Subelement>
                         <Subelement Path="1,2,3,4">
-                          <StartValue>1.25</StartValue>
+                          <StartValue>2.25</StartValue>
                         </Subelement>
                         <Subelement Path="1,3,1,1">
-                          <StartValue>0.50</StartValue>
+                          <StartValue>1.50</StartValue>
                         </Subelement>
                         <Subelement Path="1,3,1,2">
-                          <StartValue>0.75</StartValue>
+                          <StartValue>1.75</StartValue>
                         </Subelement>
                         <Subelement Path="1,3,1,3">
-                          <StartValue>1.00</StartValue>
+                          <StartValue>2.00</StartValue>
                         </Subelement>
                         <Subelement Path="1,3,1,4">
-                          <StartValue>1.25</StartValue>
+                          <StartValue>2.25</StartValue>
                         </Subelement>
                         <Subelement Path="1,3,2,1">
-                          <StartValue>0.50</StartValue>
+                          <StartValue>1.50</StartValue>
                         </Subelement>
                         <Subelement Path="1,3,2,2">
-                          <StartValue>0.75</StartValue>
+                          <StartValue>1.75</StartValue>
                         </Subelement>
                         <Subelement Path="1,3,2,3">
-                          <StartValue>1.00</StartValue>
+                          <StartValue>2.00</StartValue>
                         </Subelement>
                         <Subelement Path="1,3,2,4">
-                          <StartValue>1.25</StartValue>
+                          <StartValue>2.25</StartValue>
                         </Subelement>
                         <Subelement Path="1,3,3,1">
-                          <StartValue>0.50</StartValue>
+                          <StartValue>1.50</StartValue>
                         </Subelement>
                         <Subelement Path="1,3,3,2">
-                          <StartValue>0.75</StartValue>
+                          <StartValue>1.75</StartValue>
                         </Subelement>
                         <Subelement Path="1,3,3,3">
-                          <StartValue>1.00</StartValue>
+                          <StartValue>2.00</StartValue>
                         </Subelement>
                         <Subelement Path="1,3,3,4">
-                          <StartValue>1.25</StartValue>
+                          <StartValue>2.25</StartValue>
                         </Subelement>
                         <Subelement Path="2,2,1,1">
-                          <StartValue>0.50</StartValue>
+                          <StartValue>1.50</StartValue>
                         </Subelement>
                         <Subelement Path="2,2,1,2">
-                          <StartValue>0.75</StartValue>
+                          <StartValue>1.75</StartValue>
                         </Subelement>
                         <Subelement Path="2,2,1,3">
-                          <StartValue>1.00</StartValue>
+                          <StartValue>2.00</StartValue>
                         </Subelement>
                         <Subelement Path="2,2,1,4">
-                          <StartValue>1.25</StartValue>
+                          <StartValue>2.25</StartValue>
                         </Subelement>
                         <Subelement Path="2,2,2,1">
-                          <StartValue>0.50</StartValue>
+                          <StartValue>1.50</StartValue>
                         </Subelement>
                         <Subelement Path="2,2,2,2">
-                          <StartValue>0.75</StartValue>
+                          <StartValue>1.75</StartValue>
                         </Subelement>
                         <Subelement Path="2,2,2,3">
-                          <StartValue>1.00</StartValue>
+                          <StartValue>2.00</StartValue>
                         </Subelement>
                         <Subelement Path="2,2,2,4">
-                          <StartValue>1.25</StartValue>
+                          <StartValue>2.25</StartValue>
                         </Subelement>
                         <Subelement Path="2,2,3,1">
-                          <StartValue>0.50</StartValue>
+                          <StartValue>1.50</StartValue>
                         </Subelement>
                         <Subelement Path="2,2,3,2">
-                          <StartValue>0.75</StartValue>
+                          <StartValue>1.75</StartValue>
                         </Subelement>
                         <Subelement Path="2,2,3,3">
-                          <StartValue>1.00</StartValue>
+                          <StartValue>2.00</StartValue>
                         </Subelement>
                         <Subelement Path="2,2,3,4">
-                          <StartValue>1.25</StartValue>
+                          <StartValue>2.25</StartValue>
                         </Subelement>
                         <Subelement Path="2,3,1,1">
-                          <StartValue>0.50</StartValue>
+                          <StartValue>1.50</StartValue>
                         </Subelement>
                         <Subelement Path="2,3,1,2">
-                          <StartValue>0.75</StartValue>
+                          <StartValue>1.75</StartValue>
                         </Subelement>
                         <Subelement Path="2,3,1,3">
-                          <StartValue>1.00</StartValue>
+                          <StartValue>2.00</StartValue>
                         </Subelement>
                         <Subelement Path="2,3,1,4">
-                          <StartValue>1.25</StartValue>
+                          <StartValue>2.25</StartValue>
                         </Subelement>
                         <Subelement Path="2,3,2,1">
-                          <StartValue>0.50</StartValue>
+                          <StartValue>1.50</StartValue>
                         </Subelement>
                         <Subelement Path="2,3,2,2">
-                          <StartValue>0.75</StartValue>
+                          <StartValue>1.75</StartValue>
                         </Subelement>
                         <Subelement Path="2,3,2,3">
-                          <StartValue>1.00</StartValue>
+                          <StartValue>2.00</StartValue>
                         </Subelement>
                         <Subelement Path="2,3,2,4">
-                          <StartValue>1.25</StartValue>
+                          <StartValue>2.25</StartValue>
                         </Subelement>
                         <Subelement Path="2,3,3,1">
-                          <StartValue>0.50</StartValue>
+                          <StartValue>1.50</StartValue>
                         </Subelement>
                         <Subelement Path="2,3,3,2">
-                          <StartValue>0.75</StartValue>
+                          <StartValue>1.75</StartValue>
                         </Subelement>
                         <Subelement Path="2,3,3,3">
-                          <StartValue>1.00</StartValue>
+                          <StartValue>2.00</StartValue>
                         </Subelement>
                         <Subelement Path="2,3,3,4">
-                          <StartValue>1.25</StartValue>
+                          <StartValue>2.25</StartValue>
                         </Subelement>
                       </Member>
                       <Member Name="flowLimits" Datatype="&quot;UDT_AlarmLimits&quot;">

--- a/assets/fixtures/DB_TemperatureSP.xml
+++ b/assets/fixtures/DB_TemperatureSP.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Document>
+  <Engineering version="V20" />
+  <SW.Blocks.GlobalDB ID="0">
+    <AttributeList>
+      <AutoNumber>true</AutoNumber>
+      <HeaderVersion>0.1</HeaderVersion>
+      <Interface><Sections xmlns="http://www.siemens.com/automation/Openness/SW/Interface/v5" /></Interface>
+      <MemoryLayout>Optimized</MemoryLayout>
+      <Name>DB_TemperatureSP</Name>
+      <Number>7</Number>
+      <ProgrammingLanguage>DB</ProgrammingLanguage>
+    </AttributeList>
+  </SW.Blocks.GlobalDB>
+</Document>

--- a/assets/fixtures/TagTables/VALVE_TAGS.xml
+++ b/assets/fixtures/TagTables/VALVE_TAGS.xml
@@ -127,6 +127,966 @@
         </ObjectList>
       </SW.Tags.PlcUserConstant>
 
+
+      <SW.Tags.PlcUserConstant ID="13" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10111</Name>
+          <Value>'V-10111'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="14" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="15" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 1 valve 1 (instance 1)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="16" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10112</Name>
+          <Value>'V-10112'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="17" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="18" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 1 valve 1 (instance 2)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="19" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10113</Name>
+          <Value>'V-10113'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="1A" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="1B" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 1 valve 1 (instance 3)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="1C" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10114</Name>
+          <Value>'V-10114'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="1D" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="1E" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 1 valve 1 (instance 4)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="1F" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10121</Name>
+          <Value>'V-10121'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="20" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="21" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 1 valve 2 (instance 1)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="22" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10122</Name>
+          <Value>'V-10122'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="23" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="24" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 1 valve 2 (instance 2)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="25" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10123</Name>
+          <Value>'V-10123'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="26" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="27" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 1 valve 2 (instance 3)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="28" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10124</Name>
+          <Value>'V-10124'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="29" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="2A" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 1 valve 2 (instance 4)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="2B" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10131</Name>
+          <Value>'V-10131'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="2C" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="2D" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 1 valve 3 (instance 1)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="2E" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10132</Name>
+          <Value>'V-10132'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="2F" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="30" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 1 valve 3 (instance 2)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="31" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10133</Name>
+          <Value>'V-10133'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="32" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="33" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 1 valve 3 (instance 3)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="34" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10134</Name>
+          <Value>'V-10134'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="35" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="36" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 1 valve 3 (instance 4)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="37" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10211</Name>
+          <Value>'V-10211'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="38" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="39" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 2 valve 1 (instance 1)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="3A" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10212</Name>
+          <Value>'V-10212'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="3B" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="3C" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 2 valve 1 (instance 2)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="3D" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10213</Name>
+          <Value>'V-10213'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="3E" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="3F" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 2 valve 1 (instance 3)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="40" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10214</Name>
+          <Value>'V-10214'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="41" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="42" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 2 valve 1 (instance 4)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="43" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10221</Name>
+          <Value>'V-10221'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="44" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="45" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 2 valve 2 (instance 1)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="46" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10222</Name>
+          <Value>'V-10222'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="47" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="48" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 2 valve 2 (instance 2)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="49" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10223</Name>
+          <Value>'V-10223'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="4A" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="4B" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 2 valve 2 (instance 3)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="4C" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10224</Name>
+          <Value>'V-10224'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="4D" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="4E" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 2 valve 2 (instance 4)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="4F" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10231</Name>
+          <Value>'V-10231'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="50" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="51" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 2 valve 3 (instance 1)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="52" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10232</Name>
+          <Value>'V-10232'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="53" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="54" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 2 valve 3 (instance 2)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="55" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10233</Name>
+          <Value>'V-10233'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="56" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="57" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 2 valve 3 (instance 3)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="58" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-10234</Name>
+          <Value>'V-10234'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="59" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="5A" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 1 module 2 valve 3 (instance 4)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="5B" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20111</Name>
+          <Value>'V-20111'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="5C" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="5D" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 1 valve 1 (instance 1)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="5E" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20112</Name>
+          <Value>'V-20112'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="5F" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="60" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 1 valve 1 (instance 2)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="61" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20113</Name>
+          <Value>'V-20113'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="62" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="63" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 1 valve 1 (instance 3)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="64" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20114</Name>
+          <Value>'V-20114'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="65" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="66" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 1 valve 1 (instance 4)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="67" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20121</Name>
+          <Value>'V-20121'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="68" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="69" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 1 valve 2 (instance 1)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="6A" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20122</Name>
+          <Value>'V-20122'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="6B" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="6C" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 1 valve 2 (instance 2)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="6D" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20123</Name>
+          <Value>'V-20123'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="6E" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="6F" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 1 valve 2 (instance 3)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="70" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20124</Name>
+          <Value>'V-20124'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="71" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="72" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 1 valve 2 (instance 4)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="73" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20131</Name>
+          <Value>'V-20131'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="74" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="75" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 1 valve 3 (instance 1)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="76" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20132</Name>
+          <Value>'V-20132'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="77" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="78" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 1 valve 3 (instance 2)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="79" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20133</Name>
+          <Value>'V-20133'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="7A" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="7B" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 1 valve 3 (instance 3)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="7C" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20134</Name>
+          <Value>'V-20134'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="7D" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="7E" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 1 valve 3 (instance 4)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="7F" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20211</Name>
+          <Value>'V-20211'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="80" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="81" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 2 valve 1 (instance 1)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="82" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20212</Name>
+          <Value>'V-20212'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="83" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="84" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 2 valve 1 (instance 2)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="85" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20213</Name>
+          <Value>'V-20213'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="86" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="87" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 2 valve 1 (instance 3)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="88" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20214</Name>
+          <Value>'V-20214'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="89" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="8A" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 2 valve 1 (instance 4)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="8B" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20221</Name>
+          <Value>'V-20221'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="8C" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="8D" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 2 valve 2 (instance 1)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="8E" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20222</Name>
+          <Value>'V-20222'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="8F" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="90" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 2 valve 2 (instance 2)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="91" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20223</Name>
+          <Value>'V-20223'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="92" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="93" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 2 valve 2 (instance 3)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="94" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20224</Name>
+          <Value>'V-20224'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="95" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="96" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 2 valve 2 (instance 4)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="97" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20231</Name>
+          <Value>'V-20231'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="98" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="99" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 2 valve 3 (instance 1)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="9A" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20232</Name>
+          <Value>'V-20232'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="9B" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="9C" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 2 valve 3 (instance 2)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="9D" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20233</Name>
+          <Value>'V-20233'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="9E" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="9F" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 2 valve 3 (instance 3)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
+
+      <SW.Tags.PlcUserConstant ID="A0" CompositionName="UserConstants">
+        <AttributeList>
+          <DataTypeName>String</DataTypeName>
+          <Name>V-20234</Name>
+          <Value>'V-20234'</Value>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="A1" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="A2" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Unit 2 module 2 valve 3 (instance 4)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcUserConstant>
     </ObjectList>
   </SW.Tags.PlcTagTable>
 </Document>

--- a/assets/screenshots/scripts/build_workflow_grid.py
+++ b/assets/screenshots/scripts/build_workflow_grid.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Pack workflow_inline.json scenes into a single validation composite.
+
+Same principle as build_masonry.py — PIL, greedy shortest-column masonry,
+black label-box overlay on a light background — but reads scenes in
+manifest (narrative) order so the composite reflects the video, and
+labels each tile with the scene id (not the filename) so each tile maps
+back to the manifest at a glance.
+
+    python assets/screenshots/scripts/build_workflow_grid.py
+    python assets/screenshots/scripts/build_workflow_grid.py --columns 5
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from PIL import Image, ImageDraw
+
+from build_masonry import _load_label_font
+
+
+def build_montage_labeled(
+    items: list[tuple[Path, str]],
+    columns: int,
+    col_width: int,
+    gap: int,
+    label_size: int,
+    bg: tuple[int, int, int] = (245, 246, 248),
+) -> Image.Image:
+    """Row-major layout for validation: scene N+1 is always to the right of
+    scene N (wrapping to the start of the next row), so the numbering reads
+    left-to-right top-to-bottom and lines up with the manifest. Row height
+    = tallest cell in that row (handles mixed aspect ratios between dialog,
+    chapter, and external scenes). Same label-box + light-bg styling as
+    build_masonry.py."""
+    scaled: list[tuple[str, Image.Image]] = []
+    for path, label in items:
+        if path.exists():
+            im = Image.open(path).convert("RGB")
+            ratio = col_width / im.width
+            new_h = max(1, int(round(im.height * ratio)))
+            scaled.append((label, im.resize((col_width, new_h), Image.Resampling.LANCZOS)))
+        else:
+            placeholder = Image.new("RGB", (col_width, col_width * 9 // 16), (60, 20, 20))
+            d = ImageDraw.Draw(placeholder)
+            d.text((10, 10), "MISSING", fill=(255, 200, 200))
+            scaled.append((label, placeholder))
+
+    rows = [scaled[i:i + columns] for i in range(0, len(scaled), columns)]
+    row_heights = [max(im.height for _, im in row) for row in rows]
+
+    total_w = columns * col_width + (columns - 1) * gap
+    total_h = sum(row_heights) + (len(rows) - 1) * gap if rows else 0
+
+    canvas = Image.new("RGB", (total_w, total_h), bg)
+    draw = ImageDraw.Draw(canvas, "RGBA")
+    font = _load_label_font(label_size)
+
+    y = 0
+    for row, rh in zip(rows, row_heights):
+        for ci, (name, im) in enumerate(row):
+            x = ci * (col_width + gap)
+            canvas.paste(im, (x, y))
+
+            # Labels at bottom-left of each tile, not top-left — the top-left
+            # of dialog screenshots is exactly where the Add-PLC dropdown /
+            # pill popups appear, and a black overlay there obscures the very
+            # UI states the grid is meant to verify. build_masonry.py keeps
+            # top-left because its CI screenshots don't have that constraint.
+            pad = max(4, label_size // 3)
+            bbox = draw.textbbox((0, 0), name, font=font)
+            tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
+            box_h = th + pad * 2
+            box_w = tw + pad * 2
+            box_bottom = y + im.height - pad
+            box_top = box_bottom - box_h
+            box = (x + pad, box_top, x + pad + box_w, box_bottom)
+            draw.rectangle(box, fill=(0, 0, 0, 170))
+            draw.text((box[0] + pad, box[1] + pad), name, fill=(255, 255, 255), font=font)
+        y += rh + gap
+
+    return canvas
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--manifest", default="assets/screenshots/scripts/workflow_inline.json")
+    ap.add_argument("--frames-dir", default="assets/screenshots/workflow")
+    ap.add_argument("--out", default="assets/screenshots/workflow/_validation_grid.png")
+    ap.add_argument("--columns", type=int, default=4,
+                    help="Column count. Defaults preset so total width ≈ 2560px.")
+    ap.add_argument("--col-width", type=int, default=None,
+                    help="Per-column width in px; auto-sized from --columns + --gap when omitted.")
+    ap.add_argument("--gap", type=int, default=20)
+    ap.add_argument("--label-size", type=int, default=14)
+    ap.add_argument("--target-width", type=int, default=2560,
+                    help="Used only when --col-width is omitted.")
+    args = ap.parse_args()
+
+    if args.col_width is None:
+        args.col_width = (args.target_width - (args.columns - 1) * args.gap) // args.columns
+
+    manifest = json.loads(Path(args.manifest).read_text(encoding="utf-8"))
+    frames_dir = Path(args.frames_dir)
+
+    items: list[tuple[Path, str]] = []
+    missing = 0
+    for i, scene in enumerate(manifest["scenes"], start=1):
+        p = frames_dir / scene["filename"]
+        if not p.exists():
+            missing += 1
+        items.append((p, f"{i:>3}. {scene['id']}"))
+
+    total_w = args.columns * args.col_width + (args.columns - 1) * args.gap
+    print(f"Packing {len(items)} scenes ({missing} missing) -- "
+          f"{args.columns} cols x {args.col_width}px (gap {args.gap}) -> {total_w}px wide")
+
+    img = build_montage_labeled(
+        items,
+        columns=args.columns,
+        col_width=args.col_width,
+        gap=args.gap,
+        label_size=args.label_size,
+    )
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    img.save(args.out, optimize=True)
+    size_mb = Path(args.out).stat().st_size / (1024 * 1024)
+    print(f"Wrote: {args.out}  ({img.width} x {img.height}, {size_mb:.1f} MB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/assets/screenshots/scripts/build_workflow_video.sh
+++ b/assets/screenshots/scripts/build_workflow_video.sh
@@ -79,6 +79,26 @@ rm -f "$concat_list"
 mp4_size=$(stat -c%s "$out_mp4" 2>/dev/null || stat -f%z "$out_mp4")
 echo "MP4: $((mp4_size / 1024)) KB"
 
-# Launch in the OS default video player so each iteration is a single command.
-# `cmd //c start` avoids msys path mangling; cygpath converts to a Windows path.
-cmd //c start "" "$(cygpath -w "$out_mp4")"
+# Validation contact sheet, built from the exact same frames just stitched into
+# the MP4 so the two never diverge. Skipped (with a one-line warning) when
+# Python or PIL is missing — the MP4 is the primary artifact; the grid is a
+# review aid that shouldn't block the pipeline.
+grid_script="$script_dir/build_workflow_grid.py"
+if [[ -f "$grid_script" ]]; then
+    if command -v python >/dev/null && python -c "import PIL" 2>/dev/null; then
+        echo "Building validation grid -> assets/screenshots/workflow/_validation_grid.png"
+        ( cd "$script_dir/../../.." && python "$grid_script" )
+    else
+        echo "WARN: skipping validation grid (python or Pillow not on PATH)."
+        echo "      Install: python -m pip install Pillow"
+    fi
+fi
+
+# Opt-in player launch only. The default behavior used to be `cmd //c start`,
+# which spawned a child cmd that never exits from this script's perspective —
+# the spawning shell stays "running" until the player is closed, which hangs
+# headless pipelines and any agent-driven rebuild. Set BLOCKPARAM_AUTO_OPEN=1
+# (interactive use) to restore the old behavior.
+if [[ "${BLOCKPARAM_AUTO_OPEN:-0}" == "1" ]]; then
+    cmd //c start "" "$(cygpath -w "$out_mp4")"
+fi

--- a/assets/screenshots/scripts/workflow_inline.json
+++ b/assets/screenshots/scripts/workflow_inline.json
@@ -6,6 +6,16 @@
   "udt_dir": "../../fixtures/UdtTypes",
   "tag_table_dir": "../../fixtures/TagTables",
   "rules_dir": "../../fixtures/rules",
+  "anchor_plc": "Plant_A",
+  "peer_fixtures": [
+    { "plc": "Plant_A", "path": "../../fixtures/DB_ProcessPlant_A1.xml" },
+    { "plc": "Plant_A", "path": "../../fixtures/DB_FluidControl.xml" },
+    { "plc": "Plant_A", "path": "../../fixtures/DB_PressureLoop.xml" },
+    { "plc": "Plant_A", "path": "../../fixtures/DB_TemperatureSP.xml" },
+    { "plc": "Plant_A", "path": "../../fixtures/DB_BatchRecipe.xml" },
+    { "plc": "Plant_B", "path": "../../fixtures/DB_ProcessPlant_B1.xml" },
+    { "plc": "Plant_C", "path": "../../fixtures/DB_ProcessPlant_C1.xml" }
+  ],
   "scenes": [
 
     { "id": "wf01_ch_discover", "filename": "wf01_ch_discover.png", "beat": "chapterHold",
@@ -470,6 +480,14 @@
 
     { "id": "mdb06_tree_rebuilds", "filename": "mdb06_tree_rebuilds.png", "beat": "readingBulk", "dialog": "main", "preserveState": true,
       "cursor": { "target": "chip:DB_ProcessPlant_B1" } },
+
+    { "id": "mdb06a_pill_a_hover", "filename": "mdb06a_pill_a_hover.png", "beat": "pointingWithMouse", "dialog": "main", "preserveState": true,
+      "cursor": { "target": "chip:DB_ProcessPlant_A1" } },
+    { "id": "mdb06b_pill_a_press", "filename": "mdb06b_pill_a_press.png", "beat": "clickDown", "dialog": "main", "preserveState": true, "click": "press",
+      "cursor": { "target": "chip:DB_ProcessPlant_A1" } },
+    { "id": "mdb06c_pill_a_popup_open", "filename": "mdb06c_pill_a_popup_open.png", "beat": "readingShort", "dialog": "main", "preserveState": true, "click": "release",
+      "activeSet": { "openPillPopup": "Plant_A" },
+      "cursor": { "target": "chip:DB_ProcessPlant_A1" } },
 
     { "id": "mdb07_chip_strip_settled", "filename": "mdb07_chip_strip_settled.png", "beat": "readingShort", "dialog": "main", "preserveState": true,
       "cursor": { "target": "chip:DB_ProcessPlant_A1" } },

--- a/src/BlockParam.DevLauncher/CaptureScript.cs
+++ b/src/BlockParam.DevLauncher/CaptureScript.cs
@@ -20,7 +20,32 @@ public sealed class CaptureScript
     [JsonProperty("udt_dir")] public string? UdtDir { get; set; }
     [JsonProperty("tag_table_dir")] public string? TagTableDir { get; set; }
     [JsonProperty("rules_dir")] public string? RulesDir { get; set; }
+
+    /// <summary>
+    /// PLC name attached to the main <see cref="Fixture"/>. Drives
+    /// <c>ActiveSet.CurrentPlcName</c> and acts as the anchor PLC when
+    /// enumerating peers. Lets multi-PLC scenes (mdb02..mdb28) work
+    /// without a <c>--plc</c> arg on the DevLauncher command line.
+    /// </summary>
+    [JsonProperty("anchor_plc")] public string? AnchorPlc { get; set; }
+
+    /// <summary>
+    /// Extra fixture DBs to seed into <c>%TEMP%\BlockParam\</c> before
+    /// scenes run, so <c>EnumerateDevLauncherDbs</c> finds them when
+    /// <c>activeSet.addPeer</c> / <c>solo</c> / <c>reactivate</c> reference
+    /// peer DBs by name. Each entry is copied as
+    /// <c>&lt;plc&gt;__&lt;dbName&gt;.xml</c> so the PLC grouping shows
+    /// in the chip toolbar.
+    /// </summary>
+    [JsonProperty("peer_fixtures")] public List<PeerFixture>? PeerFixtures { get; set; }
+
     [JsonProperty("scenes")] public List<Scene> Scenes { get; set; } = new();
+}
+
+public sealed class PeerFixture
+{
+    [JsonProperty("plc")] public string Plc { get; set; } = "";
+    [JsonProperty("path")] public string Path { get; set; } = "";
 }
 
 public sealed class Viewport
@@ -249,6 +274,24 @@ public sealed class ActiveSetScene
     [JsonProperty("openAddDropdown")] public bool? OpenAddDropdown { get; set; }
 
     /// <summary>
+    /// PLC name of the pill whose popup should be painted open in the
+    /// snapshot. Walks the dialog's pill row to find the matching
+    /// <c>PillMultiSelect</c> and shows the dialog-level in-tree overlay
+    /// (the real WPF <c>&lt;Popup&gt;</c> lives in a separate HWND and is
+    /// invisible to <c>RenderTargetBitmap</c>, mirroring the
+    /// <see cref="OpenScopeDropdown"/> / <see cref="OpenAddDropdown"/>
+    /// pattern).
+    /// <para>
+    /// Cleared at the top of every scene's Apply() — same as the scope
+    /// and Add-DB overlays — so a scene that wants the popup to stay
+    /// open across frames must re-declare <c>openPillPopup</c> in each
+    /// frame. <c>preserveState</c> does NOT keep the overlay alive; it
+    /// only governs tree / selection / pending-edit state.
+    /// </para>
+    /// </summary>
+    [JsonProperty("openPillPopup")] public string? OpenPillPopup { get; set; }
+
+    /// <summary>
     /// DB name to add to the active set via
     /// <c>vm.ActiveSet.AddActiveDbFromSummary</c>. The DB must exist
     /// in <c>%TEMP%\BlockParam\</c> (discoverable by
@@ -355,6 +398,8 @@ public static class SceneApplier
         dialog.HideCursor();
         ClearHoverPreview(vm, dialog);
         dialog.HideScopeDropdownScripted();
+        dialog.HideAddDbDropdownScripted();
+        dialog.HideAllPillPopupsScripted();
         dialog.HidePromptOverlayScripted();
 
         // Reset zoom to the default (or per-scene override) so a previous
@@ -685,7 +730,17 @@ public static class SceneApplier
                 vm.ActiveSet.OpenDataBlocksDropdownCommand.Execute(null);
             else
                 vm.ActiveSet.IsAddDbPopupOpen = true;
+            // The real Popup is invisible to RenderTargetBitmap (separate HWND),
+            // so also paint the scripted in-tree overlay (mirrors ScopeOverlay).
+            dialog.ShowAddDbDropdownForScripted();
         }
+
+        // Open the pill popup for a specific PLC. Same HWND-popup problem as
+        // OpenAddDropdown / OpenScopeDropdown — we set the VM's IsOpen true so
+        // the real lazy-load runs (DB enumeration, group rollup), then paint
+        // the in-tree mirror on the matching PillMultiSelect instance.
+        if (!string.IsNullOrEmpty(block.OpenPillPopup))
+            dialog.ShowPillPopupForScripted(block.OpenPillPopup!);
 
         // Add a peer DB by name.
         if (block.AddPeer != null)

--- a/src/BlockParam.DevLauncher/Program.cs
+++ b/src/BlockParam.DevLauncher/Program.cs
@@ -160,6 +160,49 @@ class Program
 
         // 1. Find DB XML. Capture plan fixture wins; bare arg next; else defaults.
         var tiaExportDir = Path.Combine(Path.GetTempPath(), "BlockParam");
+
+        // Capture-script peer seeding + anchor PLC. Multi-PLC scenes
+        // (mdb02..mdb28) need EnumerateDevLauncherDbs to find peer DBs under
+        // distinct PLCs, but the dev's %TEMP%\BlockParam\ usually has only
+        // whatever they last opened in TIA. Copy the manifest's peer_fixtures
+        // in with <Plc>__<DbName>.xml names so the picker has something to
+        // show — and override anchorPlc from the manifest so the main fixture
+        // is grouped under its declared PLC too.
+        if (capturePlan is CapturePlan seedPlan)
+        {
+            if (!string.IsNullOrEmpty(seedPlan.AnchorPlc))
+                anchorPlc = seedPlan.AnchorPlc;
+
+            if (seedPlan.PeerFixtures is { Count: > 0 })
+            {
+                Directory.CreateDirectory(tiaExportDir);
+                foreach (var peer in seedPlan.PeerFixtures)
+                {
+                    if (!File.Exists(peer.Path))
+                    {
+                        Log.Warning("Peer fixture not found: {Path}", peer.Path);
+                        continue;
+                    }
+                    var dbName = Path.GetFileNameWithoutExtension(peer.Path);
+                    var destName = $"{peer.Plc}__{dbName}.xml";
+                    var destPath = Path.Combine(tiaExportDir, destName);
+                    // Skip-if-exists: %TEMP%\BlockParam may contain a real TIA
+                    // export the dev is actively iterating on. The anchor DB's
+                    // own filename is in peer_fixtures, so silent overwrite
+                    // would clobber a real export on every capture run. Delete
+                    // the destination file by hand to force a reseed.
+                    if (File.Exists(destPath))
+                    {
+                        Log.Information(
+                            "Peer fixture skipped (already present, delete to reseed): {Dest}",
+                            destName);
+                        continue;
+                    }
+                    File.Copy(peer.Path, destPath);
+                    Log.Information("Seeded peer fixture: {Dest}", destName);
+                }
+            }
+        }
         string? xmlPath;
         var dbArg = (capturePlan as CapturePlan)?.FixturePath
                     ?? captureDbArg
@@ -453,6 +496,11 @@ class Program
             CaptureWindowToPng(dialog, outPath, plan.Scale);
             Log.Information("Scene {Id}: saved {Path}", scene.Id, outPath);
         }
+        // OnClosing's "unsaved changes" prompt uses MessageBox.Show directly
+        // (bypassing the scripted IMessageBoxService), so without this flag
+        // the headless run hangs on a real modal whenever the last scene
+        // leaves pending or stashed edits.
+        dialog.SuppressClosePromptsScripted = true;
         dialog.Close();
     }
 
@@ -595,6 +643,7 @@ class Program
     {
         public CapturePlan(string outputDir, double scale, Viewport? viewport,
             string? fixturePath, string? udtDir, string? tagTableDir, string? rulesDir,
+            string? anchorPlc, List<PeerFixture>? peerFixtures,
             List<Scene> scenes)
         {
             OutputDir = outputDir;
@@ -604,6 +653,8 @@ class Program
             UdtDir = udtDir;
             TagTableDir = tagTableDir;
             RulesDir = rulesDir;
+            AnchorPlc = anchorPlc;
+            PeerFixtures = peerFixtures;
             Scenes = scenes;
         }
         public string OutputDir { get; }
@@ -613,6 +664,8 @@ class Program
         public string? UdtDir { get; }
         public string? TagTableDir { get; }
         public string? RulesDir { get; }
+        public string? AnchorPlc { get; }
+        public List<PeerFixture>? PeerFixtures { get; }
         public List<Scene> Scenes { get; }
     }
 
@@ -640,6 +693,8 @@ class Program
                 udtDir: null,
                 tagTableDir: null,
                 rulesDir: null,
+                anchorPlc: null,
+                peerFixtures: null,
                 scenes: new List<Scene>
                 {
                     new Scene { Id = "default", Filename = Path.GetFileName(outFile), Dialog = "main" },
@@ -671,6 +726,21 @@ class Program
                 : null;
             // DPI 96 = 1x, 192 = 2x; convert to scale factor.
             var scale = (script.Dpi ?? 192.0) / 96.0;
+
+            // Resolve peer fixture paths to absolute now (the consumer at scene
+            // run time has no idea where baseDir is).
+            List<PeerFixture>? peerFixtures = null;
+            if (script.PeerFixtures is { Count: > 0 })
+            {
+                peerFixtures = script.PeerFixtures
+                    .Select(p => new PeerFixture
+                    {
+                        Plc = p.Plc,
+                        Path = CaptureScriptLoader.ResolveRelative(baseDir, p.Path),
+                    })
+                    .ToList();
+            }
+
             return new CapturePlan(
                 outputDir: outputDir,
                 scale: scale,
@@ -679,6 +749,8 @@ class Program
                 udtDir: udtDir,
                 tagTableDir: tagTableDir,
                 rulesDir: rulesDir,
+                anchorPlc: script.AnchorPlc,
+                peerFixtures: peerFixtures,
                 scenes: script.Scenes);
         }
 

--- a/src/BlockParam/UI/BulkChangeDialog.xaml
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml
@@ -1828,5 +1828,65 @@
             </ListBox.ItemTemplate>
         </ListBox>
     </Border>
+
+    <!-- Scripted-only Add-DB dropdown overlay. Same HWND-popup problem as
+         ScopeOverlay above: the real <Popup> bound to IsAddDbPopupOpen lives
+         outside the dialog's visual tree and is invisible to RenderTargetBitmap,
+         so mdb02 / mdb03 / mdb04 captured a closed dropdown. This in-tree
+         mirror is shown only by ShowAddDbDropdownForScripted and stays
+         Collapsed everywhere else. Item template kept visually equivalent to
+         the AddPlcListBox template inside the real Popup. -->
+    <Border x:Name="AddDbOverlay" Panel.ZIndex="1001"
+            Background="White" BorderBrush="#E5E7EB" BorderThickness="1"
+            CornerRadius="6" Padding="4" MinWidth="180"
+            HorizontalAlignment="Left" VerticalAlignment="Top"
+            Visibility="Collapsed" MaxHeight="320">
+        <Border.Effect>
+            <DropShadowEffect Color="#000000" Opacity="0.18"
+                              BlurRadius="12" ShadowDepth="2"/>
+        </Border.Effect>
+        <ListBox x:Name="AddDbOverlayList" Background="Transparent"
+                 BorderThickness="0" MaxHeight="312">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Orientation="Horizontal" Margin="2">
+                        <Path Data="{StaticResource DatabaseIconGeometry}"
+                              Fill="#1F2937"
+                              Stretch="Uniform" Width="14" Height="14"
+                              VerticalAlignment="Center"
+                              Margin="0,0,8,0"/>
+                        <TextBlock Text="{Binding}"
+                                   VerticalAlignment="Center"/>
+                    </StackPanel>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+    </Border>
+
+    <!-- Scripted-only pill-popup overlay. Same HWND-popup problem as the
+         add-DB / scope overlays above, but here the mirror has to live at
+         the dialog level rather than inside the pill: if it sat inside the
+         pill's own Grid it would either stretch the chip's height (Grid
+         measure feedback) or be z-ordered beneath the toolbar / tree rows
+         that render after the chip strip. Sitting at the dialog root with
+         Panel.ZIndex 1001 sidesteps both problems.
+
+         The MultiSelectDropdown reuses the same UserControl the real popup
+         hosts, with DataContext wired in code-behind to the pill's
+         InternalState — single source of truth, identical visuals to the
+         live UI. -->
+    <Border x:Name="PillPopupOverlay" Panel.ZIndex="1001"
+            Background="White"
+            CornerRadius="8"
+            BorderBrush="#E5E7EB" BorderThickness="1"
+            HorizontalAlignment="Left" VerticalAlignment="Top"
+            Visibility="Collapsed">
+        <Border.Effect>
+            <DropShadowEffect Color="#000000" Opacity="0.18"
+                              BlurRadius="14" ShadowDepth="3"
+                              Direction="270"/>
+        </Border.Effect>
+        <controls:MultiSelectDropdown x:Name="PillPopupOverlayContent"/>
+    </Border>
     </Grid>
 </Window>

--- a/src/BlockParam/UI/BulkChangeDialog.xaml.cs
+++ b/src/BlockParam/UI/BulkChangeDialog.xaml.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -473,6 +474,133 @@ public partial class BulkChangeDialog : Window
         ScopeOverlay.Visibility = Visibility.Collapsed;
         ScopeOverlayList.ItemsSource = null;
         ScopeOverlayList.SelectedItem = null;
+    }
+
+    /// <summary>
+    /// Scripted-only: opens a fake Add-DB dropdown anchored under the
+    /// "+ PLC" / AddDbButton, populated with the VM's InactiveProjectPlcs.
+    /// The real Popup bound to IsAddDbPopupOpen lives in a separate HWND
+    /// and is invisible to RenderTargetBitmap, so mdb02 / mdb03 / mdb04
+    /// captured an empty dialog instead of the open dropdown they expected
+    /// (#138). Mirrors the ScopeOverlay pattern: in-tree Border + ListBox
+    /// positioned by translating the button's bottom-left into Content
+    /// coordinates.
+    /// </summary>
+    internal void ShowAddDbDropdownForScripted()
+    {
+        if (DataContext is not BulkChangeViewModel vm) return;
+        if (vm.ActiveSet.InactiveProjectPlcs.Count == 0) return;
+
+        UpdateLayout();
+
+        AddDbOverlayList.ItemsSource = vm.ActiveSet.InactiveProjectPlcs;
+        AddDbOverlayList.SelectedItem = null;
+
+        var bottomLeft = AddDbButton.TranslatePoint(
+            new System.Windows.Point(0, AddDbButton.ActualHeight), (UIElement)Content);
+        AddDbOverlay.Margin = new Thickness(bottomLeft.X, bottomLeft.Y, 0, 0);
+        AddDbOverlay.Visibility = Visibility.Visible;
+
+        UpdateLayout();
+        foreach (var item in AddDbOverlayList.Items)
+            AddDbOverlayList.ItemContainerGenerator.ContainerFromItem(item);
+    }
+
+    /// <summary>Scripted-only: tears down the Add-DB dropdown overlay.</summary>
+    internal void HideAddDbDropdownScripted()
+    {
+        AddDbOverlay.Visibility = Visibility.Collapsed;
+        AddDbOverlayList.ItemsSource = null;
+        AddDbOverlayList.SelectedItem = null;
+    }
+
+    /// <summary>
+    /// Scripted-only: open the dialog-level pill popup mirror anchored under
+    /// the PLC pill whose VM matches <paramref name="plcName"/>. The mirror
+    /// lives at the dialog's root Grid (not inside the pill) for two
+    /// reasons: an in-pill overlay either stretches the chip via Grid
+    /// measure feedback, or gets z-ordered beneath the toolbar/tree rows
+    /// that paint after the chip strip. Sitting at root with ZIndex=1001
+    /// avoids both.
+    /// </summary>
+    internal void ShowPillPopupForScripted(string plcName)
+    {
+        UpdateLayout();
+        var match = FindPillByPlcName(plcName);
+        if (match == null)
+        {
+            Log.Warning(
+                "ShowPillPopupForScripted: no PillMultiSelect found for PLC '{Plc}'",
+                plcName);
+            return;
+        }
+
+        // Run the same lazy-load the real popup triggers, so the dropdown
+        // populates before we render the overlay.
+        match.SetScriptedOpenState(true);
+        UpdateLayout();
+
+        // Point the overlay's MultiSelectDropdown at this pill's state. Same
+        // source of truth as the real popup — no second copy of internal
+        // state, no drift.
+        PillPopupOverlayContent.DataContext = match.InternalState;
+
+        // Anchor under the trigger's bottom-left in dialog-content coords.
+        var bottomLeft = match.TriggerElement.TranslatePoint(
+            new System.Windows.Point(0, match.TriggerElement.ActualHeight),
+            (UIElement)Content);
+        PillPopupOverlay.Margin = new Thickness(bottomLeft.X, bottomLeft.Y + 4, 0, 0);
+        PillPopupOverlay.Visibility = Visibility.Visible;
+        UpdateLayout();
+    }
+
+    /// <summary>Scripted-only: hide the pill-popup overlay (per-scene reset).</summary>
+    internal void HideAllPillPopupsScripted()
+    {
+        PillPopupOverlay.Visibility = Visibility.Collapsed;
+        PillPopupOverlayContent.DataContext = null;
+        // Reset the IsOpen flag on every pill so a re-show doesn't inherit
+        // a previous scene's "already lazy-loaded" state.
+        foreach (var pill in EnumerateAllPills())
+            pill.SetScriptedOpenState(false);
+    }
+
+    /// <summary>
+    /// Walks the visual tree under this dialog and yields every
+    /// PillMultiSelect instance — used by capture-mode helpers that need to
+    /// address pills without each one having a named XAML hook.
+    /// </summary>
+    private IEnumerable<BlockParam.UI.Controls.PillMultiSelect.PillMultiSelect>
+        EnumerateAllPills()
+    {
+        var stack = new Stack<DependencyObject>();
+        stack.Push(this);
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            int count = VisualTreeHelper.GetChildrenCount(current);
+            for (int i = 0; i < count; i++)
+            {
+                var child = VisualTreeHelper.GetChild(current, i);
+                if (child is BlockParam.UI.Controls.PillMultiSelect.PillMultiSelect pill)
+                    yield return pill;
+                else
+                    stack.Push(child);
+            }
+        }
+    }
+
+    private BlockParam.UI.Controls.PillMultiSelect.PillMultiSelect? FindPillByPlcName(string plcName)
+    {
+        foreach (var pill in EnumerateAllPills())
+        {
+            if (pill.DataContext is PlcPillViewModel vm
+                && string.Equals(vm.PlcName, plcName, System.StringComparison.OrdinalIgnoreCase))
+            {
+                return pill;
+            }
+        }
+        return null;
     }
 
     /// <summary>
@@ -1099,10 +1227,45 @@ public partial class BulkChangeDialog : Window
         return vm.PendingInlineEditCount == 0;
     }
 
+    /// <summary>
+    /// Scripted-only escape hatch: when true, OnClosing skips every
+    /// "unsaved changes" prompt and discards both active and stashed
+    /// pending edits silently. Set by DevLauncher capture mode before
+    /// <see cref="Window.Close"/>, because the late MessageBox.Show
+    /// fallbacks in OnClosing bypass the IMessageBoxService injection
+    /// and would otherwise pop a real modal that hangs the headless
+    /// run waiting for a human click.
+    /// <para>
+    /// Visibility is <c>internal</c> to match the rest of the
+    /// scripted-only API on this dialog; DevLauncher + Tests already
+    /// have InternalsVisibleTo, so widening is unnecessary.
+    /// </para>
+    /// </summary>
+    internal bool SuppressClosePromptsScripted { get; set; }
+
     protected override void OnClosing(System.ComponentModel.CancelEventArgs e)
     {
         base.OnClosing(e);
         if (DataContext is not BulkChangeViewModel vm) return;
+
+        if (SuppressClosePromptsScripted)
+        {
+            // Mirror the non-scripted DiscardAll branch: discard active
+            // edits AND wipe stashes. Stashes are in-memory only so they'd
+            // evaporate with the process anyway, but clearing them keeps
+            // the symmetry explicit and stops the asymmetry being a
+            // footgun if this flag ever gets reused in interactive mode.
+            if (vm.PendingInlineEditCount > 0)
+                vm.DiscardPendingSilent();
+            if (vm.ActiveSet.StashedDbs.Count > 0)
+            {
+                Log.Information(
+                    "SuppressClosePromptsScripted: dropping {Count} stashed DB(s)",
+                    vm.ActiveSet.StashedDbs.Count);
+                vm.ActiveSet.StashedDbs.Clear();
+            }
+            return;
+        }
 
         // Unsaved pending edits — across the active DB *and* any stashed DBs.
         // Stash-only loss used to be silent (#59 follow-up); now both states

--- a/src/BlockParam/UI/Controls/PillMultiSelect/PillMultiSelect.xaml
+++ b/src/BlockParam/UI/Controls/PillMultiSelect/PillMultiSelect.xaml
@@ -154,5 +154,6 @@
                 <local:MultiSelectDropdown x:Name="Dropdown"/>
             </Border>
         </Popup>
+
     </Grid>
 </UserControl>

--- a/src/BlockParam/UI/Controls/PillMultiSelect/PillMultiSelect.xaml.cs
+++ b/src/BlockParam/UI/Controls/PillMultiSelect/PillMultiSelect.xaml.cs
@@ -505,4 +505,14 @@ public partial class PillMultiSelect : UserControl
         // user gets both behaviors per click which is jarring.
         e.Handled = true;
     }
+
+    /// <summary>
+    /// Scripted-only: drive the same lazy-load path the real popup uses
+    /// (<see cref="MultiSelectInternalState.IsOpen"/> → host VM's
+    /// <c>OnIsOpenFlippedToTrue</c>) without going through the trigger
+    /// click. <see cref="InternalState"/> and <see cref="TriggerElement"/>
+    /// already cover the read side; this method is the write side capture
+    /// mode needs.
+    /// </summary>
+    internal void SetScriptedOpenState(bool open) => _internalState.IsOpen = open;
 }


### PR DESCRIPTION
## Summary

The workflow-video frames had drifted: the Issues panel (added in PR #31 after PR #12 designed the video) surfaced ~90 pre-existing fixture violations on every dialog screenshot, and three different WPF popups were invisible to `RenderTargetBitmap` because they live in separate HWNDs. This PR rebuilds the capture-mode infrastructure so every scene matches what marketing actually wants to show, then re-stitches the MP4 (203 scenes total).

## What changed

### Issues panel goes clean
- `VALVE_TAGS.xml`: 6 → 54 entries, covering the 48 `V-XXXXX` tags the DB fixture actually references. The original 6 stay as the "clean target" values the inline-edit demo migrates to.
- `DB_ProcessPlant_A1.xml`: deadband 0.50/0.75/1.00/1.25 → 1.50/1.75/2.00/2.25 so every value is inside the rule's `min=1` range.

### In-tree popup mirrors (the HWND problem)
- `AddDbOverlay` in `BulkChangeDialog.xaml` — mirrors the "+ PLC" picker for `mdb02`/`mdb03`/`mdb04`.
- `PillPopupOverlay` in `BulkChangeDialog.xaml` — hosts a second `MultiSelectDropdown` bound to the target pill's `_internalState`. Lives at the dialog's root Grid (ZIndex 1001), **not** inside the pill: in-pill placement either stretched the chip via Grid measure feedback or got z-ordered beneath the toolbar/tree rows.
- `PillMultiSelect` exposes `ScriptedInternalState` / `ScriptedTrigger` / `SetScriptedOpenState` so the dialog overlay can drive it without duplicate state.

### Multi-PLC capture seeding
- New manifest fields `anchor_plc` + `peer_fixtures[]`. `DevLauncher` copies each peer into `%TEMP%\BlockParam` with `<plc>__<DbName>.xml` naming so `EnumerateDevLauncherDbs` sees them, and overrides `anchorPlc` from the manifest when no `--plc` arg is passed.
- Four stub fixtures (`DB_FluidControl`, `DB_PressureLoop`, `DB_TemperatureSP`, `DB_BatchRecipe`) carrying only the SimaticML DB envelope so `Plant_A`'s popup shows 5 entries instead of 1.

### Capture-mode reliability
- `SuppressClosePromptsScripted` on `BulkChangeDialog`: `OnClosing`'s fallback `MessageBox.Show` calls bypass the scripted `IMessageBoxService`, so the headless run used to hang on a real modal whenever the last scene left pending or stashed edits.
- `build_workflow_video.sh`'s auto-launch is now opt-in via `BLOCKPARAM_AUTO_OPEN=1`; the previous `cmd //c start` kept the parent shell "running" until the player was closed.

### Validation grid + new capture directive
- `build_workflow_grid.py` builds a row-major contact sheet from manifest order (4 cols, 2560 px wide, bottom-left labels so they don't obscure dialog popups). Wired into `build_workflow_video.sh` so MP4 and grid never go out of sync. Same packing principle as `build_masonry.py`; reuses `_load_label_font`.
- New `openPillPopup: "<PlcName>"` directive on `ActiveSetScene`. Reset between scenes alongside the existing dropdown overlays.
- `workflow_inline.json` gains `mdb06a` / `mdb06b` / `mdb06c` (pill hover → press → popup open on `Plant_A`) — 200 scenes → 203.

### .gitignore
Ignores `_validation_grid.png` and `__pycache__/` — both regenerable build artifacts.

## Test plan

- [ ] Open `assets/screenshots/workflow/_validation_grid.png` and confirm:
  - Issues panel is empty across all dialog scenes (no red rows).
  - `mdb02`/`mdb03`/`mdb04` show the Add-PLC dropdown overlay populated with `Plant_B` / `Plant_C`.
  - `mdb06c_pill_a_popup_open` shows the 5-DB pill popup below `Plant_A`'s chip at natural height (chip not stretched).
  - `mdb28_multi_plc_chips` shows the multi-PLC chip groups.
- [ ] Play `assets/screenshots/workflow/workflow_inline.mp4` end-to-end (3:23) — no auto-launch from the script.
- [ ] Re-run the full pipeline (`recreate-workflow-video` skill or the 4 bash commands in `SKILL.md`); confirm capture exits cleanly with no `MessageBox` prompt, MP4 + grid both rebuild, neither hangs the shell.
- [ ] Manual smoke in DevLauncher interactive mode (no `--capture-script`): pill popup, Add-PLC popup, scope dropdown all still open/close normally; close prompt still appears with pending edits (the `SuppressClosePromptsScripted` flag is default `false`).
- [ ] CI on `windows-latest`: `v20` + `peverify` + `v21` jobs should all stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)