### PR TITLE
docs(#175): fix Pro price, add purple row colour, drop unused-cleanup claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ single action.
 - **Live search** with hit count, match highlighting, and smart expansion of matching subtrees.
 - **Setpoint filter** hides internal/structural members (configurable per rule).
 - **Colour-coded rows**: search hits (yellow), pending edits (orange), already-matching (green),
-  affected by bulk op (blue), invalid (red).
-- **Unused struct-member cleanup** with safety confirmation (UDT members are never touched).
+  affected by bulk op (blue), invalid (red), pre-existing rule violations (purple) &mdash; entries
+  that already fail the configured rules in the TIA project, so you can see legacy violations
+  BlockParam did not introduce.
 
 ### Platform
 - **English &amp; German UI**.
@@ -128,7 +129,7 @@ release notes: [Releases page](https://github.com/Sawascwoolf/BlockParam/release
 | Tier | Daily limit | Features | Price |
 |---|---|---|---|
 | **Free** | 200 value changes per day | All features included | &euro; 0 |
-| **Pro** | Unlimited | All features + priority email support | 15 &euro; / year (net) |
+| **Pro** | Unlimited | All features + priority email support | 50 &euro; / year (net) |
 
 All features work in both tiers &mdash; the Pro tier lifts the daily quota and funds further
 development. Pro licenses are sold via [LemonSqueezy](https://blockparam.lemonsqueezy.com) as


### PR DESCRIPTION
## Summary

Resolves the three README drifts called out in #175 after validating each against the current repo:

- **Pro price**: corrected from 15 €/year to **50 €/year (net)**. `docs/user/licensing.md` and `docs/legal/terms.md` already state 50 €; only the README had drifted.
- **Purple row colour**: added to the colour-coded rows list with the meaning confirmed in the issue thread (entries that already fail configured rules in the TIA project — legacy violations BlockParam did not introduce). Verified in `BulkChangeDialog.xaml:396-403`, which sets `BorderBrush="#9C27B0"` when `HasExistingViolation` is true.
- **"Unused struct-member cleanup"**: bullet removed. `SimaticMLWriter.RemoveMembers()` exists but is only invoked from unit tests; no production command, ViewModel, or UI surface exposes it.

## Test plan

- [x] Validated each claim against source (XAML, docs, services) before editing.
- [x] `git diff README.md` reviewed — only the three intended lines changed.
- [ ] Marketing site (`blockparam.lautimweb.de`) sources feature copy from this README; spot-check after merge that the rendered page matches.

Closes #175

---
_Generated by [Claude Code](https://claude.ai/code/session_016EtZGZQSBpGC4RLJrWkG81)_