### PR TITLE
fix(#179): swap H4 perf workload to expose old O(depth^2) HHD recursion

### DIFF
--- a/src/BlockParam.Tests/OpenPathPerfTests.cs
+++ b/src/BlockParam.Tests/OpenPathPerfTests.cs
@@ -152,27 +152,54 @@ public class OpenPathPerfTests
 
     /// <summary>
     /// #154 H4. "Before": the removed recursive HasHighlightedDescendant
-    /// called per visible node under a smart-expanded parent (O(n²) on a flat
-    /// array). "After": the real <see cref="FlatTreeManager.Refresh"/>, which
-    /// fills the highlight cache in one O(n) pass. Asserts both produce the
-    /// identical visible sequence (timing equivalent work) plus a speedup.
+    /// called per visible node under a smart-expanded parent — quadratic in
+    /// the depth of every visible chain because HHD re-scans the subtree
+    /// from each level. "After": the real <see cref="FlatTreeManager.Refresh"/>,
+    /// which fills the highlight cache in one O(n) post-order pass.
+    ///
+    /// #179: the prior workload (single flat array, one mid-array highlight)
+    /// did not exercise the quadratic path — leaves have no children, so HHD
+    /// returns in O(1) and the new code's unconditional O(n) cache fill ended
+    /// up doing more total work than the old short-circuiting walk, flipping
+    /// the assertion on Windows runners with shifted constants. The workload
+    /// below replaces it with 50 "sticks" of depth 100 (single-child chains)
+    /// where the only highlight sits at each stick's bottom leaf: HHD at level
+    /// k must walk (depth-k-1) descendants down the chain before finding it,
+    /// summing to depth*(depth-1)/2 ≈ 5,000 ops per stick × 50 sticks ≈ 247k
+    /// ops for old vs. ~10k for new (2× walk over 5,001 nodes). That gives a
+    /// stable 20×+ ratio and matches the regression #154 H4 actually defends.
     /// </summary>
     [Fact]
     public void H4_SmartExpandFlatBuild_BeforeAfter()
     {
-        const int n = 5000;
-        var leaves = new MemberNode[n];
-        for (int i = 0; i < n; i++)
-            leaves[i] = new MemberNode($"[{i}]", "DInt", i.ToString(),
-                $"Big[{i}]", null, Array.Empty<MemberNode>());
-        var rootModel = new MemberNode("Big", "Array[0..4999] of DInt", null,
-            "Big", null, leaves);
+        const int sticks = 50;
+        const int depth = 100;
+        var stickRoots = new MemberNode[sticks];
+        for (int s = 0; s < sticks; s++)
+        {
+            // Build bottom leaf first, then wrap upwards into a chain.
+            MemberNode node = new MemberNode($"S{s}_Leaf", "DInt", "0",
+                $"S{s}.Leaf", null, Array.Empty<MemberNode>());
+            for (int d = depth - 2; d >= 0; d--)
+                node = new MemberNode($"S{s}_L{d}", "Struct", null,
+                    $"S{s}.L{d}", null, new[] { node });
+            stickRoots[s] = node;
+        }
+        var rootModel = new MemberNode("Root", "Struct", null,
+            "Root", null, stickRoots);
         var rootVm = new MemberNodeViewModel(rootModel, null);
-        rootVm.IsExpanded = true;
-        rootVm.IsSmartExpanded = true;
-        rootVm.Children[n / 2].IsAffected = true; // one highlighted, mid-array
+        SetExpandedRecursive(rootVm);
 
-        // ---- before: reproduce old per-node recursive scan (O(n²)) ----
+        // Highlight every stick's bottom leaf so each chain stays visible and
+        // every visible internal node's HHD has to walk to the bottom.
+        foreach (var stickTop in rootVm.Children)
+        {
+            var cur = stickTop;
+            while (cur.Children.Count > 0) cur = cur.Children[0];
+            cur.IsAffected = true;
+        }
+
+        // ---- before: reproduce old per-node recursive scan (O(depth²) per stick) ----
         var swOld = Stopwatch.StartNew();
         var oldFlat = new List<MemberNodeViewModel>();
         OldAddNodeToFlatList(rootVm, oldFlat);
@@ -184,20 +211,32 @@ public class OpenPathPerfTests
         mgr.Refresh(new[] { rootVm });
         swNew.Stop();
 
-        // Equivalence: identical visible sequence.
+        // Equivalence: identical visible sequence. Every node on every chain
+        // is visible (each is on the path to a highlighted leaf).
+        var totalNodes = 1 + sticks * depth;
         mgr.FlatList.Select(v => v.Name)
             .Should().Equal(oldFlat.Select(v => v.Name));
-        oldFlat.Select(v => v.Name).Should().Equal("Big", $"[{n / 2}]");
+        oldFlat.Should().HaveCount(totalNodes);
+        oldFlat[0].Name.Should().Be("Root");
+        oldFlat[oldFlat.Count - 1].Name.Should().Be($"S{sticks - 1}_Leaf");
 
         var oldMs = swOld.Elapsed.TotalMilliseconds;
         var newMs = swNew.Elapsed.TotalMilliseconds;
         _out.WriteLine(
-            $"[#154 H4] N={n}  before/recursive-scan={oldMs:F1} ms  "
-            + $"after/cached={newMs:F1} ms  "
+            $"[#154 H4] sticks={sticks} depth={depth} N={totalNodes}  "
+            + $"before/recursive-scan={oldMs:F1} ms  after/cached={newMs:F1} ms  "
             + $"speedup≈{oldMs / System.Math.Max(newMs, 0.001):F1}x");
 
         newMs.Should().BeLessThan(oldMs,
-            "the cached O(n) highlight pass must beat the old O(n²) per-node recursion");
+            "the cached O(n) highlight pass must beat the old O(depth²) per-node recursion");
+    }
+
+    private static void SetExpandedRecursive(MemberNodeViewModel node)
+    {
+        node.IsExpanded = true;
+        node.IsSmartExpanded = true;
+        foreach (var child in node.Children)
+            SetExpandedRecursive(child);
     }
 
     // Faithful reproduction of the REMOVED FlatTreeManager.AddNodeToFlatList +

--- a/src/BlockParam.Tests/OpenPathPerfTests.cs
+++ b/src/BlockParam.Tests/OpenPathPerfTests.cs
@@ -174,6 +174,11 @@ public class OpenPathPerfTests
     {
         const int sticks = 50;
         const int depth = 100;
+        // depth must be ≥ 2: with depth==1 the wrapper loop body never runs,
+        // each "stick" collapses to a bare leaf, and HHD returns in O(1) per
+        // node — the degenerate #179 shape this test was rewritten to avoid.
+        System.Diagnostics.Debug.Assert(depth >= 2,
+            "H4 needs nested chains; depth<2 re-creates the #179 shape");
         var stickRoots = new MemberNode[sticks];
         for (int s = 0; s < sticks; s++)
         {
@@ -198,6 +203,16 @@ public class OpenPathPerfTests
             while (cur.Children.Count > 0) cur = cur.Children[0];
             cur.IsAffected = true;
         }
+
+        // JIT warmup: prime both code paths so the timed sections don't pay
+        // first-call compilation cost. swNew goes through four previously-
+        // uncalled product methods (BuildFlatList, RefreshHighlightCache,
+        // AddNodeToFlatList, BulkObservableCollection.ReplaceAll) — at the
+        // sub-millisecond absolute scale this test runs at, JIT alone can
+        // swamp the algorithmic gap and re-flip the assertion (#179).
+        var warmupOldFlat = new List<MemberNodeViewModel>();
+        OldAddNodeToFlatList(rootVm, warmupOldFlat);
+        new FlatTreeManager().Refresh(new[] { rootVm });
 
         // ---- before: reproduce old per-node recursive scan (O(depth²) per stick) ----
         var swOld = Stopwatch.StartNew();
@@ -229,12 +244,21 @@ public class OpenPathPerfTests
 
         newMs.Should().BeLessThan(oldMs,
             "the cached O(n) highlight pass must beat the old O(depth²) per-node recursion");
+        (oldMs / System.Math.Max(newMs, 0.001)).Should().BeGreaterThan(3,
+            "expected ratio ~20× (depth² vs depth) — a result below 3× means the "
+            + "cache regressed or the workload's quadratic structure was broken");
     }
 
     private static void SetExpandedRecursive(MemberNodeViewModel node)
     {
-        node.IsExpanded = true;
-        node.IsSmartExpanded = true;
+        // Match production ExpandRecursive's HasChildren guard — IsExpanded /
+        // IsSmartExpanded on a leaf is meaningless and the symmetry keeps any
+        // future "IsSmartExpanded ⇒ HasChildren" invariant from tripping here.
+        if (node.HasChildren)
+        {
+            node.IsExpanded = true;
+            node.IsSmartExpanded = true;
+        }
         foreach (var child in node.Children)
             SetExpandedRecursive(child);
     }


### PR DESCRIPTION
## Summary

- H4 was asserting `newMs < oldMs` on a workload that didn't actually exercise the quadratic path it defends: a single 5,000-leaf flat array with one mid-array highlight. Leaves have no children, so the old `HasHighlightedDescendant` returned in O(1) per node — both algorithms were O(n) and the new code's unconditional cache fill ended up doing more total work than the old short-circuiting walk. A Windows runner constant shift around 2026-05-26 flipped it from passing-by-margin to failing.
- Replaced with 50 single-child chains of depth 100, one highlight at each chain's bottom leaf, every internal node smart-expanded. HHD at level k must walk `depth-k-1` descendants to find the highlight, summing to `depth*(depth-1)/2 ≈ 5k` ops per chain × 50 = ~247k ops for old vs. ~10k for the new two-pass walk over 5,001 nodes — a stable 20×+ ratio that matches the regression #154 H4 actually defends.

Closes #179

## Test plan

- [x] CI green on the branch (run 26438049123: v20, peverify, v21 all pass; 1,299 tests passed, 0 failed)

https://claude.ai/code/session_01KYES22gDVEQyDjua6kEMea