### PR TITLE
refactor(#169): extract PillSelectionCoordinator from ActiveSetViewModel

### DIFF
--- a/src/BlockParam.Tests/PillSelectionCoordinatorTests.cs
+++ b/src/BlockParam.Tests/PillSelectionCoordinatorTests.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BlockParam.Models;
+using BlockParam.UI;
+using FluentAssertions;
+using Xunit;
+
+namespace BlockParam.Tests;
+
+/// <summary>
+/// Focused tests for <see cref="PillSelectionCoordinator"/> (#169).
+/// Validates cascade ordering, re-entrancy guard, and no-op on equal
+/// selections without going through the full ActiveSetViewModel.
+/// </summary>
+public class PillSelectionCoordinatorTests
+{
+    [Fact]
+    public void RebuildPlcPills_ProducesOnePillPerPlc()
+    {
+        var h = new Harness(Db("DB1", "PLC1"), Db("DB2", "PLC2"));
+        h.Coordinator.RebuildPlcPills();
+
+        h.Coordinator.PlcPills.Should().HaveCount(2);
+        h.Coordinator.PlcPills[0].PlcName.Should().Be("PLC1");
+        h.Coordinator.PlcPills[1].PlcName.Should().Be("PLC2");
+    }
+
+    [Fact]
+    public void RebuildPlcPills_UnsubscribesOldPillsBeforeRebuilding()
+    {
+        var h = new Harness(Db("DB1", "PLC1"));
+        h.Coordinator.RebuildPlcPills();
+        var oldPill = h.Coordinator.PlcPills[0];
+
+        h.Coordinator.RebuildPlcPills();
+
+        // The old pill's SelectionChanged should be unsubscribed — firing it
+        // after rebuild must not trigger any add/remove on the active set.
+        h.AddedSummaries.Clear();
+        oldPill.SyncSelectedDbs(Array.Empty<DataBlockListItem>());
+        h.AddedSummaries.Should().BeEmpty("old pill is unsubscribed after rebuild");
+    }
+
+    [Fact]
+    public void OnPillSelectionChanged_Added_CallsAddActiveDbFromSummary()
+    {
+        var h = new Harness(Db("DB1", "PLC1"));
+        h.Coordinator.RebuildPlcPills();
+
+        var pill = h.Coordinator.PlcPills[0];
+        var newSummary = new DataBlockSummary("DB2", "", plcName: "PLC1");
+        var item = new DataBlockListItem(newSummary, false, false);
+        pill.AvailableDbs.Add(item);
+        pill.SelectedDbs.Add(item);
+
+        h.AddedSummaries.Should().ContainSingle()
+            .Which.Name.Should().Be("DB2");
+    }
+
+    [Fact]
+    public void OnPillSelectionChanged_Removed_CallsRemoveActiveDb()
+    {
+        var db1 = Db("DB1", "PLC1");
+        var db2 = Db("DB2", "PLC1");
+        var h = new Harness(db1, db2);
+        h.Coordinator.RebuildPlcPills();
+
+        var pill = h.Coordinator.PlcPills[0];
+        // Simulate removing the second selected item from the pill
+        var toRemove = pill.SelectedDbs.Cast<DataBlockListItem>()
+            .FirstOrDefault(i => i.Name == "DB2");
+        if (toRemove != null)
+            pill.SelectedDbs.Remove(toRemove);
+
+        h.RemovedDbs.Should().ContainSingle()
+            .Which.Info.Name.Should().Be("DB2");
+    }
+
+    [Fact]
+    public void OnPillSelectionChanged_RefusesRemovalOfLastDb()
+    {
+        var h = new Harness(Db("DB1", "PLC1"));
+        h.Coordinator.RebuildPlcPills();
+
+        var pill = h.Coordinator.PlcPills[0];
+        var item = pill.SelectedDbs.Cast<DataBlockListItem>().First();
+        pill.SelectedDbs.Remove(item);
+
+        h.RemovedDbs.Should().BeEmpty("last DB must not be removable");
+        // Pill should be re-synced to still show the DB as selected
+        pill.SelectedDbs.Should().NotBeEmpty("pill snaps back to active set");
+    }
+
+    [Fact]
+    public void Guard_PreventsReEntrantCascade()
+    {
+        // When addActiveDbFromSummary triggers a rebuild (which re-syncs pills),
+        // the coordinator must not re-enter OnPillSelectionChanged.
+        int addCount = 0;
+        var db1 = Db("DB1", "PLC1");
+        var state = Snap(db1);
+        var coordinator = new PillSelectionCoordinator(
+            getState: () => state,
+            getActiveStatusFor: s => (false, false),
+            addActiveDbFromSummary: s =>
+            {
+                addCount++;
+                // Simulate the host rebuilding pills during add
+                coordinator!.RebuildPlcPills();
+            },
+            findActiveDb: s => null,
+            removeActiveDb: db => { },
+            hasDataBlockSwitcher: () => false,
+            loadAvailableDataBlocks: _ => { },
+            getAvailableDataBlocks: () => null,
+            hasEnumerateDataBlocks: false,
+            onDataBlockListItemToggled: null);
+
+        coordinator.RebuildPlcPills();
+        var pill = coordinator.PlcPills[0];
+        var newItem = new DataBlockListItem(
+            new DataBlockSummary("DB2", "", plcName: "PLC1"), false, false);
+        pill.AvailableDbs.Add(newItem);
+        pill.SelectedDbs.Add(newItem);
+
+        addCount.Should().Be(1, "guard prevents re-entrant cascade");
+    }
+
+    [Fact]
+    public void NoOpOnEqualSelection_DoesNotCallMutators()
+    {
+        var h = new Harness(Db("DB1", "PLC1"));
+        h.Coordinator.RebuildPlcPills();
+
+        var pill = h.Coordinator.PlcPills[0];
+        // Adding an item that's already active should be a no-op
+        var alreadyActive = new DataBlockListItem(
+            new DataBlockSummary("DB1", "", plcName: "PLC1"), true, true);
+        pill.AvailableDbs.Add(alreadyActive);
+        pill.SelectedDbs.Add(alreadyActive);
+
+        h.AddedSummaries.Should().BeEmpty("already-active item is a no-op");
+    }
+
+    // ---------- helpers ----------
+
+    private static ActiveSetState Snap(params ActiveDb[] dbs)
+        => new ActiveSetState(
+            dbs,
+            new Dictionary<string, StashedDbState>(),
+            dbs.Length > 0 ? (dbs[0].PlcName ?? "") : "");
+
+    private static ActiveDb Db(string name, string plc = "")
+    {
+        var info = new DataBlockInfo(name, 1, "Optimized", "GlobalDB", Array.Empty<MemberNode>());
+        return new ActiveDb(info, $"<Block name='{name}' />", onApply: null, plcName: plc);
+    }
+
+    private class Harness
+    {
+        private ActiveSetState _state;
+        private readonly List<ActiveDb> _activeDbs;
+
+        public List<DataBlockSummary> AddedSummaries { get; } = new();
+        public List<ActiveDb> RemovedDbs { get; } = new();
+        public PillSelectionCoordinator Coordinator { get; }
+
+        public Harness(params ActiveDb[] dbs)
+        {
+            _activeDbs = dbs.ToList();
+            _state = Snap(dbs);
+
+            Coordinator = new PillSelectionCoordinator(
+                getState: () => _state,
+                getActiveStatusFor: s =>
+                {
+                    for (int i = 0; i < _state.Dbs.Count; i++)
+                    {
+                        var db = _state.Dbs[i];
+                        if (string.Equals(db.Info.Name, s.Name, StringComparison.Ordinal)
+                            && string.Equals(db.PlcName, s.PlcName, StringComparison.Ordinal))
+                            return (true, i == 0);
+                    }
+                    return (false, false);
+                },
+                addActiveDbFromSummary: s => AddedSummaries.Add(s),
+                findActiveDb: s =>
+                {
+                    foreach (var db in _state.Dbs)
+                    {
+                        if (string.Equals(db.Info.Name, s.Name, StringComparison.Ordinal)
+                            && string.Equals(db.PlcName, s.PlcName, StringComparison.Ordinal))
+                            return db;
+                    }
+                    return null;
+                },
+                removeActiveDb: db =>
+                {
+                    RemovedDbs.Add(db);
+                    var next = _state.Dbs.Where(d => !ReferenceEquals(d, db)).ToList();
+                    _state = new ActiveSetState(next, _state.Stashes, _state.AnchorPlcName);
+                },
+                hasDataBlockSwitcher: () => false,
+                loadAvailableDataBlocks: _ => { },
+                getAvailableDataBlocks: () => null,
+                hasEnumerateDataBlocks: false,
+                onDataBlockListItemToggled: null);
+        }
+    }
+}

--- a/src/BlockParam.Tests/PillSelectionCoordinatorTests.cs
+++ b/src/BlockParam.Tests/PillSelectionCoordinatorTests.cs
@@ -100,7 +100,7 @@ public class PillSelectionCoordinatorTests
         int addCount = 0;
         var db1 = Db("DB1", "PLC1");
         var state = Snap(db1);
-        PillSelectionCoordinator? coordinator = null;
+        PillSelectionCoordinator coordinator = null!;
         coordinator = new PillSelectionCoordinator(
             getState: () => state,
             getActiveStatusFor: s => (false, false),

--- a/src/BlockParam.Tests/PillSelectionCoordinatorTests.cs
+++ b/src/BlockParam.Tests/PillSelectionCoordinatorTests.cs
@@ -100,13 +100,13 @@ public class PillSelectionCoordinatorTests
         int addCount = 0;
         var db1 = Db("DB1", "PLC1");
         var state = Snap(db1);
-        var coordinator = new PillSelectionCoordinator(
+        PillSelectionCoordinator? coordinator = null;
+        coordinator = new PillSelectionCoordinator(
             getState: () => state,
             getActiveStatusFor: s => (false, false),
             addActiveDbFromSummary: s =>
             {
                 addCount++;
-                // Simulate the host rebuilding pills during add
                 coordinator!.RebuildPlcPills();
             },
             findActiveDb: s => null,

--- a/src/BlockParam/UI/ActiveSetViewModel.cs
+++ b/src/BlockParam/UI/ActiveSetViewModel.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Windows.Input;
 using System.Windows.Threading;
 using BlockParam.Diagnostics;
@@ -15,28 +14,9 @@ namespace BlockParam.UI;
 /// <summary>
 /// State container + mutators for the dialog's active-DB set
 /// (#80 slices 8a + 8b). Owns the <see cref="ActiveSetState"/> snapshot,
-/// the bound <see cref="StashedDbs"/> collection, the DB-switcher
-/// dropdown state, and the PLC-pill row.
-///
-/// <para>
-/// <see cref="SetState"/> raises <see cref="StateChanged"/> with the
-/// (old, new) pair so the host's cross-slice cascade (tree rebuild,
-/// selection clear, filter pass, pill rebuild, anchor-display refresh)
-/// runs exactly once per snapshot change. <see cref="StashedDbs"/> is
-/// re-mirrored from the new snapshot internally — the host doesn't
-/// need a second copy.
-/// </para>
-///
-/// <para>
-/// Mutators (Add / Solo / Remove / Reactivate) compose the next
-/// snapshot in locals and assign once via <see cref="SetState"/>:
-/// exactly one cascade per user gesture regardless of how many DBs
-/// were swapped in or out. Operations with host-side side effects
-/// (Apply-in-place on remove, replay stashed edits onto the live tree)
-/// run through caller-supplied callbacks (<see cref="_tryApplyActiveDbInPlace"/>,
-/// <see cref="_restoreStashOntoLive"/>) so the slice never reaches
-/// into the host's <c>_writer</c> / <c>Tree</c> / <c>Subscription</c>.
-/// </para>
+/// the bound <see cref="StashedDbs"/> collection, and the DB-switcher
+/// dropdown state. Pill-row coordination is delegated to
+/// <see cref="PillSelectionCoordinator"/> (#169).
 /// </summary>
 public sealed class ActiveSetViewModel : ViewModelBase
 {
@@ -71,21 +51,10 @@ public sealed class ActiveSetViewModel : ViewModelBase
     private bool _isDataBlocksDropdownOpen;
     private bool _isLoadingDataBlocks;
 
-    // --- Pill-row state ---
-    private readonly HashSet<string> _extraPillPlcs = new(StringComparer.Ordinal);
-    // Re-entrancy guard: when the cascade rewrites SelectedDbs on each pill,
-    // the pill fires SelectionChanged → OnPillSelectionChanged. Without the
-    // guard we'd enter AddActiveDbToSet / RemoveActiveDb for every item in
-    // the selection sync, spiraling into multiple cascades.
-    private bool _syncingPillSelection;
-    private bool _isAddDbPopupOpen;
+    // --- Pill-row coordination (#169) ---
+    private PillSelectionCoordinator? _pillCoordinator;
 
-    /// <summary>
-    /// Legacy state-only constructor preserved for the slice-8a tests. The
-    /// slice operates as a pure snapshot container with no mutator wiring;
-    /// any call to a mutator method that needs an unwired dep throws
-    /// <see cref="InvalidOperationException"/>.
-    /// </summary>
+    /// <summary>State-only ctor for tests that need no mutator wiring.</summary>
     public ActiveSetViewModel(ActiveSetState initial)
         : this(initial,
             messageBox: null,
@@ -103,11 +72,6 @@ public sealed class ActiveSetViewModel : ViewModelBase
     {
     }
 
-    /// <summary>
-    /// Full constructor. Host VM wires every callback; tests pass only
-    /// the dependencies their scenario needs and rely on the no-op /
-    /// throw defaults for the rest.
-    /// </summary>
     public ActiveSetViewModel(
         ActiveSetState initial,
         IMessageBoxService? messageBox,
@@ -146,7 +110,17 @@ public sealed class ActiveSetViewModel : ViewModelBase
         _getPendingCount = getPendingCount;
         _ = dispatcher; // reserved for LoadDbsForPlcAsync continuation if it ever goes off-thread
 
-        PlcPills = new ObservableCollection<PlcPillViewModel>();
+        _pillCoordinator = new PillSelectionCoordinator(
+            getState: () => _state,
+            getActiveStatusFor: GetActiveStatusFor,
+            addActiveDbFromSummary: AddActiveDbFromSummary,
+            findActiveDb: s => FindActiveDb(s),
+            removeActiveDb: db => RemoveActiveDb(db),
+            hasDataBlockSwitcher: () => HasDataBlockSwitcher,
+            loadAvailableDataBlocks: force => LoadAvailableDataBlocks(force),
+            getAvailableDataBlocks: () => _availableDataBlocks,
+            hasEnumerateDataBlocks: _enumerateDataBlocks != null,
+            onDataBlockListItemToggled: OnDataBlockListItemToggled);
 
         OpenDataBlocksDropdownCommand = new RelayCommand(ExecuteOpenDataBlocksDropdown,
             () => _enumerateDataBlocks != null && _switchToDataBlock != null);
@@ -533,205 +507,29 @@ public sealed class ActiveSetViewModel : ViewModelBase
         Log.Information("DB enabled via dropdown: {Name}", built.Info.Name);
     }
 
-    // ===== Pill row =========================================================
+    // ===== Pill row (delegated to PillSelectionCoordinator, #169) =============
 
     /// <summary>
-    /// One pill per PLC that has at least one active DB. Replaces the old
-    /// chip row + DbSwitcherButton / DbSwitcherPopup in the dialog toolbar.
-    /// Rebuilt by <see cref="RebuildPlcPills"/> whenever the active set changes.
+    /// One pill per PLC that has at least one active DB. Delegated to
+    /// <see cref="PillSelectionCoordinator"/>.
     /// </summary>
-    public ObservableCollection<PlcPillViewModel> PlcPills { get; }
+    public ObservableCollection<PlcPillViewModel> PlcPills =>
+        _pillCoordinator!.PlcPills;
 
-    /// <summary>
-    /// PLC names present in the project but not yet represented in the
-    /// pill row. Drives the "+ PLC" popup's item list and the
-    /// <see cref="CanAddPlc"/> visibility gate.
-    /// </summary>
-    public IReadOnlyList<string> InactiveProjectPlcs
-    {
-        get
-        {
-            if (!HasDataBlockSwitcher) return Array.Empty<string>();
-            LoadAvailableDataBlocks(force: false);
-            var projectDbs = _availableDataBlocks;
-            if (projectDbs == null || projectDbs.Count == 0)
-                return Array.Empty<string>();
+    public IReadOnlyList<string> InactiveProjectPlcs =>
+        _pillCoordinator!.InactiveProjectPlcs;
 
-            var rowPlcs = new HashSet<string>(
-                PlcPills.Select(p => p.PlcName ?? ""), StringComparer.Ordinal);
-            var seen = new HashSet<string>(StringComparer.Ordinal);
-            var result = new List<string>();
-            foreach (var db in projectDbs)
-            {
-                var plc = db.PlcName ?? "";
-                if (rowPlcs.Contains(plc)) continue;
-                if (!seen.Add(plc)) continue;
-                result.Add(plc);
-            }
-            return result;
-        }
-    }
-
-    /// <summary>
-    /// True when at least one project PLC is not yet in the row. Bound
-    /// to the "+ PLC" button's Visibility.
-    /// </summary>
-    public bool CanAddPlc => InactiveProjectPlcs.Count > 0;
+    public bool CanAddPlc => _pillCoordinator!.CanAddPlc;
 
     public bool IsAddDbPopupOpen
     {
-        get => _isAddDbPopupOpen;
-        set => SetProperty(ref _isAddDbPopupOpen, value);
+        get => _pillCoordinator!.IsAddDbPopupOpen;
+        set => _pillCoordinator!.IsAddDbPopupOpen = value;
     }
 
-    /// <summary>
-    /// Adds <paramref name="plcName"/> to the row as an empty pill. The
-    /// new pill loads its DB list lazily on first popup open, same as the
-    /// active-set-derived pills. No-op if the PLC isn't a current candidate
-    /// (already in row, or not present in the project's DB list at all) —
-    /// this keeps <see cref="_extraPillPlcs"/> from accumulating stale
-    /// names if the click stream races a project mutation.
-    /// </summary>
-    public void AddPlcToRow(string plcName)
-    {
-        if (string.IsNullOrEmpty(plcName)) return;
-        if (!InactiveProjectPlcs.Contains(plcName, StringComparer.Ordinal)) return;
-        _extraPillPlcs.Add(plcName);
-        RebuildPlcPills();
-        OnPropertyChanged(nameof(InactiveProjectPlcs));
-    }
+    public void AddPlcToRow(string plcName) => _pillCoordinator!.AddPlcToRow(plcName);
 
-    /// <summary>
-    /// Rebuilds <see cref="PlcPills"/> from the current snapshot. Called
-    /// on every active-set change by the host's cascade subscriber.
-    /// </summary>
-    public void RebuildPlcPills()
-    {
-        // Unsubscribe old pills before clearing.
-        foreach (var pill in PlcPills)
-            pill.SelectionChanged -= OnPillSelectionChanged;
-        PlcPills.Clear();
-
-        // Prune _extraPillPlcs of names that no longer correspond to any
-        // project PLC. Without this, a manually-added pill survives even
-        // after its PLC disappears from the project (e.g., after a
-        // refresh), and the orphan stays in the row indefinitely.
-        if (_extraPillPlcs.Count > 0 && _availableDataBlocks != null)
-        {
-            var projectPlcs = new HashSet<string>(
-                _availableDataBlocks.Select(d => d.PlcName ?? ""),
-                StringComparer.Ordinal);
-            _extraPillPlcs.RemoveWhere(p => !projectPlcs.Contains(p));
-        }
-
-        var newPills = PlcPillGroupsService.Build(
-            _state.Dbs,
-            _state.AnchorPlcName,
-            loadDbsForPlc: LoadDbsForPlcAsync,
-            extraPlcs: _extraPillPlcs);
-
-        foreach (var pill in newPills)
-        {
-            pill.SelectionChanged += OnPillSelectionChanged;
-            PlcPills.Add(pill);
-        }
-
-        // Pill row just changed — re-evaluate the inactive-PLCs list so
-        // the "+ PLC" popup and its button visibility stay in sync.
-        OnPropertyChanged(nameof(InactiveProjectPlcs));
-        OnPropertyChanged(nameof(CanAddPlc));
-    }
-
-    private void OnPillSelectionChanged(object? sender, PillSelectionChangedEventArgs e)
-    {
-        if (_syncingPillSelection) return;
-        _syncingPillSelection = true;
-        try
-        {
-            foreach (var summary in e.Added)
-            {
-                if (!GetActiveStatusFor(summary).isActive)
-                    AddActiveDbFromSummary(summary);
-            }
-            foreach (var summary in e.Removed)
-            {
-                if (_state.Dbs.Count <= 1)
-                {
-                    Log.Information(
-                        "Refusing pill remove on {Name} — at least one DB must stay active",
-                        summary.Name);
-                    // Snap pill selection back so the UI doesn't show a deselected last DB.
-                    if (sender is PlcPillViewModel pill)
-                    {
-                        var activeItems = GetActiveItemsForPlc(pill);
-                        pill.SyncSelectedDbs(activeItems);
-                    }
-                    return;
-                }
-                var match = FindActiveDb(summary);
-                if (match != null) RemoveActiveDb(match);
-            }
-        }
-        finally
-        {
-            _syncingPillSelection = false;
-        }
-    }
-
-    private IReadOnlyList<DataBlockListItem> GetActiveItemsForPlc(PlcPillViewModel pill)
-    {
-        var result = new List<DataBlockListItem>();
-        // Identity is by ActiveDb.PlcName uniformly across indices (#82) —
-        // the anchor is no longer special. isAnchor stays position-based:
-        // it's display state, not identity.
-        for (int i = 0; i < _state.Dbs.Count; i++)
-        {
-            var db = _state.Dbs[i];
-            var plc = db.PlcName ?? "";
-            if (!string.Equals(plc, pill.PlcName, StringComparison.Ordinal)) continue;
-            result.Add(new DataBlockListItem(
-                new DataBlockSummary(db.Info.Name, "", plcName: plc, number: db.Info.Number),
-                isActive: true,
-                isAnchor: i == 0));
-        }
-        return result;
-    }
-
-    /// <summary>
-    /// Lazy-loads the available DB list for a specific PLC. Called by each
-    /// <see cref="PlcPillViewModel"/> on first popup open.
-    ///
-    /// Reuses the same <see cref="_availableDataBlocks"/> cache that
-    /// <see cref="RefreshDataBlocksCommand"/> populates, then filters to the
-    /// requested PLC so each pill only shows its own DBs.
-    ///
-    /// Returns on the calling (UI) thread since <see cref="LoadAvailableDataBlocks"/>
-    /// already runs synchronously on the UI thread.
-    /// </summary>
-    internal Task<IReadOnlyList<DataBlockListItem>> LoadDbsForPlcAsync(string plcName)
-    {
-        if (_enumerateDataBlocks == null)
-            return Task.FromResult<IReadOnlyList<DataBlockListItem>>(Array.Empty<DataBlockListItem>());
-
-        LoadAvailableDataBlocks(force: false);
-
-        var source = _availableDataBlocks ?? Array.Empty<DataBlockSummary>();
-        var filtered = string.IsNullOrEmpty(plcName)
-            ? source
-            : source.Where(s => string.Equals(s.PlcName, plcName, StringComparison.Ordinal)).ToList();
-
-        var items = filtered
-            .Select(s =>
-            {
-                var (isActive, isAnchor) = GetActiveStatusFor(s);
-                var item = new DataBlockListItem(s, isActive, isAnchor);
-                item.ToggleRequested += OnDataBlockListItemToggled;
-                return item;
-            })
-            .ToList();
-
-        return Task.FromResult<IReadOnlyList<DataBlockListItem>>(items);
-    }
+    public void RebuildPlcPills() => _pillCoordinator!.RebuildPlcPills();
 
     // ===== Mutators ==========================================================
 

--- a/src/BlockParam/UI/ActiveSetViewModel.cs
+++ b/src/BlockParam/UI/ActiveSetViewModel.cs
@@ -52,7 +52,7 @@ public sealed class ActiveSetViewModel : ViewModelBase
     private bool _isLoadingDataBlocks;
 
     // --- Pill-row coordination (#169) ---
-    private PillSelectionCoordinator? _pillCoordinator;
+    private PillSelectionCoordinator _pillCoordinator = null!;
 
     /// <summary>State-only ctor for tests that need no mutator wiring.</summary>
     public ActiveSetViewModel(ActiveSetState initial)
@@ -119,7 +119,7 @@ public sealed class ActiveSetViewModel : ViewModelBase
             hasDataBlockSwitcher: () => HasDataBlockSwitcher,
             loadAvailableDataBlocks: force => LoadAvailableDataBlocks(force),
             getAvailableDataBlocks: () => _availableDataBlocks,
-            hasEnumerateDataBlocks: _enumerateDataBlocks != null,
+            hasEnumerateDataBlocks: _enumerateDataBlocks != null, // fixed at ctor — field is wired once, never replaced
             onDataBlockListItemToggled: OnDataBlockListItemToggled);
 
         OpenDataBlocksDropdownCommand = new RelayCommand(ExecuteOpenDataBlocksDropdown,
@@ -514,22 +514,22 @@ public sealed class ActiveSetViewModel : ViewModelBase
     /// <see cref="PillSelectionCoordinator"/>.
     /// </summary>
     public ObservableCollection<PlcPillViewModel> PlcPills =>
-        _pillCoordinator!.PlcPills;
+        _pillCoordinator.PlcPills;
 
     public IReadOnlyList<string> InactiveProjectPlcs =>
-        _pillCoordinator!.InactiveProjectPlcs;
+        _pillCoordinator.InactiveProjectPlcs;
 
-    public bool CanAddPlc => _pillCoordinator!.CanAddPlc;
+    public bool CanAddPlc => _pillCoordinator.CanAddPlc;
 
     public bool IsAddDbPopupOpen
     {
-        get => _pillCoordinator!.IsAddDbPopupOpen;
-        set => _pillCoordinator!.IsAddDbPopupOpen = value;
+        get => _pillCoordinator.IsAddDbPopupOpen;
+        set => _pillCoordinator.IsAddDbPopupOpen = value;
     }
 
-    public void AddPlcToRow(string plcName) => _pillCoordinator!.AddPlcToRow(plcName);
+    public void AddPlcToRow(string plcName) => _pillCoordinator.AddPlcToRow(plcName);
 
-    public void RebuildPlcPills() => _pillCoordinator!.RebuildPlcPills();
+    public void RebuildPlcPills() => _pillCoordinator.RebuildPlcPills();
 
     // ===== Mutators ==========================================================
 

--- a/src/BlockParam/UI/PillSelectionCoordinator.cs
+++ b/src/BlockParam/UI/PillSelectionCoordinator.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using BlockParam.Diagnostics;
+using BlockParam.Models;
+using BlockParam.Services;
+
+namespace BlockParam.UI;
+
+/// <summary>
+/// Owns the pill ↔ active-set selection cascade (#169). Sits between
+/// <see cref="PlcPillViewModel.SelectionChanged"/> and the active-set
+/// mutators on the host. The re-entrancy guard (<c>_syncing</c>) lives
+/// here instead of on <see cref="ActiveSetViewModel"/>.
+/// </summary>
+public sealed class PillSelectionCoordinator : ViewModelBase
+{
+    private readonly HashSet<string> _extraPillPlcs = new(StringComparer.Ordinal);
+    private bool _syncing;
+    private bool _isAddDbPopupOpen;
+
+    // Host callbacks — keep the coordinator from reaching into the host's internals.
+    private readonly Func<ActiveSetState> _getState;
+    private readonly Func<DataBlockSummary, (bool isActive, bool isAnchor)> _getActiveStatusFor;
+    private readonly Action<DataBlockSummary> _addActiveDbFromSummary;
+    private readonly Func<DataBlockSummary, ActiveDb?> _findActiveDb;
+    private readonly Action<ActiveDb> _removeActiveDb;
+    private readonly Func<bool> _hasDataBlockSwitcher;
+    private readonly Action<bool> _loadAvailableDataBlocks;
+    private readonly Func<IReadOnlyList<DataBlockSummary>?> _getAvailableDataBlocks;
+    private readonly bool _hasEnumerateDataBlocks;
+    private readonly Action<DataBlockListItem>? _onDataBlockListItemToggled;
+
+    public PillSelectionCoordinator(
+        Func<ActiveSetState> getState,
+        Func<DataBlockSummary, (bool isActive, bool isAnchor)> getActiveStatusFor,
+        Action<DataBlockSummary> addActiveDbFromSummary,
+        Func<DataBlockSummary, ActiveDb?> findActiveDb,
+        Action<ActiveDb> removeActiveDb,
+        Func<bool> hasDataBlockSwitcher,
+        Action<bool> loadAvailableDataBlocks,
+        Func<IReadOnlyList<DataBlockSummary>?> getAvailableDataBlocks,
+        bool hasEnumerateDataBlocks,
+        Action<DataBlockListItem>? onDataBlockListItemToggled)
+    {
+        _getState = getState ?? throw new ArgumentNullException(nameof(getState));
+        _getActiveStatusFor = getActiveStatusFor ?? throw new ArgumentNullException(nameof(getActiveStatusFor));
+        _addActiveDbFromSummary = addActiveDbFromSummary ?? throw new ArgumentNullException(nameof(addActiveDbFromSummary));
+        _findActiveDb = findActiveDb ?? throw new ArgumentNullException(nameof(findActiveDb));
+        _removeActiveDb = removeActiveDb ?? throw new ArgumentNullException(nameof(removeActiveDb));
+        _hasDataBlockSwitcher = hasDataBlockSwitcher ?? throw new ArgumentNullException(nameof(hasDataBlockSwitcher));
+        _loadAvailableDataBlocks = loadAvailableDataBlocks ?? throw new ArgumentNullException(nameof(loadAvailableDataBlocks));
+        _getAvailableDataBlocks = getAvailableDataBlocks ?? throw new ArgumentNullException(nameof(getAvailableDataBlocks));
+        _hasEnumerateDataBlocks = hasEnumerateDataBlocks;
+        _onDataBlockListItemToggled = onDataBlockListItemToggled;
+
+        PlcPills = new ObservableCollection<PlcPillViewModel>();
+    }
+
+    /// <summary>
+    /// One pill per PLC that has at least one active DB. Rebuilt by
+    /// <see cref="RebuildPlcPills"/> whenever the active set changes.
+    /// </summary>
+    public ObservableCollection<PlcPillViewModel> PlcPills { get; }
+
+    /// <summary>
+    /// PLC names present in the project but not yet represented in the
+    /// pill row. Drives the "+ PLC" popup's item list.
+    /// </summary>
+    public IReadOnlyList<string> InactiveProjectPlcs
+    {
+        get
+        {
+            if (!_hasDataBlockSwitcher()) return Array.Empty<string>();
+            _loadAvailableDataBlocks(false);
+            var projectDbs = _getAvailableDataBlocks();
+            if (projectDbs == null || projectDbs.Count == 0)
+                return Array.Empty<string>();
+
+            var rowPlcs = new HashSet<string>(
+                PlcPills.Select(p => p.PlcName ?? ""), StringComparer.Ordinal);
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            var result = new List<string>();
+            foreach (var db in projectDbs)
+            {
+                var plc = db.PlcName ?? "";
+                if (rowPlcs.Contains(plc)) continue;
+                if (!seen.Add(plc)) continue;
+                result.Add(plc);
+            }
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// True when at least one project PLC is not yet in the row. Bound
+    /// to the "+ PLC" button's Visibility.
+    /// </summary>
+    public bool CanAddPlc => InactiveProjectPlcs.Count > 0;
+
+    public bool IsAddDbPopupOpen
+    {
+        get => _isAddDbPopupOpen;
+        set => SetProperty(ref _isAddDbPopupOpen, value);
+    }
+
+    /// <summary>
+    /// Adds <paramref name="plcName"/> to the row as an empty pill.
+    /// No-op if the PLC isn't a current candidate.
+    /// </summary>
+    public void AddPlcToRow(string plcName)
+    {
+        if (string.IsNullOrEmpty(plcName)) return;
+        if (!InactiveProjectPlcs.Contains(plcName, StringComparer.Ordinal)) return;
+        _extraPillPlcs.Add(plcName);
+        RebuildPlcPills();
+        OnPropertyChanged(nameof(InactiveProjectPlcs));
+    }
+
+    /// <summary>
+    /// Rebuilds <see cref="PlcPills"/> from the current snapshot. Called
+    /// on every active-set change by the host's cascade subscriber.
+    /// </summary>
+    public void RebuildPlcPills()
+    {
+        foreach (var pill in PlcPills)
+            pill.SelectionChanged -= OnPillSelectionChanged;
+        PlcPills.Clear();
+
+        var availableDataBlocks = _getAvailableDataBlocks();
+        if (_extraPillPlcs.Count > 0 && availableDataBlocks != null)
+        {
+            var projectPlcs = new HashSet<string>(
+                availableDataBlocks.Select(d => d.PlcName ?? ""),
+                StringComparer.Ordinal);
+            _extraPillPlcs.RemoveWhere(p => !projectPlcs.Contains(p));
+        }
+
+        var state = _getState();
+        var newPills = PlcPillGroupsService.Build(
+            state.Dbs,
+            state.AnchorPlcName,
+            loadDbsForPlc: LoadDbsForPlcAsync,
+            extraPlcs: _extraPillPlcs);
+
+        foreach (var pill in newPills)
+        {
+            pill.SelectionChanged += OnPillSelectionChanged;
+            PlcPills.Add(pill);
+        }
+
+        OnPropertyChanged(nameof(InactiveProjectPlcs));
+        OnPropertyChanged(nameof(CanAddPlc));
+    }
+
+    /// <summary>
+    /// Lazy-loads the available DB list for a specific PLC. Called by each
+    /// <see cref="PlcPillViewModel"/> on first popup open.
+    /// </summary>
+    internal Task<IReadOnlyList<DataBlockListItem>> LoadDbsForPlcAsync(string plcName)
+    {
+        if (!_hasEnumerateDataBlocks)
+            return Task.FromResult<IReadOnlyList<DataBlockListItem>>(Array.Empty<DataBlockListItem>());
+
+        _loadAvailableDataBlocks(false);
+
+        var source = _getAvailableDataBlocks() ?? Array.Empty<DataBlockSummary>();
+        var filtered = string.IsNullOrEmpty(plcName)
+            ? source
+            : source.Where(s => string.Equals(s.PlcName, plcName, StringComparison.Ordinal)).ToList();
+
+        var items = filtered
+            .Select(s =>
+            {
+                var (isActive, isAnchor) = _getActiveStatusFor(s);
+                var item = new DataBlockListItem(s, isActive, isAnchor);
+                if (_onDataBlockListItemToggled != null)
+                    item.ToggleRequested += _onDataBlockListItemToggled;
+                return item;
+            })
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<DataBlockListItem>>(items);
+    }
+
+    private void OnPillSelectionChanged(object? sender, PillSelectionChangedEventArgs e)
+    {
+        if (_syncing) return;
+        _syncing = true;
+        try
+        {
+            var state = _getState();
+            foreach (var summary in e.Added)
+            {
+                if (!_getActiveStatusFor(summary).isActive)
+                    _addActiveDbFromSummary(summary);
+            }
+            foreach (var summary in e.Removed)
+            {
+                if (state.Dbs.Count <= 1)
+                {
+                    Log.Information(
+                        "Refusing pill remove on {Name} — at least one DB must stay active",
+                        summary.Name);
+                    if (sender is PlcPillViewModel pill)
+                    {
+                        var activeItems = GetActiveItemsForPlc(pill);
+                        pill.SyncSelectedDbs(activeItems);
+                    }
+                    return;
+                }
+                var match = _findActiveDb(summary);
+                if (match != null) _removeActiveDb(match);
+                // Re-read state after mutation — the host may have changed
+                // the snapshot via SetState inside RemoveActiveDb.
+                state = _getState();
+            }
+        }
+        finally
+        {
+            _syncing = false;
+        }
+    }
+
+    private IReadOnlyList<DataBlockListItem> GetActiveItemsForPlc(PlcPillViewModel pill)
+    {
+        var state = _getState();
+        var result = new List<DataBlockListItem>();
+        for (int i = 0; i < state.Dbs.Count; i++)
+        {
+            var db = state.Dbs[i];
+            var plc = db.PlcName ?? "";
+            if (!string.Equals(plc, pill.PlcName, StringComparison.Ordinal)) continue;
+            result.Add(new DataBlockListItem(
+                new DataBlockSummary(db.Info.Name, "", plcName: plc, number: db.Info.Number),
+                isActive: true,
+                isAnchor: i == 0));
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary

- Extract the pill ↔ active-set selection cascade into a new `PillSelectionCoordinator` class (243 LOC), moving the re-entrancy guard, pill row collection, and selection event handler out of `ActiveSetViewModel`
- `ActiveSetViewModel` drops from 1,247 → 1,045 LOC (−202 lines) and delegates to the coordinator through thin forwarding properties — public API surface and XAML bindings are unchanged
- Add 7 focused unit tests covering cascade ordering, re-entrancy guard, last-DB refusal, no-op on equal selections, and unsubscribe-on-rebuild

### What moved to the coordinator

`_syncing` (was `_syncingPillSelection`), `PlcPills`, `_extraPillPlcs`, `IsAddDbPopupOpen`, `RebuildPlcPills()`, `OnPillSelectionChanged()`, `GetActiveItemsForPlc()`, `LoadDbsForPlcAsync()`, `AddPlcToRow()`, `InactiveProjectPlcs`, `CanAddPlc`

## Test plan

- [x] All 7 new `PillSelectionCoordinatorTests` pass
- [x] Existing `ActiveSetViewModelMutatorTests` pass unmodified
- [x] V20 build + xUnit green
- [x] V21 build green
- [x] PEVerify green

Closes #169

https://claude.ai/code/session_01N4KBnCHFUQ24vsmVSZ8HDh

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4KBnCHFUQ24vsmVSZ8HDh)_